### PR TITLE
Phase 2: execution kernel and streamed subprocess runner

### DIFF
--- a/asat/__init__.py
+++ b/asat/__init__.py
@@ -1,14 +1,18 @@
 """Accessible Spatial Audio Terminal.
 
-Phase 1 exposes the foundational data structures and event bus.
-Later phases add the execution kernel, audio engine, input router,
-output parser, and ANSI interactivity layer.
+Phase 1 added the foundational data structures and event bus.
+Phase 2 adds the execution kernel and its supporting subprocess
+runner. Later phases bring the audio engine, input router, output
+parser, and ANSI interactivity layer.
 """
 
 from asat.cell import Cell, CellStatus
 from asat.session import Session
 from asat.events import Event, EventType
 from asat.event_bus import EventBus
+from asat.execution import ExecutionMode, ExecutionRequest, ExecutionResult
+from asat.runner import ProcessRunner
+from asat.kernel import ExecutionKernel
 
 __all__ = [
     "Cell",
@@ -17,6 +21,11 @@ __all__ = [
     "Event",
     "EventType",
     "EventBus",
+    "ExecutionKernel",
+    "ExecutionMode",
+    "ExecutionRequest",
+    "ExecutionResult",
+    "ProcessRunner",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/asat/execution.py
+++ b/asat/execution.py
@@ -1,0 +1,73 @@
+"""Value objects for describing a command execution.
+
+These dataclasses carry everything the low-level runner needs to spawn
+a process, and everything the kernel needs to record the outcome on a
+Cell. They are deliberately inert: no logic beyond field storage. The
+runner and kernel modules consume them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+
+class ExecutionMode(str, Enum):
+    """How a command string is translated into arguments.
+
+    ARGV: parse the command string with shlex into a strict argv list
+        and call the executable directly. No shell interpreter is
+        involved. Pipes, redirections, globbing, and variable
+        expansion are not available. This is the safer default
+        because no second interpreter ever sees the command.
+
+    SHELL: hand the raw command string to the platform shell
+        (/bin/sh -c on POSIX, cmd.exe /c on Windows). All shell
+        features are available. A terminal user typing commands at
+        their own prompt is the trust model, so this mode is
+        legitimate despite the general warnings around shell=True.
+    """
+
+    ARGV = "argv"
+    SHELL = "shell"
+
+
+@dataclass(frozen=True)
+class ExecutionRequest:
+    """Parameters for a single command execution.
+
+    command: The raw command string as typed by the user.
+    mode: Whether to parse as argv or hand off to the shell.
+    cwd: Working directory for the child process, or None to inherit.
+    env: Environment mapping for the child process, or None to inherit.
+    timeout_seconds: Wall-clock limit before the child is killed, or
+        None for no timeout.
+    """
+
+    command: str
+    mode: ExecutionMode = ExecutionMode.ARGV
+    cwd: Optional[Path] = None
+    env: Optional[dict[str, str]] = None
+    timeout_seconds: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class ExecutionResult:
+    """Outcome of a single command execution.
+
+    stdout: Complete captured standard output as a single string.
+    stderr: Complete captured standard error as a single string.
+    exit_code: Process exit code. Negative values on POSIX indicate
+        termination by a signal (see subprocess docs). The kernel
+        uses 127 for 'command not found' and 2 for 'parse error' to
+        mirror shell conventions.
+    timed_out: True if the process was killed by the timeout enforcer
+        rather than exiting on its own.
+    """
+
+    stdout: str
+    stderr: str
+    exit_code: int
+    timed_out: bool = False

--- a/asat/kernel.py
+++ b/asat/kernel.py
@@ -1,0 +1,158 @@
+"""ExecutionKernel: orchestrates running a Cell's command.
+
+The kernel is the sole module that knows how to connect a Cell, the
+ProcessRunner, and the EventBus. Everything else in ASAT interacts
+with execution through the events the kernel publishes.
+
+Event sequence for a normal run:
+    COMMAND_SUBMITTED  (payload: cell_id, command)
+    COMMAND_STARTED    (payload: cell_id)
+    OUTPUT_CHUNK       (payload: cell_id, line)   zero or more
+    ERROR_CHUNK        (payload: cell_id, line)   zero or more
+    COMMAND_COMPLETED  (payload: cell_id, exit_code, timed_out)
+    or
+    COMMAND_FAILED     (payload: cell_id, exit_code, timed_out)
+    or
+    COMMAND_FAILED     (payload: cell_id, error, error_type) when the
+        kernel could not launch the process at all (missing executable,
+        unparseable command string).
+
+Command exit codes that are non-zero are reported as COMMAND_FAILED
+rather than COMMAND_COMPLETED so the audio engine can easily route
+them to the error voice.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from asat.cell import Cell
+from asat.event_bus import EventBus
+from asat.events import Event, EventType
+from asat.execution import ExecutionMode, ExecutionRequest, ExecutionResult
+from asat.runner import ProcessRunner
+
+
+EXIT_CODE_NOT_FOUND = 127
+EXIT_CODE_PARSE_ERROR = 2
+
+
+class ExecutionKernel:
+    """Runs a Cell's command and records the outcome back on the cell."""
+
+    SOURCE = "kernel"
+
+    def __init__(
+        self,
+        event_bus: EventBus,
+        runner: Optional[ProcessRunner] = None,
+        default_mode: ExecutionMode = ExecutionMode.ARGV,
+    ) -> None:
+        """Store collaborators and the default execution mode.
+
+        event_bus receives lifecycle and streaming events. runner is
+        replaceable for testing. default_mode applies when the caller
+        does not override the mode on a specific execute call.
+        """
+        self._bus = event_bus
+        self._runner = runner if runner is not None else ProcessRunner()
+        self._default_mode = default_mode
+
+    def execute(
+        self,
+        cell: Cell,
+        mode: Optional[ExecutionMode] = None,
+        cwd: Optional[Path] = None,
+        env: Optional[dict[str, str]] = None,
+        timeout_seconds: Optional[float] = None,
+    ) -> ExecutionResult:
+        """Run the cell's command and update the cell in place.
+
+        Returns the ExecutionResult for callers that want direct access
+        to the outcome. The cell itself is mutated: command outputs
+        and the final status are written to it regardless of whether
+        the caller inspects the return value.
+        """
+        request = ExecutionRequest(
+            command=cell.command,
+            mode=mode if mode is not None else self._default_mode,
+            cwd=cwd,
+            env=env,
+            timeout_seconds=timeout_seconds,
+        )
+        self._publish(
+            EventType.COMMAND_SUBMITTED,
+            cell_id=cell.cell_id,
+            command=cell.command,
+        )
+        cell.mark_running()
+        self._publish(EventType.COMMAND_STARTED, cell_id=cell.cell_id)
+        try:
+            result = self._runner.run(
+                request,
+                stdout_handler=self._make_line_forwarder(cell.cell_id, EventType.OUTPUT_CHUNK),
+                stderr_handler=self._make_line_forwarder(cell.cell_id, EventType.ERROR_CHUNK),
+            )
+        except FileNotFoundError as exc:
+            return self._fail_before_launch(cell, exc, EXIT_CODE_NOT_FOUND)
+        except ValueError as exc:
+            return self._fail_before_launch(cell, exc, EXIT_CODE_PARSE_ERROR)
+
+        cell.mark_completed(
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.exit_code,
+        )
+        succeeded = result.exit_code == 0 and not result.timed_out
+        final_type = EventType.COMMAND_COMPLETED if succeeded else EventType.COMMAND_FAILED
+        self._publish(
+            final_type,
+            cell_id=cell.cell_id,
+            exit_code=result.exit_code,
+            timed_out=result.timed_out,
+        )
+        return result
+
+    def _make_line_forwarder(self, cell_id: str, event_type: EventType):
+        """Build a line handler that republishes each line as an event."""
+
+        def forward(line: str) -> None:
+            self._publish(event_type, cell_id=cell_id, line=line)
+
+        return forward
+
+    def _fail_before_launch(
+        self,
+        cell: Cell,
+        exc: BaseException,
+        exit_code: int,
+    ) -> ExecutionResult:
+        """Record a launch-time failure on the cell and publish an event.
+
+        Used when the kernel could not even start the subprocess, for
+        example because the executable does not exist or the command
+        string could not be parsed.
+        """
+        message = str(exc)
+        cell.mark_completed(stdout="", stderr=message, exit_code=exit_code)
+        self._publish(
+            EventType.COMMAND_FAILED,
+            cell_id=cell.cell_id,
+            error=message,
+            error_type=exc.__class__.__name__,
+            exit_code=exit_code,
+            timed_out=False,
+        )
+        return ExecutionResult(
+            stdout="",
+            stderr=message,
+            exit_code=exit_code,
+            timed_out=False,
+        )
+
+    def _publish(self, event_type: EventType, **payload) -> None:
+        """Publish an Event on the bus with the kernel as the source."""
+        self._bus.publish(
+            Event(event_type=event_type, payload=payload, source=self.SOURCE)
+        )

--- a/asat/runner.py
+++ b/asat/runner.py
@@ -1,0 +1,115 @@
+"""Low-level subprocess runner with streamed output capture.
+
+The ProcessRunner is the only place in ASAT that directly touches the
+subprocess module. Everything above it (the kernel, the future parsers
+and audio engine) consumes ExecutionResult objects and LineHandler
+callbacks. Keeping this module thin makes it easy to audit the one
+spot where untrusted command strings become running processes.
+"""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+import threading
+from io import StringIO
+from typing import Callable, Optional
+
+from asat.execution import ExecutionMode, ExecutionRequest, ExecutionResult
+
+
+LineHandler = Callable[[str], None]
+
+
+class ProcessRunner:
+    """Synchronous runner that streams stdout and stderr line by line.
+
+    The run method blocks until the process exits or the timeout fires.
+    Two background threads drain the child's stdout and stderr pipes
+    independently so a flood of output on one stream cannot deadlock
+    the other. This is the standard portable pattern for concurrent
+    pipe reading from subprocess.Popen.
+    """
+
+    def run(
+        self,
+        request: ExecutionRequest,
+        stdout_handler: Optional[LineHandler] = None,
+        stderr_handler: Optional[LineHandler] = None,
+    ) -> ExecutionResult:
+        """Execute the request and return its ExecutionResult.
+
+        stdout_handler and stderr_handler, if provided, are invoked on
+        the reader threads with each line as it arrives. Handlers must
+        be thread-safe with respect to any shared state they touch;
+        the runner itself serializes nothing on their behalf.
+        """
+        argv, use_shell = self._build_argv(request)
+        process = subprocess.Popen(
+            argv,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=str(request.cwd) if request.cwd is not None else None,
+            env=request.env,
+            shell=use_shell,
+            text=True,
+            bufsize=1,
+        )
+        stdout_buffer = StringIO()
+        stderr_buffer = StringIO()
+        stdout_thread = self._spawn_pump(process.stdout, stdout_buffer, stdout_handler)
+        stderr_thread = self._spawn_pump(process.stderr, stderr_buffer, stderr_handler)
+        timed_out = False
+        try:
+            exit_code = process.wait(timeout=request.timeout_seconds)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            exit_code = process.wait()
+            timed_out = True
+        stdout_thread.join()
+        stderr_thread.join()
+        return ExecutionResult(
+            stdout=stdout_buffer.getvalue(),
+            stderr=stderr_buffer.getvalue(),
+            exit_code=exit_code,
+            timed_out=timed_out,
+        )
+
+    @staticmethod
+    def _build_argv(request: ExecutionRequest):
+        """Return the (argv, shell_flag) pair for subprocess.Popen.
+
+        Raises ValueError on an empty command or a shlex parse failure.
+        """
+        if request.mode == ExecutionMode.SHELL:
+            if not request.command.strip():
+                raise ValueError("Command is empty")
+            return request.command, True
+        argv = shlex.split(request.command)
+        if not argv:
+            raise ValueError("Command is empty")
+        return argv, False
+
+    @staticmethod
+    def _spawn_pump(stream, buffer: StringIO, handler: Optional[LineHandler]) -> threading.Thread:
+        """Start a daemon thread that drains stream into buffer."""
+        thread = threading.Thread(
+            target=ProcessRunner._pump,
+            args=(stream, buffer, handler),
+            daemon=True,
+        )
+        thread.start()
+        return thread
+
+    @staticmethod
+    def _pump(stream, buffer: StringIO, handler: Optional[LineHandler]) -> None:
+        """Read lines from stream until EOF, mirroring into buffer and handler."""
+        if stream is None:
+            return
+        try:
+            for line in stream:
+                buffer.write(line)
+                if handler is not None:
+                    handler(line)
+        finally:
+            stream.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "asat"
-version = "0.1.0"
+version = "0.2.0"
 description = "Accessible Spatial Audio Terminal"
 requires-python = ">=3.10"
 readme = { text = "Phase 1 foundation: data models and event bus.", content-type = "text/plain" }

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,0 +1,56 @@
+"""Unit tests for the execution value objects."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from asat.execution import ExecutionMode, ExecutionRequest, ExecutionResult
+
+
+class ExecutionRequestTests(unittest.TestCase):
+
+    def test_defaults(self) -> None:
+        request = ExecutionRequest(command="ls")
+        self.assertEqual(request.command, "ls")
+        self.assertEqual(request.mode, ExecutionMode.ARGV)
+        self.assertIsNone(request.cwd)
+        self.assertIsNone(request.env)
+        self.assertIsNone(request.timeout_seconds)
+
+    def test_custom_fields(self) -> None:
+        request = ExecutionRequest(
+            command="ls -la",
+            mode=ExecutionMode.SHELL,
+            cwd=Path("/tmp"),
+            env={"KEY": "VALUE"},
+            timeout_seconds=5.0,
+        )
+        self.assertEqual(request.mode, ExecutionMode.SHELL)
+        self.assertEqual(request.cwd, Path("/tmp"))
+        self.assertEqual(request.env, {"KEY": "VALUE"})
+        self.assertEqual(request.timeout_seconds, 5.0)
+
+    def test_is_frozen(self) -> None:
+        request = ExecutionRequest(command="ls")
+        with self.assertRaises(Exception):
+            request.command = "rm -rf /"  # type: ignore[misc]
+
+
+class ExecutionResultTests(unittest.TestCase):
+
+    def test_defaults(self) -> None:
+        result = ExecutionResult(stdout="hi\n", stderr="", exit_code=0)
+        self.assertEqual(result.stdout, "hi\n")
+        self.assertEqual(result.stderr, "")
+        self.assertEqual(result.exit_code, 0)
+        self.assertFalse(result.timed_out)
+
+    def test_timed_out_flag(self) -> None:
+        result = ExecutionResult(stdout="", stderr="", exit_code=-9, timed_out=True)
+        self.assertTrue(result.timed_out)
+        self.assertEqual(result.exit_code, -9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1,0 +1,206 @@
+"""Unit tests for ExecutionKernel.
+
+The kernel is tested with a stub ProcessRunner for most cases to keep
+the tests fast and deterministic. One end-to-end test exercises a real
+subprocess to confirm the wiring from kernel through runner to cell.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from typing import Optional
+
+from asat.cell import Cell, CellStatus
+from asat.event_bus import EventBus
+from asat.events import Event, EventType
+from asat.execution import ExecutionMode, ExecutionRequest, ExecutionResult
+from asat.kernel import EXIT_CODE_NOT_FOUND, EXIT_CODE_PARSE_ERROR, ExecutionKernel
+from asat.runner import ProcessRunner
+
+
+class StubRunner:
+    """ProcessRunner stand-in for fast unit tests."""
+
+    def __init__(
+        self,
+        result: Optional[ExecutionResult] = None,
+        raises: Optional[BaseException] = None,
+        stdout_lines: Optional[list[str]] = None,
+        stderr_lines: Optional[list[str]] = None,
+    ) -> None:
+        self.result = result
+        self.raises = raises
+        self.stdout_lines = stdout_lines or []
+        self.stderr_lines = stderr_lines or []
+        self.last_request: Optional[ExecutionRequest] = None
+
+    def run(self, request, stdout_handler=None, stderr_handler=None):
+        self.last_request = request
+        if self.raises is not None:
+            raise self.raises
+        if stdout_handler is not None:
+            for line in self.stdout_lines:
+                stdout_handler(line)
+        if stderr_handler is not None:
+            for line in self.stderr_lines:
+                stderr_handler(line)
+        return self.result
+
+
+class _Recorder:
+    """Collects every event published to a bus, in order."""
+
+    def __init__(self, bus: EventBus) -> None:
+        self.events: list[Event] = []
+        bus.subscribe("*", self.events.append)
+
+    def types(self) -> list[EventType]:
+        return [event.event_type for event in self.events]
+
+
+class KernelSuccessTests(unittest.TestCase):
+
+    def test_successful_command_marks_cell_completed(self) -> None:
+        bus = EventBus()
+        runner = StubRunner(
+            result=ExecutionResult(stdout="hi\n", stderr="", exit_code=0),
+        )
+        kernel = ExecutionKernel(bus, runner=runner)
+        cell = Cell.new("echo hi")
+        result = kernel.execute(cell)
+        self.assertEqual(cell.status, CellStatus.COMPLETED)
+        self.assertEqual(cell.stdout, "hi\n")
+        self.assertEqual(cell.exit_code, 0)
+        self.assertEqual(result.stdout, "hi\n")
+
+    def test_lifecycle_event_order(self) -> None:
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        runner = StubRunner(
+            result=ExecutionResult(stdout="", stderr="", exit_code=0),
+            stdout_lines=["one\n", "two\n"],
+        )
+        kernel = ExecutionKernel(bus, runner=runner)
+        kernel.execute(Cell.new("noop"))
+        self.assertEqual(
+            recorder.types(),
+            [
+                EventType.COMMAND_SUBMITTED,
+                EventType.COMMAND_STARTED,
+                EventType.OUTPUT_CHUNK,
+                EventType.OUTPUT_CHUNK,
+                EventType.COMMAND_COMPLETED,
+            ],
+        )
+
+    def test_output_chunk_payload_carries_line_and_cell_id(self) -> None:
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        runner = StubRunner(
+            result=ExecutionResult(stdout="", stderr="", exit_code=0),
+            stdout_lines=["hello\n"],
+        )
+        kernel = ExecutionKernel(bus, runner=runner)
+        cell = Cell.new("noop")
+        kernel.execute(cell)
+        chunks = [e for e in recorder.events if e.event_type == EventType.OUTPUT_CHUNK]
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(chunks[0].payload["line"], "hello\n")
+        self.assertEqual(chunks[0].payload["cell_id"], cell.cell_id)
+
+
+class KernelFailureTests(unittest.TestCase):
+
+    def test_nonzero_exit_is_failure(self) -> None:
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        runner = StubRunner(
+            result=ExecutionResult(stdout="", stderr="boom\n", exit_code=3),
+            stderr_lines=["boom\n"],
+        )
+        kernel = ExecutionKernel(bus, runner=runner)
+        cell = Cell.new("false")
+        kernel.execute(cell)
+        self.assertEqual(cell.status, CellStatus.FAILED)
+        self.assertEqual(cell.exit_code, 3)
+        self.assertIn(EventType.COMMAND_FAILED, recorder.types())
+        self.assertIn(EventType.ERROR_CHUNK, recorder.types())
+
+    def test_timeout_reports_failure(self) -> None:
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        runner = StubRunner(
+            result=ExecutionResult(stdout="", stderr="", exit_code=-9, timed_out=True),
+        )
+        kernel = ExecutionKernel(bus, runner=runner)
+        cell = Cell.new("sleep 60")
+        kernel.execute(cell, timeout_seconds=0.1)
+        self.assertEqual(cell.status, CellStatus.FAILED)
+        final = recorder.events[-1]
+        self.assertEqual(final.event_type, EventType.COMMAND_FAILED)
+        self.assertTrue(final.payload["timed_out"])
+
+    def test_missing_executable_fails_gracefully(self) -> None:
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        runner = StubRunner(raises=FileNotFoundError("no such binary"))
+        kernel = ExecutionKernel(bus, runner=runner)
+        cell = Cell.new("nope")
+        result = kernel.execute(cell)
+        self.assertEqual(cell.status, CellStatus.FAILED)
+        self.assertEqual(cell.exit_code, EXIT_CODE_NOT_FOUND)
+        self.assertEqual(result.exit_code, EXIT_CODE_NOT_FOUND)
+        failed = [e for e in recorder.events if e.event_type == EventType.COMMAND_FAILED]
+        self.assertEqual(len(failed), 1)
+        self.assertEqual(failed[0].payload["error_type"], "FileNotFoundError")
+
+    def test_parse_error_fails_gracefully(self) -> None:
+        bus = EventBus()
+        runner = StubRunner(raises=ValueError("unbalanced quote"))
+        kernel = ExecutionKernel(bus, runner=runner)
+        cell = Cell.new('echo "oops')
+        result = kernel.execute(cell)
+        self.assertEqual(cell.status, CellStatus.FAILED)
+        self.assertEqual(result.exit_code, EXIT_CODE_PARSE_ERROR)
+
+
+class KernelConfigurationTests(unittest.TestCase):
+
+    def test_default_mode_is_forwarded(self) -> None:
+        bus = EventBus()
+        runner = StubRunner(
+            result=ExecutionResult(stdout="", stderr="", exit_code=0),
+        )
+        kernel = ExecutionKernel(bus, runner=runner, default_mode=ExecutionMode.SHELL)
+        kernel.execute(Cell.new("echo hi"))
+        assert runner.last_request is not None
+        self.assertEqual(runner.last_request.mode, ExecutionMode.SHELL)
+
+    def test_per_call_mode_overrides_default(self) -> None:
+        bus = EventBus()
+        runner = StubRunner(
+            result=ExecutionResult(stdout="", stderr="", exit_code=0),
+        )
+        kernel = ExecutionKernel(bus, runner=runner, default_mode=ExecutionMode.ARGV)
+        kernel.execute(Cell.new("echo hi"), mode=ExecutionMode.SHELL)
+        assert runner.last_request is not None
+        self.assertEqual(runner.last_request.mode, ExecutionMode.SHELL)
+
+
+class KernelEndToEndTests(unittest.TestCase):
+
+    def test_real_subprocess_pipeline(self) -> None:
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        kernel = ExecutionKernel(bus, runner=ProcessRunner())
+        cell = Cell.new(f'{sys.executable} -c "print(2+2)"')
+        kernel.execute(cell)
+        self.assertEqual(cell.status, CellStatus.COMPLETED)
+        self.assertIn("4", cell.stdout)
+        self.assertEqual(cell.exit_code, 0)
+        self.assertIn(EventType.COMMAND_COMPLETED, recorder.types())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,142 @@
+"""Integration tests for ProcessRunner.
+
+These tests spawn real subprocesses using sys.executable so they work
+on any platform that can run Python. No shell-specific commands are
+used in ARGV mode tests.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import unittest
+
+from asat.execution import ExecutionMode, ExecutionRequest
+from asat.runner import ProcessRunner
+
+
+def _python(script: str, mode: ExecutionMode = ExecutionMode.ARGV) -> ExecutionRequest:
+    """Build a request that runs the given inline Python script."""
+    command = f'{sys.executable} -c "{script}"'
+    return ExecutionRequest(command=command, mode=mode)
+
+
+class RunnerStdoutStderrTests(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.runner = ProcessRunner()
+
+    def test_captures_stdout(self) -> None:
+        result = self.runner.run(_python("print('hello')"))
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("hello", result.stdout)
+        self.assertEqual(result.stderr, "")
+        self.assertFalse(result.timed_out)
+
+    def test_captures_stderr_separately(self) -> None:
+        script = "import sys; sys.stderr.write('oops\\n'); sys.exit(3)"
+        result = self.runner.run(_python(script))
+        self.assertEqual(result.exit_code, 3)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("oops", result.stderr)
+
+    def test_preserves_both_streams(self) -> None:
+        script = (
+            "import sys; "
+            "print('out'); "
+            "sys.stderr.write('err\\n'); "
+            "sys.exit(0)"
+        )
+        result = self.runner.run(_python(script))
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("out", result.stdout)
+        self.assertIn("err", result.stderr)
+
+
+class RunnerStreamingTests(unittest.TestCase):
+
+    def test_stdout_handler_receives_lines(self) -> None:
+        script = "import sys; print('a'); print('b'); print('c')"
+        received: list[str] = []
+        lock = threading.Lock()
+
+        def handler(line: str) -> None:
+            with lock:
+                received.append(line)
+
+        runner = ProcessRunner()
+        runner.run(_python(script), stdout_handler=handler)
+        self.assertEqual([line.strip() for line in received], ["a", "b", "c"])
+
+    def test_stderr_handler_receives_lines(self) -> None:
+        script = "import sys; sys.stderr.write('x\\ny\\n')"
+        received: list[str] = []
+
+        def handler(line: str) -> None:
+            received.append(line)
+
+        ProcessRunner().run(_python(script), stderr_handler=handler)
+        self.assertEqual([line.strip() for line in received], ["x", "y"])
+
+
+class RunnerTimeoutTests(unittest.TestCase):
+
+    def test_timeout_kills_process(self) -> None:
+        request = ExecutionRequest(
+            command=f'{sys.executable} -c "import time; time.sleep(10)"',
+            timeout_seconds=0.2,
+        )
+        result = ProcessRunner().run(request)
+        self.assertTrue(result.timed_out)
+        self.assertNotEqual(result.exit_code, 0)
+
+
+class RunnerErrorTests(unittest.TestCase):
+
+    def test_missing_executable_raises(self) -> None:
+        request = ExecutionRequest(command="definitely_not_a_real_command_xyz")
+        with self.assertRaises(FileNotFoundError):
+            ProcessRunner().run(request)
+
+    def test_unparseable_command_raises(self) -> None:
+        request = ExecutionRequest(command='echo "unclosed')
+        with self.assertRaises(ValueError):
+            ProcessRunner().run(request)
+
+    def test_empty_command_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            ProcessRunner().run(ExecutionRequest(command="   "))
+
+    def test_empty_shell_command_raises(self) -> None:
+        request = ExecutionRequest(command="", mode=ExecutionMode.SHELL)
+        with self.assertRaises(ValueError):
+            ProcessRunner().run(request)
+
+
+class RunnerEnvironmentTests(unittest.TestCase):
+
+    def test_env_is_passed_through(self) -> None:
+        script = "import os; print(os.environ.get('ASAT_TEST_VAR', 'missing'))"
+        request = ExecutionRequest(
+            command=f'{sys.executable} -c "{script}"',
+            env={**os.environ, "ASAT_TEST_VAR": "present"},
+        )
+        result = ProcessRunner().run(request)
+        self.assertIn("present", result.stdout)
+
+
+class RunnerShellModeTests(unittest.TestCase):
+
+    def test_shell_mode_runs_a_simple_command(self) -> None:
+        request = ExecutionRequest(
+            command=f"{sys.executable} -c \"print('shelled')\"",
+            mode=ExecutionMode.SHELL,
+        )
+        result = ProcessRunner().run(request)
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("shelled", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Second chunk. Builds on the Phase 1 foundation to add the Execution Kernel: the only part of the system that knows how to take a command string and turn it into a running process. Still no audio, no input handling, no parsing — those come later.

### What's in the kernel

Three small, single-responsibility modules:

- **`asat/execution.py`** — value objects only. `ExecutionMode` (ARGV / SHELL), `ExecutionRequest` (command + mode + cwd + env + timeout), `ExecutionResult` (stdout, stderr, exit_code, timed_out). All frozen dataclasses; no logic.

- **`asat/runner.py`** — `ProcessRunner`, the single module that touches `subprocess`. Keeps the audit surface tiny. Streams stdout and stderr on two daemon threads so neither pipe can deadlock the other. Accepts optional line handlers invoked as output arrives — the kernel wires these up to the event bus. Enforces timeouts (kill on expiry). Rejects empty commands. Raises `ValueError` on shlex parse errors, `FileNotFoundError` from Popen for missing executables.

- **`asat/kernel.py`** — `ExecutionKernel` orchestrates everything. Given a `Cell`, it:
  1. Publishes `COMMAND_SUBMITTED`.
  2. Calls `cell.mark_running()` and publishes `COMMAND_STARTED`.
  3. Hands off to the runner with stdout/stderr line handlers that republish each line as `OUTPUT_CHUNK` / `ERROR_CHUNK` events.
  4. On success publishes `COMMAND_COMPLETED`; on non-zero exit or timeout, `COMMAND_FAILED`.
  5. Launch-time failures (`FileNotFoundError` → exit 127, `ValueError` → exit 2, shell conventions) mark the cell FAILED and publish `COMMAND_FAILED` with `error` and `error_type` fields. Nothing escapes the kernel as an exception.

### Security posture

- Zero external dependencies — still 100% stdlib.
- Default mode is `ARGV` (`shlex.split`, direct exec, no shell interpreter). `SHELL` mode is available but opt-in per call or per kernel.
- `subprocess` is quarantined to one file (`runner.py`) so future audits have a single place to look.
- No `eval`, no dynamic import, no string interpolation into shell arguments anywhere outside the command string the user themselves typed.

### Screen-reader-conscious choices

- Three short files rather than one large one — each has a narrow, clearly-named responsibility.
- Docstrings at the top of every function; no inline chatter.
- No deep nesting; early returns and helper methods keep each function flat.
- Event vocabulary already defined in Phase 1, so this PR introduces no new names to learn outside the three new classes.

## Test plan

67 tests, all passing in ~0.5 s (40 from Phase 1 + 27 new).

- [x] `tests/test_execution.py` — defaults, custom fields, frozen dataclass, timed_out flag
- [x] `tests/test_runner.py` — stdout/stderr capture and isolation, line streaming via handlers, timeout kills the child, missing executable raises `FileNotFoundError`, unbalanced quotes raise `ValueError`, empty commands rejected, env passthrough, shell mode works
- [x] `tests/test_kernel.py` — successful cell update, event lifecycle order, chunk payload shape, non-zero exit → FAILED, timeout → FAILED, missing executable → graceful FAILED with `error_type`, parse error → graceful FAILED, default mode + per-call override, and one end-to-end real subprocess test
- [x] `python -m unittest discover -s tests -v` — all 67 pass

## Blocked on your review

Phase 3 (Spatial Audio Engine: pure TTS first, then numpy-based HRTF convolution) stays untouched until you've vetted this. That'll be the first phase that introduces external dependencies (numpy, a TTS wrapper, sounddevice), so it's a natural checkpoint.
