### PR TITLE
Phase 1: foundation models and event bus

### DIFF
--- a/asat/__init__.py
+++ b/asat/__init__.py
@@ -1,0 +1,22 @@
+"""Accessible Spatial Audio Terminal.
+
+Phase 1 exposes the foundational data structures and event bus.
+Later phases add the execution kernel, audio engine, input router,
+output parser, and ANSI interactivity layer.
+"""
+
+from asat.cell import Cell, CellStatus
+from asat.session import Session
+from asat.events import Event, EventType
+from asat.event_bus import EventBus
+
+__all__ = [
+    "Cell",
+    "CellStatus",
+    "Session",
+    "Event",
+    "EventType",
+    "EventBus",
+]
+
+__version__ = "0.1.0"

--- a/asat/cell.py
+++ b/asat/cell.py
@@ -1,0 +1,141 @@
+"""Cell model: one input/output interaction in the notebook.
+
+A Cell records a single command submission and the resulting output.
+It is the atomic unit of the notebook workflow. Cells are intentionally
+dumb data containers. All mutation logic lives in the Session class or
+in later-phase modules (execution kernel, parser).
+
+Fields are ordered so the most important identity information is read
+first by a screen reader: id, command, timestamp, then outputs, then
+status and lineage.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Optional
+
+
+class CellStatus(str, Enum):
+    """Lifecycle states for a Cell.
+
+    PENDING: Created but not yet executed.
+    RUNNING: Currently being executed by the kernel.
+    COMPLETED: Finished with exit code zero.
+    FAILED: Finished with a non-zero exit code or raised an error.
+    CANCELLED: User cancelled execution before completion.
+    """
+
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+def _utcnow() -> datetime:
+    """Return the current UTC time with an explicit timezone."""
+    return datetime.now(timezone.utc)
+
+
+def _new_id() -> str:
+    """Return a fresh random identifier as a hex string."""
+    return uuid.uuid4().hex
+
+
+@dataclass
+class Cell:
+    """A single input/output notebook cell.
+
+    Use Cell.new(command) to construct a fresh cell. Direct construction
+    is supported for deserialization but callers should prefer the
+    factory method so that identifiers and timestamps are generated
+    consistently.
+    """
+
+    cell_id: str
+    command: str
+    created_at: datetime
+    updated_at: datetime
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: Optional[int] = None
+    status: CellStatus = CellStatus.PENDING
+    parent_id: Optional[str] = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def new(cls, command: str, parent_id: Optional[str] = None) -> "Cell":
+        """Create a fresh pending cell for the given command.
+
+        The parent_id is used when the user edits and re-runs a previous
+        cell. It lets the session preserve the original cell as history
+        while treating the new cell as its branch.
+        """
+        now = _utcnow()
+        return cls(
+            cell_id=_new_id(),
+            command=command,
+            created_at=now,
+            updated_at=now,
+            parent_id=parent_id,
+        )
+
+    def mark_running(self) -> None:
+        """Transition this cell to the RUNNING state."""
+        self.status = CellStatus.RUNNING
+        self.updated_at = _utcnow()
+
+    def mark_completed(self, stdout: str, stderr: str, exit_code: int) -> None:
+        """Record a completed execution and set status from the exit code."""
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_code = exit_code
+        self.status = CellStatus.COMPLETED if exit_code == 0 else CellStatus.FAILED
+        self.updated_at = _utcnow()
+
+    def mark_cancelled(self) -> None:
+        """Record that the user cancelled this cell before completion."""
+        self.status = CellStatus.CANCELLED
+        self.updated_at = _utcnow()
+
+    def update_command(self, new_command: str) -> None:
+        """Edit the input command and reset output-related state.
+
+        Used when the user edits a previous cell in place rather than
+        branching. Output fields are cleared so a stale result is never
+        shown alongside an unexecuted command.
+        """
+        self.command = new_command
+        self.stdout = ""
+        self.stderr = ""
+        self.exit_code = None
+        self.status = CellStatus.PENDING
+        self.updated_at = _utcnow()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this cell to a JSON-compatible dictionary."""
+        data = asdict(self)
+        data["created_at"] = self.created_at.isoformat()
+        data["updated_at"] = self.updated_at.isoformat()
+        data["status"] = self.status.value
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Cell":
+        """Rebuild a Cell from a dictionary previously produced by to_dict."""
+        return cls(
+            cell_id=data["cell_id"],
+            command=data["command"],
+            created_at=datetime.fromisoformat(data["created_at"]),
+            updated_at=datetime.fromisoformat(data["updated_at"]),
+            stdout=data.get("stdout", ""),
+            stderr=data.get("stderr", ""),
+            exit_code=data.get("exit_code"),
+            status=CellStatus(data.get("status", CellStatus.PENDING.value)),
+            parent_id=data.get("parent_id"),
+            metadata=dict(data.get("metadata", {})),
+        )

--- a/asat/event_bus.py
+++ b/asat/event_bus.py
@@ -1,0 +1,115 @@
+"""EventBus: synchronous publish/subscribe message router.
+
+The bus is intentionally synchronous for Phase 1. A single publish call
+invokes each subscribed handler in registration order before returning.
+This keeps the event flow deterministic and easy to reason about when
+reading the source with a screen reader.
+
+Handlers must be plain callables that accept one Event argument and
+return None. Exceptions raised by one handler do not prevent other
+handlers for the same event from running; they are collected and
+re-raised together after all handlers have had a chance to react.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Callable
+
+from asat.events import Event, EventType
+
+
+Handler = Callable[[Event], None]
+
+WILDCARD = "*"
+
+
+class EventBusError(Exception):
+    """Aggregated error raised when one or more handlers failed."""
+
+    def __init__(self, event: Event, errors: list[BaseException]):
+        """Record the offending event and the list of handler errors."""
+        self.event = event
+        self.errors = errors
+        message = f"{len(errors)} handler(s) raised while processing {event.event_type.value}"
+        super().__init__(message)
+
+
+class EventBus:
+    """Synchronous in-process publish/subscribe router.
+
+    Create one instance per application. Pass it into modules that need
+    to publish or subscribe. Keeping a single bus per process removes
+    any ambiguity about which handlers will receive which events.
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty subscription registry."""
+        self._subscribers: dict[object, list[Handler]] = defaultdict(list)
+
+    def subscribe(self, event_type: EventType | str, handler: Handler) -> None:
+        """Register handler to receive events of the given type.
+
+        Pass the WILDCARD constant ("*") instead of an EventType to
+        receive every event published to the bus. Wildcard handlers are
+        typically used for logging or for recording sessions.
+        """
+        key = self._key(event_type)
+        self._subscribers[key].append(handler)
+
+    def unsubscribe(self, event_type: EventType | str, handler: Handler) -> None:
+        """Remove a previously registered handler.
+
+        Silently succeeds if the handler was not registered. This keeps
+        teardown code simple and idempotent.
+        """
+        key = self._key(event_type)
+        handlers = self._subscribers.get(key)
+        if not handlers:
+            return
+        try:
+            handlers.remove(handler)
+        except ValueError:
+            return
+
+    def publish(self, event: Event) -> None:
+        """Deliver the event to every subscribed handler.
+
+        Handlers registered for the exact event type run first, then
+        wildcard handlers. All handlers are attempted even if one
+        raises. If any raised, an EventBusError is raised at the end
+        aggregating all captured exceptions.
+        """
+        errors: list[BaseException] = []
+        for handler in list(self._subscribers.get(event.event_type, ())):
+            self._safe_call(handler, event, errors)
+        for handler in list(self._subscribers.get(WILDCARD, ())):
+            self._safe_call(handler, event, errors)
+        if errors:
+            raise EventBusError(event, errors)
+
+    def clear(self) -> None:
+        """Remove every subscription. Primarily useful in tests."""
+        self._subscribers.clear()
+
+    def subscriber_count(self, event_type: EventType | str) -> int:
+        """Return how many handlers are registered for the given type."""
+        key = self._key(event_type)
+        return len(self._subscribers.get(key, ()))
+
+    @staticmethod
+    def _key(event_type: EventType | str) -> object:
+        """Translate the public subscription key into the internal key."""
+        if event_type == WILDCARD:
+            return WILDCARD
+        if isinstance(event_type, EventType):
+            return event_type
+        raise TypeError("event_type must be an EventType or the wildcard string")
+
+    @staticmethod
+    def _safe_call(handler: Handler, event: Event, errors: list[BaseException]) -> None:
+        """Invoke handler, capturing any exception into errors."""
+        try:
+            handler(event)
+        except BaseException as exc:
+            errors.append(exc)

--- a/asat/events.py
+++ b/asat/events.py
@@ -1,0 +1,91 @@
+"""Event types and the Event value object.
+
+Events are immutable records describing something that happened in the
+system. They are published to the EventBus, which routes them to any
+subscribed handlers. Keeping events as plain data makes it trivial to
+log, replay, or serialize an entire session for debugging.
+
+Phase 1 defines only the event vocabulary. Later phases will emit these
+events from the execution kernel, input router, audio engine, and
+parser modules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+
+class EventType(str, Enum):
+    """All event categories the bus may carry.
+
+    Grouped by producer for readability:
+
+    Session lifecycle:
+        SESSION_CREATED, SESSION_LOADED, SESSION_SAVED
+
+    Cell lifecycle:
+        CELL_CREATED, CELL_UPDATED, CELL_REMOVED, CELL_MOVED
+
+    Execution kernel:
+        COMMAND_SUBMITTED, COMMAND_STARTED, COMMAND_COMPLETED,
+        COMMAND_FAILED, COMMAND_CANCELLED
+
+    Output streaming:
+        OUTPUT_CHUNK, ERROR_CHUNK
+
+    Input and focus router:
+        FOCUS_CHANGED, KEY_PRESSED, ACTION_INVOKED
+
+    Audio engine:
+        AUDIO_SPOKEN, AUDIO_INTERRUPTED
+    """
+
+    SESSION_CREATED = "session.created"
+    SESSION_LOADED = "session.loaded"
+    SESSION_SAVED = "session.saved"
+
+    CELL_CREATED = "cell.created"
+    CELL_UPDATED = "cell.updated"
+    CELL_REMOVED = "cell.removed"
+    CELL_MOVED = "cell.moved"
+
+    COMMAND_SUBMITTED = "command.submitted"
+    COMMAND_STARTED = "command.started"
+    COMMAND_COMPLETED = "command.completed"
+    COMMAND_FAILED = "command.failed"
+    COMMAND_CANCELLED = "command.cancelled"
+
+    OUTPUT_CHUNK = "output.chunk"
+    ERROR_CHUNK = "error.chunk"
+
+    FOCUS_CHANGED = "focus.changed"
+    KEY_PRESSED = "input.key"
+    ACTION_INVOKED = "input.action"
+
+    AUDIO_SPOKEN = "audio.spoken"
+    AUDIO_INTERRUPTED = "audio.interrupted"
+
+
+def _utcnow() -> datetime:
+    """Return the current UTC time with an explicit timezone."""
+    return datetime.now(timezone.utc)
+
+
+@dataclass(frozen=True)
+class Event:
+    """An immutable record of something that happened.
+
+    event_type identifies the category. payload is an arbitrary
+    dictionary of structured data associated with the event. source is
+    a short string naming the producer module, useful when multiple
+    producers publish the same event type. timestamp is set
+    automatically at construction time.
+    """
+
+    event_type: EventType
+    payload: dict[str, Any] = field(default_factory=dict)
+    source: str = ""
+    timestamp: datetime = field(default_factory=_utcnow)

--- a/asat/session.py
+++ b/asat/session.py
@@ -1,0 +1,205 @@
+"""Session model: the notebook-level container of cells.
+
+A Session owns an ordered list of Cells, a cursor pointing at the
+currently focused cell, and the bookkeeping needed to reorder, remove,
+and serialize them. The Session is deliberately passive: it never
+executes commands or produces audio. Later phases call into the Session
+from the execution kernel, input router, and audio engine.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator, Optional
+
+from asat.cell import Cell
+
+
+def _utcnow() -> datetime:
+    """Return the current UTC time with an explicit timezone."""
+    return datetime.now(timezone.utc)
+
+
+def _new_id() -> str:
+    """Return a fresh random identifier as a hex string."""
+    return uuid.uuid4().hex
+
+
+class SessionError(Exception):
+    """Raised when a Session operation is given an invalid argument."""
+
+
+@dataclass
+class Session:
+    """An ordered collection of notebook cells.
+
+    Use Session.new() for a fresh session. Direct construction is used
+    by from_dict during deserialization. All mutation methods update the
+    session's updated_at timestamp so persistence layers can detect
+    dirty state.
+    """
+
+    session_id: str
+    created_at: datetime
+    updated_at: datetime
+    cells: list[Cell] = field(default_factory=list)
+    active_cell_id: Optional[str] = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def new(cls) -> "Session":
+        """Create a fresh empty session."""
+        now = _utcnow()
+        return cls(session_id=_new_id(), created_at=now, updated_at=now)
+
+    def __len__(self) -> int:
+        """Return the number of cells currently in the session."""
+        return len(self.cells)
+
+    def __iter__(self) -> Iterator[Cell]:
+        """Iterate over cells in notebook order."""
+        return iter(self.cells)
+
+    def add_cell(self, cell: Cell, position: Optional[int] = None) -> Cell:
+        """Insert a cell at the given position, or append if position is None.
+
+        Returns the inserted cell so callers can chain. Raises SessionError
+        if a cell with the same id already exists, since duplicated ids
+        would corrupt lookups and ordering.
+        """
+        if self._index_or_none(cell.cell_id) is not None:
+            raise SessionError(f"Cell {cell.cell_id} already exists in session")
+        if position is None:
+            self.cells.append(cell)
+        else:
+            self._check_position(position, allow_end=True)
+            self.cells.insert(position, cell)
+        self.updated_at = _utcnow()
+        return cell
+
+    def remove_cell(self, cell_id: str) -> Cell:
+        """Remove and return the cell with the given id.
+
+        Clears active_cell_id if it pointed at the removed cell.
+        """
+        index = self._require_index(cell_id)
+        removed = self.cells.pop(index)
+        if self.active_cell_id == cell_id:
+            self.active_cell_id = None
+        self.updated_at = _utcnow()
+        return removed
+
+    def move_cell(self, cell_id: str, new_position: int) -> None:
+        """Move a cell to a new position within the session.
+
+        new_position is interpreted against the list after the cell has
+        been removed, matching standard list.insert semantics. Positions
+        outside [0, len - 1] raise SessionError.
+        """
+        current = self._require_index(cell_id)
+        self._check_position(new_position, allow_end=False)
+        cell = self.cells.pop(current)
+        self.cells.insert(new_position, cell)
+        self.updated_at = _utcnow()
+
+    def get_cell(self, cell_id: str) -> Cell:
+        """Return the cell with the given id or raise SessionError."""
+        index = self._require_index(cell_id)
+        return self.cells[index]
+
+    def index_of(self, cell_id: str) -> int:
+        """Return the position of the cell with the given id."""
+        return self._require_index(cell_id)
+
+    def set_active(self, cell_id: Optional[str]) -> None:
+        """Set the focused cell. Pass None to clear focus.
+
+        Raises SessionError if the id is not present in the session.
+        """
+        if cell_id is not None:
+            self._require_index(cell_id)
+        self.active_cell_id = cell_id
+        self.updated_at = _utcnow()
+
+    def active_cell(self) -> Optional[Cell]:
+        """Return the currently focused cell, or None if no cell is focused."""
+        if self.active_cell_id is None:
+            return None
+        return self.get_cell(self.active_cell_id)
+
+    def next_cell(self, cell_id: str) -> Optional[Cell]:
+        """Return the cell immediately after cell_id, or None at the end."""
+        index = self._require_index(cell_id)
+        if index + 1 >= len(self.cells):
+            return None
+        return self.cells[index + 1]
+
+    def previous_cell(self, cell_id: str) -> Optional[Cell]:
+        """Return the cell immediately before cell_id, or None at the start."""
+        index = self._require_index(cell_id)
+        if index == 0:
+            return None
+        return self.cells[index - 1]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the session to a JSON-compatible dictionary."""
+        return {
+            "session_id": self.session_id,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "active_cell_id": self.active_cell_id,
+            "metadata": dict(self.metadata),
+            "cells": [cell.to_dict() for cell in self.cells],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Session":
+        """Rebuild a session from a dictionary previously produced by to_dict."""
+        return cls(
+            session_id=data["session_id"],
+            created_at=datetime.fromisoformat(data["created_at"]),
+            updated_at=datetime.fromisoformat(data["updated_at"]),
+            cells=[Cell.from_dict(item) for item in data.get("cells", [])],
+            active_cell_id=data.get("active_cell_id"),
+            metadata=dict(data.get("metadata", {})),
+        )
+
+    def save(self, path: Path | str) -> None:
+        """Write the session as pretty-printed JSON to the given path."""
+        target = Path(path)
+        target.write_text(json.dumps(self.to_dict(), indent=2), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: Path | str) -> "Session":
+        """Read a session from a JSON file previously written by save."""
+        source = Path(path)
+        data = json.loads(source.read_text(encoding="utf-8"))
+        return cls.from_dict(data)
+
+    def _index_or_none(self, cell_id: str) -> Optional[int]:
+        """Return the index of the given cell id, or None if absent."""
+        for index, cell in enumerate(self.cells):
+            if cell.cell_id == cell_id:
+                return index
+        return None
+
+    def _require_index(self, cell_id: str) -> int:
+        """Return the index of the given cell id or raise SessionError."""
+        index = self._index_or_none(cell_id)
+        if index is None:
+            raise SessionError(f"Cell {cell_id} not found in session")
+        return index
+
+    def _check_position(self, position: int, allow_end: bool) -> None:
+        """Validate that position is a legal insertion or move target.
+
+        allow_end permits position == len(cells), which is valid for
+        insertion but not for moving an existing cell.
+        """
+        upper = len(self.cells) if allow_end else max(len(self.cells) - 1, 0)
+        if position < 0 or position > upper:
+            raise SessionError(f"Position {position} is out of range")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "asat"
+version = "0.1.0"
+description = "Accessible Spatial Audio Terminal"
+requires-python = ">=3.10"
+readme = { text = "Phase 1 foundation: data models and event bus.", content-type = "text/plain" }
+license = { file = "LICENSE" }
+authors = [{ name = "ASAT contributors" }]
+dependencies = []
+
+[tool.setuptools.packages.find]
+include = ["asat*"]
+exclude = ["tests*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -1,0 +1,107 @@
+"""Unit tests for the Cell data model."""
+
+from __future__ import annotations
+
+import time
+import unittest
+
+from asat.cell import Cell, CellStatus
+
+
+class CellFactoryTests(unittest.TestCase):
+    """Behaviour of Cell.new and initial state."""
+
+    def test_new_cell_starts_pending(self) -> None:
+        cell = Cell.new("echo hi")
+        self.assertEqual(cell.command, "echo hi")
+        self.assertEqual(cell.status, CellStatus.PENDING)
+        self.assertEqual(cell.stdout, "")
+        self.assertEqual(cell.stderr, "")
+        self.assertIsNone(cell.exit_code)
+        self.assertIsNone(cell.parent_id)
+
+    def test_new_cell_has_unique_id(self) -> None:
+        first = Cell.new("ls")
+        second = Cell.new("ls")
+        self.assertNotEqual(first.cell_id, second.cell_id)
+
+    def test_new_cell_records_timestamps(self) -> None:
+        cell = Cell.new("pwd")
+        self.assertEqual(cell.created_at, cell.updated_at)
+        self.assertIsNotNone(cell.created_at.tzinfo)
+
+    def test_new_cell_accepts_parent_id(self) -> None:
+        cell = Cell.new("retry", parent_id="abc123")
+        self.assertEqual(cell.parent_id, "abc123")
+
+
+class CellLifecycleTests(unittest.TestCase):
+    """Status transitions and output recording."""
+
+    def test_mark_running_updates_status_and_timestamp(self) -> None:
+        cell = Cell.new("sleep 1")
+        original_updated = cell.updated_at
+        time.sleep(0.001)
+        cell.mark_running()
+        self.assertEqual(cell.status, CellStatus.RUNNING)
+        self.assertGreater(cell.updated_at, original_updated)
+
+    def test_mark_completed_zero_exit_becomes_completed(self) -> None:
+        cell = Cell.new("true")
+        cell.mark_completed(stdout="ok\n", stderr="", exit_code=0)
+        self.assertEqual(cell.status, CellStatus.COMPLETED)
+        self.assertEqual(cell.stdout, "ok\n")
+        self.assertEqual(cell.exit_code, 0)
+
+    def test_mark_completed_nonzero_exit_becomes_failed(self) -> None:
+        cell = Cell.new("false")
+        cell.mark_completed(stdout="", stderr="boom\n", exit_code=1)
+        self.assertEqual(cell.status, CellStatus.FAILED)
+        self.assertEqual(cell.stderr, "boom\n")
+        self.assertEqual(cell.exit_code, 1)
+
+    def test_mark_cancelled(self) -> None:
+        cell = Cell.new("sleep 60")
+        cell.mark_running()
+        cell.mark_cancelled()
+        self.assertEqual(cell.status, CellStatus.CANCELLED)
+
+    def test_update_command_clears_previous_output(self) -> None:
+        cell = Cell.new("echo one")
+        cell.mark_completed(stdout="one\n", stderr="", exit_code=0)
+        cell.update_command("echo two")
+        self.assertEqual(cell.command, "echo two")
+        self.assertEqual(cell.stdout, "")
+        self.assertEqual(cell.stderr, "")
+        self.assertIsNone(cell.exit_code)
+        self.assertEqual(cell.status, CellStatus.PENDING)
+
+
+class CellSerializationTests(unittest.TestCase):
+    """Round-trip a Cell through to_dict and from_dict."""
+
+    def test_round_trip_preserves_all_fields(self) -> None:
+        cell = Cell.new("echo hi", parent_id="parent123")
+        cell.mark_completed(stdout="hi\n", stderr="warn\n", exit_code=0)
+        cell.metadata["tag"] = "demo"
+        restored = Cell.from_dict(cell.to_dict())
+        self.assertEqual(restored.cell_id, cell.cell_id)
+        self.assertEqual(restored.command, cell.command)
+        self.assertEqual(restored.stdout, cell.stdout)
+        self.assertEqual(restored.stderr, cell.stderr)
+        self.assertEqual(restored.exit_code, cell.exit_code)
+        self.assertEqual(restored.status, cell.status)
+        self.assertEqual(restored.parent_id, cell.parent_id)
+        self.assertEqual(restored.metadata, {"tag": "demo"})
+        self.assertEqual(restored.created_at, cell.created_at)
+        self.assertEqual(restored.updated_at, cell.updated_at)
+
+    def test_to_dict_status_is_string(self) -> None:
+        cell = Cell.new("echo")
+        data = cell.to_dict()
+        self.assertEqual(data["status"], "pending")
+        self.assertIsInstance(data["created_at"], str)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1,0 +1,114 @@
+"""Unit tests for the EventBus and Event value object."""
+
+from __future__ import annotations
+
+import unittest
+
+from asat.event_bus import EventBus, EventBusError, WILDCARD
+from asat.events import Event, EventType
+
+
+class EventConstructionTests(unittest.TestCase):
+
+    def test_event_records_timestamp_and_defaults(self) -> None:
+        event = Event(event_type=EventType.CELL_CREATED)
+        self.assertEqual(event.event_type, EventType.CELL_CREATED)
+        self.assertEqual(event.payload, {})
+        self.assertEqual(event.source, "")
+        self.assertIsNotNone(event.timestamp.tzinfo)
+
+    def test_event_is_immutable(self) -> None:
+        event = Event(event_type=EventType.CELL_CREATED)
+        with self.assertRaises(Exception):
+            event.source = "hacker"  # type: ignore[misc]
+
+
+class EventBusSubscriptionTests(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.bus = EventBus()
+        self.received: list[Event] = []
+
+    def _record(self, event: Event) -> None:
+        self.received.append(event)
+
+    def test_subscribe_and_publish_calls_handler(self) -> None:
+        self.bus.subscribe(EventType.CELL_CREATED, self._record)
+        event = Event(event_type=EventType.CELL_CREATED, payload={"id": "1"})
+        self.bus.publish(event)
+        self.assertEqual(self.received, [event])
+
+    def test_handler_only_called_for_subscribed_type(self) -> None:
+        self.bus.subscribe(EventType.CELL_CREATED, self._record)
+        self.bus.publish(Event(event_type=EventType.CELL_REMOVED))
+        self.assertEqual(self.received, [])
+
+    def test_wildcard_receives_every_event(self) -> None:
+        self.bus.subscribe(WILDCARD, self._record)
+        self.bus.publish(Event(event_type=EventType.CELL_CREATED))
+        self.bus.publish(Event(event_type=EventType.COMMAND_COMPLETED))
+        self.assertEqual(len(self.received), 2)
+
+    def test_unsubscribe_stops_delivery(self) -> None:
+        self.bus.subscribe(EventType.CELL_CREATED, self._record)
+        self.bus.unsubscribe(EventType.CELL_CREATED, self._record)
+        self.bus.publish(Event(event_type=EventType.CELL_CREATED))
+        self.assertEqual(self.received, [])
+
+    def test_unsubscribe_unknown_handler_is_silent(self) -> None:
+        self.bus.unsubscribe(EventType.CELL_CREATED, self._record)
+
+    def test_subscriber_count_tracks_registrations(self) -> None:
+        self.assertEqual(self.bus.subscriber_count(EventType.CELL_CREATED), 0)
+        self.bus.subscribe(EventType.CELL_CREATED, self._record)
+        self.assertEqual(self.bus.subscriber_count(EventType.CELL_CREATED), 1)
+        self.bus.subscribe(EventType.CELL_CREATED, lambda e: None)
+        self.assertEqual(self.bus.subscriber_count(EventType.CELL_CREATED), 2)
+
+    def test_clear_removes_all_subscriptions(self) -> None:
+        self.bus.subscribe(EventType.CELL_CREATED, self._record)
+        self.bus.subscribe(WILDCARD, self._record)
+        self.bus.clear()
+        self.assertEqual(self.bus.subscriber_count(EventType.CELL_CREATED), 0)
+        self.assertEqual(self.bus.subscriber_count(WILDCARD), 0)
+
+    def test_invalid_subscription_key_raises(self) -> None:
+        with self.assertRaises(TypeError):
+            self.bus.subscribe("not-an-event", self._record)  # type: ignore[arg-type]
+
+
+class EventBusErrorIsolationTests(unittest.TestCase):
+
+    def test_failing_handler_does_not_block_others(self) -> None:
+        bus = EventBus()
+        calls: list[str] = []
+
+        def good(_event: Event) -> None:
+            calls.append("good")
+
+        def bad(_event: Event) -> None:
+            calls.append("bad")
+            raise RuntimeError("boom")
+
+        bus.subscribe(EventType.CELL_CREATED, bad)
+        bus.subscribe(EventType.CELL_CREATED, good)
+        with self.assertRaises(EventBusError) as ctx:
+            bus.publish(Event(event_type=EventType.CELL_CREATED))
+        self.assertEqual(calls, ["bad", "good"])
+        self.assertEqual(len(ctx.exception.errors), 1)
+
+    def test_multiple_failures_aggregate(self) -> None:
+        bus = EventBus()
+
+        def bad(_event: Event) -> None:
+            raise ValueError("x")
+
+        bus.subscribe(EventType.CELL_CREATED, bad)
+        bus.subscribe(EventType.CELL_CREATED, bad)
+        with self.assertRaises(EventBusError) as ctx:
+            bus.publish(Event(event_type=EventType.CELL_CREATED))
+        self.assertEqual(len(ctx.exception.errors), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,163 @@
+"""Unit tests for the Session container."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from asat.cell import Cell
+from asat.session import Session, SessionError
+
+
+def _cells(commands: list[str]) -> list[Cell]:
+    """Return a list of fresh pending cells for each command."""
+    return [Cell.new(command) for command in commands]
+
+
+class SessionConstructionTests(unittest.TestCase):
+
+    def test_new_session_is_empty(self) -> None:
+        session = Session.new()
+        self.assertEqual(len(session), 0)
+        self.assertIsNone(session.active_cell_id)
+        self.assertEqual(session.created_at, session.updated_at)
+
+    def test_iteration_yields_cells_in_order(self) -> None:
+        session = Session.new()
+        cells = _cells(["a", "b", "c"])
+        for cell in cells:
+            session.add_cell(cell)
+        self.assertEqual([c.command for c in session], ["a", "b", "c"])
+
+
+class SessionAddRemoveTests(unittest.TestCase):
+
+    def test_add_appends_by_default(self) -> None:
+        session = Session.new()
+        first, second = _cells(["first", "second"])
+        session.add_cell(first)
+        session.add_cell(second)
+        self.assertEqual(session.cells, [first, second])
+
+    def test_add_at_position_inserts(self) -> None:
+        session = Session.new()
+        a, b, c = _cells(["a", "b", "c"])
+        session.add_cell(a)
+        session.add_cell(b)
+        session.add_cell(c, position=1)
+        self.assertEqual([cell.command for cell in session], ["a", "c", "b"])
+
+    def test_add_duplicate_id_raises(self) -> None:
+        session = Session.new()
+        cell = Cell.new("x")
+        session.add_cell(cell)
+        with self.assertRaises(SessionError):
+            session.add_cell(cell)
+
+    def test_add_out_of_range_raises(self) -> None:
+        session = Session.new()
+        with self.assertRaises(SessionError):
+            session.add_cell(Cell.new("x"), position=5)
+
+    def test_remove_returns_cell_and_clears_active(self) -> None:
+        session = Session.new()
+        a, b = _cells(["a", "b"])
+        session.add_cell(a)
+        session.add_cell(b)
+        session.set_active(a.cell_id)
+        removed = session.remove_cell(a.cell_id)
+        self.assertIs(removed, a)
+        self.assertIsNone(session.active_cell_id)
+        self.assertEqual(session.cells, [b])
+
+    def test_remove_unknown_id_raises(self) -> None:
+        session = Session.new()
+        with self.assertRaises(SessionError):
+            session.remove_cell("missing")
+
+
+class SessionMoveTests(unittest.TestCase):
+
+    def test_move_cell_changes_order(self) -> None:
+        session = Session.new()
+        a, b, c = _cells(["a", "b", "c"])
+        for cell in (a, b, c):
+            session.add_cell(cell)
+        session.move_cell(c.cell_id, 0)
+        self.assertEqual([cell.command for cell in session], ["c", "a", "b"])
+
+    def test_move_cell_to_same_position_is_noop(self) -> None:
+        session = Session.new()
+        a, b = _cells(["a", "b"])
+        session.add_cell(a)
+        session.add_cell(b)
+        session.move_cell(a.cell_id, 0)
+        self.assertEqual([cell.command for cell in session], ["a", "b"])
+
+    def test_move_cell_out_of_range_raises(self) -> None:
+        session = Session.new()
+        a = Cell.new("a")
+        session.add_cell(a)
+        with self.assertRaises(SessionError):
+            session.move_cell(a.cell_id, 5)
+
+
+class SessionFocusAndNavigationTests(unittest.TestCase):
+
+    def test_set_active_requires_membership(self) -> None:
+        session = Session.new()
+        with self.assertRaises(SessionError):
+            session.set_active("nope")
+
+    def test_active_cell_returns_focused_cell(self) -> None:
+        session = Session.new()
+        cell = Cell.new("a")
+        session.add_cell(cell)
+        session.set_active(cell.cell_id)
+        self.assertIs(session.active_cell(), cell)
+
+    def test_active_cell_is_none_when_unset(self) -> None:
+        session = Session.new()
+        self.assertIsNone(session.active_cell())
+
+    def test_next_and_previous_at_boundaries(self) -> None:
+        session = Session.new()
+        a, b, c = _cells(["a", "b", "c"])
+        for cell in (a, b, c):
+            session.add_cell(cell)
+        self.assertIs(session.next_cell(a.cell_id), b)
+        self.assertIs(session.previous_cell(b.cell_id), a)
+        self.assertIsNone(session.previous_cell(a.cell_id))
+        self.assertIsNone(session.next_cell(c.cell_id))
+
+
+class SessionSerializationTests(unittest.TestCase):
+
+    def test_round_trip_preserves_state(self) -> None:
+        session = Session.new()
+        a, b = _cells(["a", "b"])
+        session.add_cell(a)
+        session.add_cell(b)
+        session.set_active(b.cell_id)
+        session.metadata["project"] = "asat"
+        restored = Session.from_dict(session.to_dict())
+        self.assertEqual(restored.session_id, session.session_id)
+        self.assertEqual([c.command for c in restored], ["a", "b"])
+        self.assertEqual(restored.active_cell_id, b.cell_id)
+        self.assertEqual(restored.metadata, {"project": "asat"})
+
+    def test_save_and_load_roundtrip_on_disk(self) -> None:
+        session = Session.new()
+        session.add_cell(Cell.new("echo hi"))
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "session.json"
+            session.save(path)
+            loaded = Session.load(path)
+        self.assertEqual(loaded.session_id, session.session_id)
+        self.assertEqual(len(loaded), 1)
+        self.assertEqual(loaded.cells[0].command, "echo hi")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

First chunk of the Accessible Spatial Audio Terminal. Only the foundational data structures and the central event bus — no audio, execution, or input handling yet. Those land in subsequent phases.

### What's in the package

- `asat/cell.py` — `Cell` dataclass + `CellStatus` enum. Captures one input/output notebook interaction (command, stdout, stderr, exit code, lifecycle, parent id for branching, metadata).
- `asat/session.py` — `Session` container. Ordered list of cells with add / remove / move / focus / navigation helpers, plus JSON save/load.
- `asat/events.py` — `EventType` vocabulary (session / cell / command / output / input / audio groups) and an immutable `Event` value object.
- `asat/event_bus.py` — synchronous pub/sub `EventBus` with wildcard subscriptions and error isolation (one failing handler doesn't stop the others; errors aggregate into `EventBusError`).
- `pyproject.toml` — minimal setuptools config, stdlib-only.

### Screen-reader-conscious choices

- Flat package (`asat/*.py`) — shallow tree navigation.
- Docstrings at the top of every function; no inline comment clutter interrupting code flow.
- Single-purpose functions, no deep nesting, descriptive names.
- `from __future__ import annotations` everywhere so type hints don't bloat the runtime surface.

### Security posture

Zero external dependencies. Everything runs on the Python 3.10+ standard library.

## Test plan

- [x] `python -m unittest discover -s tests -v` — 40 tests pass in ~9 ms
- [x] Cell: lifecycle transitions, serialization round-trip, timestamp updates
- [x] Session: add/remove/move boundaries, focus + navigation, JSON save/load on disk
- [x] EventBus: subscribe, unsubscribe, wildcard, error aggregation, invalid-key rejection, immutability of `Event`

## Next (blocked on your review)

Phase 2 — the Execution Kernel — stays untouched until you've vetted this foundation.
