### PR TITLE
Phase 5: output parsing and contextual action system

### DIFF
--- a/asat/__init__.py
+++ b/asat/__init__.py
@@ -5,12 +5,26 @@ Phase 2 added the execution kernel and its subprocess runner.
 Phase 3 added the spatial audio engine: TTS abstraction, synthetic
 and measured HRTFs, convolution-based spatialization, and pluggable
 sinks.
-Phase 4 adds the input and state router: abstract Key value type,
+Phase 4 added the input and state router: abstract Key value type,
 NotebookCursor for non-visual navigation between cells, and an
 InputRouter that dispatches keystrokes to focus-aware actions.
-Later phases bring the output parser and ANSI interactivity layer.
+Phase 5 adds output parsing and the contextual action system:
+OutputBuffer and OutputRecorder capture streamed lines per cell,
+OutputCursor walks them line-by-line, and the ActionCatalog /
+ActionMenu pair exposes focus-driven affordances such as copying a
+line, copying stderr, or returning to the notebook.
+The ANSI interactivity layer will follow in a later phase.
 """
 
+from asat.actions import (
+    ActionCatalog,
+    ActionContext,
+    ActionMenu,
+    Clipboard,
+    MemoryClipboard,
+    MenuItem,
+    default_actions,
+)
 from asat.audio import (
     AudioBuffer,
     ChannelLayout,
@@ -30,17 +44,23 @@ from asat.input_router import BindingMap, InputRouter, default_bindings
 from asat.kernel import ExecutionKernel
 from asat.keys import Key, Modifier
 from asat.notebook import FocusMode, FocusState, NotebookCursor
+from asat.output_buffer import OutputBuffer, OutputLine, OutputRecorder
+from asat.output_cursor import OutputCursor
 from asat.runner import ProcessRunner
 from asat.session import Session
 from asat.tts import ToneTTSEngine, TTSEngine
 
 __all__ = [
+    "ActionCatalog",
+    "ActionContext",
+    "ActionMenu",
     "AudioBuffer",
     "AudioSink",
     "BindingMap",
     "Cell",
     "CellStatus",
     "ChannelLayout",
+    "Clipboard",
     "DEFAULT_SAMPLE_RATE",
     "Event",
     "EventBus",
@@ -54,9 +74,15 @@ __all__ = [
     "HRTFProfile",
     "InputRouter",
     "Key",
+    "MemoryClipboard",
     "MemorySink",
+    "MenuItem",
     "Modifier",
     "NotebookCursor",
+    "OutputBuffer",
+    "OutputCursor",
+    "OutputLine",
+    "OutputRecorder",
     "ProcessRunner",
     "Session",
     "SpatialAudioEngine",
@@ -69,8 +95,9 @@ __all__ = [
     "VoiceRouter",
     "WavFileSink",
     "convolve",
+    "default_actions",
     "default_bindings",
     "write_wav",
 ]
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/asat/actions.py
+++ b/asat/actions.py
@@ -1,0 +1,393 @@
+"""Contextual action catalog and menu.
+
+The action system is how a blind user reaches "right-click" style
+affordances without a mouse. It is organized into three layers:
+
+ActionContext
+    A frozen snapshot describing what the user is focused on:
+    focus mode, current cell, and, when in OUTPUT mode, the focused
+    line's number, stream, and text. Providers consult the context
+    to decide which items they contribute.
+
+ActionCatalog
+    A registry of ActionProvider callables keyed by FocusMode. Given
+    an ActionContext, the catalog asks each provider registered for
+    the context's focus mode for a sequence of MenuItems and returns
+    the aggregated list in registration order.
+
+ActionMenu
+    The stateful picker the user drives with keystrokes. It opens
+    against a context, tracks which item is focused, publishes menu
+    events, and activates the current item when asked. Activation
+    invokes the item's handler with the original context.
+
+Clipboard is declared as a small Protocol so later phases can plug in
+an OS-native backend. A simple in-memory MemoryClipboard is included
+so tests and early integrations do not need any side effect outside
+the process.
+
+default_actions() wires up the built-in providers Phase 5 ships with:
+entering input, viewing output, exiting modes, and copying output
+lines into the clipboard. Callers that need different affordances can
+build their own catalog from the same primitives.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Optional, Protocol
+
+from asat.event_bus import EventBus
+from asat.events import Event, EventType
+from asat.notebook import FocusMode, NotebookCursor
+from asat.output_buffer import OutputRecorder, STDERR, STDOUT
+from asat.output_cursor import OutputCursor
+
+
+@dataclass(frozen=True)
+class ActionContext:
+    """Snapshot of where the user is focused when the menu opens."""
+
+    focus_mode: FocusMode
+    cell_id: Optional[str] = None
+    line_number: Optional[int] = None
+    line_stream: Optional[str] = None
+    line_text: Optional[str] = None
+
+
+ActionHandler = Callable[[ActionContext], None]
+
+
+@dataclass(frozen=True)
+class MenuItem:
+    """One selectable entry in the contextual menu."""
+
+    id: str
+    label: str
+    handler: ActionHandler
+
+
+ActionProvider = Callable[[ActionContext], tuple[MenuItem, ...]]
+
+
+class Clipboard(Protocol):
+    """Minimal contract for a clipboard backend."""
+
+    def set_text(self, text: str) -> None:
+        """Replace the clipboard contents with the given text."""
+
+
+class MemoryClipboard:
+    """In-process clipboard used for tests and default integrations."""
+
+    def __init__(self) -> None:
+        """Initialize with empty contents."""
+        self._text = ""
+
+    @property
+    def text(self) -> str:
+        """Return the most recently stored text."""
+        return self._text
+
+    def set_text(self, text: str) -> None:
+        """Replace the stored text."""
+        self._text = text
+
+
+class ActionCatalog:
+    """Registry of per-focus-mode action providers."""
+
+    def __init__(self) -> None:
+        """Create an empty catalog with no providers registered."""
+        self._providers: dict[FocusMode, list[ActionProvider]] = {
+            mode: [] for mode in FocusMode
+        }
+
+    def register(self, mode: FocusMode, provider: ActionProvider) -> None:
+        """Append a provider for the given focus mode."""
+        self._providers[mode].append(provider)
+
+    def items_for(self, context: ActionContext) -> tuple[MenuItem, ...]:
+        """Return the concatenated items for the given context."""
+        result: list[MenuItem] = []
+        for provider in self._providers.get(context.focus_mode, []):
+            result.extend(provider(context))
+        return tuple(result)
+
+
+class ActionMenu:
+    """Stateful picker over the items returned by an ActionCatalog."""
+
+    SOURCE = "action_menu"
+
+    def __init__(self, bus: EventBus, catalog: ActionCatalog) -> None:
+        """Bind the menu to a bus and the catalog it draws items from."""
+        self._bus = bus
+        self._catalog = catalog
+        self._items: tuple[MenuItem, ...] = ()
+        self._index: int = -1
+        self._context: Optional[ActionContext] = None
+
+    @property
+    def is_open(self) -> bool:
+        """Return True if the menu is currently showing items."""
+        return self._index >= 0
+
+    @property
+    def items(self) -> tuple[MenuItem, ...]:
+        """Return the items currently shown by the menu."""
+        return self._items
+
+    def open(self, context: ActionContext) -> tuple[MenuItem, ...]:
+        """Open the menu against a context and focus the first item.
+
+        Publishes ACTION_MENU_OPENED with the item labels and an
+        ACTION_MENU_ITEM_FOCUSED event for the first item. Returns the
+        tuple of items; empty if no provider contributed anything.
+        """
+        items = self._catalog.items_for(context)
+        self._items = items
+        self._context = context
+        self._index = 0 if items else -1
+        self._publish_opened(context, items)
+        if items:
+            self._publish_focus(items[0])
+        return items
+
+    def close(self) -> None:
+        """Close the menu if it is open and publish ACTION_MENU_CLOSED."""
+        if not self.is_open and not self._items:
+            return
+        self._items = ()
+        self._index = -1
+        context = self._context
+        self._context = None
+        self._bus.publish(
+            Event(
+                event_type=EventType.ACTION_MENU_CLOSED,
+                payload={
+                    "focus_mode": context.focus_mode.value if context else None,
+                    "cell_id": context.cell_id if context else None,
+                },
+                source=self.SOURCE,
+            )
+        )
+
+    def current_item(self) -> Optional[MenuItem]:
+        """Return the currently focused item or None if the menu is closed."""
+        if not self.is_open:
+            return None
+        return self._items[self._index]
+
+    def focus_next(self) -> Optional[MenuItem]:
+        """Advance focus to the next item, clamping at the last entry."""
+        return self._move_focus(self._index + 1)
+
+    def focus_prev(self) -> Optional[MenuItem]:
+        """Move focus to the previous item, clamping at the first entry."""
+        return self._move_focus(self._index - 1)
+
+    def activate(self) -> Optional[MenuItem]:
+        """Invoke the focused item's handler and close the menu.
+
+        Publishes ACTION_MENU_ITEM_INVOKED before closing. If the menu
+        is closed or empty, returns None and does nothing.
+        """
+        item = self.current_item()
+        context = self._context
+        if item is None or context is None:
+            return None
+        self._bus.publish(
+            Event(
+                event_type=EventType.ACTION_MENU_ITEM_INVOKED,
+                payload={
+                    "item_id": item.id,
+                    "label": item.label,
+                    "focus_mode": context.focus_mode.value,
+                    "cell_id": context.cell_id,
+                },
+                source=self.SOURCE,
+            )
+        )
+        item.handler(context)
+        self.close()
+        return item
+
+    def _move_focus(self, target: int) -> Optional[MenuItem]:
+        """Clamp target into range, move, and publish on real change."""
+        if not self.is_open or not self._items:
+            return None
+        clamped = max(0, min(target, len(self._items) - 1))
+        if clamped == self._index:
+            return self._items[self._index]
+        self._index = clamped
+        item = self._items[self._index]
+        self._publish_focus(item)
+        return item
+
+    def _publish_opened(
+        self,
+        context: ActionContext,
+        items: tuple[MenuItem, ...],
+    ) -> None:
+        """Publish ACTION_MENU_OPENED with the item labels for this context."""
+        self._bus.publish(
+            Event(
+                event_type=EventType.ACTION_MENU_OPENED,
+                payload={
+                    "focus_mode": context.focus_mode.value,
+                    "cell_id": context.cell_id,
+                    "item_ids": [item.id for item in items],
+                    "labels": [item.label for item in items],
+                },
+                source=self.SOURCE,
+            )
+        )
+
+    def _publish_focus(self, item: MenuItem) -> None:
+        """Publish ACTION_MENU_ITEM_FOCUSED for the given item."""
+        self._bus.publish(
+            Event(
+                event_type=EventType.ACTION_MENU_ITEM_FOCUSED,
+                payload={
+                    "item_id": item.id,
+                    "label": item.label,
+                    "index": self._index,
+                },
+                source=self.SOURCE,
+            )
+        )
+
+
+def default_actions(
+    cursor: NotebookCursor,
+    recorder: OutputRecorder,
+    output_cursor: OutputCursor,
+    clipboard: Clipboard,
+    bus: EventBus,
+) -> ActionCatalog:
+    """Build the catalog of built-in Phase 5 actions.
+
+    NOTEBOOK mode exposes entering input and viewing output. INPUT mode
+    exposes submit and cancel. OUTPUT mode exposes copying the focused
+    line, copying the whole buffer, copying only stderr, and exiting
+    back to the notebook.
+
+    Copy actions route through the Clipboard and publish a
+    CLIPBOARD_COPIED event describing what landed on the clipboard.
+    """
+    catalog = ActionCatalog()
+
+    def _copy(context: ActionContext, text: str, source_label: str) -> None:
+        """Store text on the clipboard and publish CLIPBOARD_COPIED."""
+        clipboard.set_text(text)
+        bus.publish(
+            Event(
+                event_type=EventType.CLIPBOARD_COPIED,
+                payload={
+                    "cell_id": context.cell_id,
+                    "source": source_label,
+                    "length": len(text),
+                },
+                source="actions",
+            )
+        )
+
+    def notebook_items(context: ActionContext) -> tuple[MenuItem, ...]:
+        """Enter input / view output items for a focused cell."""
+        if context.cell_id is None:
+            return ()
+        return (
+            MenuItem(
+                id="enter_input",
+                label="Edit command",
+                handler=lambda _ctx: cursor.enter_input_mode(),
+            ),
+            MenuItem(
+                id="view_output",
+                label="Explore output",
+                handler=lambda _ctx: _enter_output(context),
+            ),
+        )
+
+    def _enter_output(context: ActionContext) -> None:
+        """Transition the cursor to OUTPUT mode and attach the cursor."""
+        cursor.view_output_mode()
+        if context.cell_id is not None:
+            output_cursor.attach(recorder.buffer_for(context.cell_id))
+
+    def input_items(_context: ActionContext) -> tuple[MenuItem, ...]:
+        """Submit / cancel items for the editing view."""
+        return (
+            MenuItem(
+                id="submit",
+                label="Submit command",
+                handler=lambda _ctx: cursor.submit(),
+            ),
+            MenuItem(
+                id="exit_input",
+                label="Cancel editing",
+                handler=lambda _ctx: cursor.exit_input_mode(),
+            ),
+        )
+
+    def output_items(context: ActionContext) -> tuple[MenuItem, ...]:
+        """Copy / exit items for the output exploration view."""
+        items: list[MenuItem] = []
+        if context.line_text is not None:
+            items.append(
+                MenuItem(
+                    id="copy_line",
+                    label="Copy focused line",
+                    handler=lambda ctx: _copy(
+                        ctx,
+                        ctx.line_text or "",
+                        "line",
+                    ),
+                )
+            )
+        if context.cell_id is not None:
+            items.append(
+                MenuItem(
+                    id="copy_all",
+                    label="Copy all output",
+                    handler=lambda ctx: _copy(
+                        ctx,
+                        _buffer_text(ctx, (STDOUT, STDERR)),
+                        "all",
+                    ),
+                )
+            )
+            items.append(
+                MenuItem(
+                    id="copy_stderr",
+                    label="Copy error output",
+                    handler=lambda ctx: _copy(
+                        ctx,
+                        _buffer_text(ctx, (STDERR,)),
+                        "stderr",
+                    ),
+                )
+            )
+        items.append(
+            MenuItem(
+                id="exit_output",
+                label="Return to notebook",
+                handler=lambda _ctx: cursor.exit_output_mode(),
+            )
+        )
+        return tuple(items)
+
+    def _buffer_text(context: ActionContext, streams: tuple[str, ...]) -> str:
+        """Join the selected streams from the cell's buffer into one string."""
+        if context.cell_id is None or not recorder.has_buffer_for(context.cell_id):
+            return ""
+        buffer = recorder.buffer_for(context.cell_id)
+        return "\n".join(
+            line.text for line in buffer.lines() if line.stream in streams
+        )
+
+    catalog.register(FocusMode.NOTEBOOK, notebook_items)
+    catalog.register(FocusMode.INPUT, input_items)
+    catalog.register(FocusMode.OUTPUT, output_items)
+    return catalog

--- a/asat/events.py
+++ b/asat/events.py
@@ -39,6 +39,16 @@ class EventType(str, Enum):
     Input and focus router:
         FOCUS_CHANGED, KEY_PRESSED, ACTION_INVOKED
 
+    Output buffering and cursor:
+        OUTPUT_LINE_APPENDED, OUTPUT_LINE_FOCUSED
+
+    Contextual action menu:
+        ACTION_MENU_OPENED, ACTION_MENU_CLOSED,
+        ACTION_MENU_ITEM_FOCUSED, ACTION_MENU_ITEM_INVOKED
+
+    Clipboard:
+        CLIPBOARD_COPIED
+
     Audio engine:
         AUDIO_SPOKEN, AUDIO_INTERRUPTED
     """
@@ -64,6 +74,16 @@ class EventType(str, Enum):
     FOCUS_CHANGED = "focus.changed"
     KEY_PRESSED = "input.key"
     ACTION_INVOKED = "input.action"
+
+    OUTPUT_LINE_APPENDED = "output.line.appended"
+    OUTPUT_LINE_FOCUSED = "output.line.focused"
+
+    ACTION_MENU_OPENED = "menu.opened"
+    ACTION_MENU_CLOSED = "menu.closed"
+    ACTION_MENU_ITEM_FOCUSED = "menu.item.focused"
+    ACTION_MENU_ITEM_INVOKED = "menu.item.invoked"
+
+    CLIPBOARD_COPIED = "clipboard.copied"
 
     AUDIO_SPOKEN = "audio.spoken"
     AUDIO_INTERRUPTED = "audio.interrupted"

--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -12,9 +12,15 @@ adapter that reads real terminal input and produces Key values is
 left to a later phase; this keeps the router fully testable in
 isolation and lets alternative input sources plug in cleanly.
 
-Default bindings cover the Phase 4 goal: non-visual navigation
-between input cells and basic in-place command editing. They can be
-overridden or extended by passing a custom bindings map.
+Default bindings cover non-visual navigation between input cells,
+in-place command editing, and line-level exploration of a cell's
+captured output. They can be overridden or extended by passing a
+custom bindings map.
+
+An OutputCursor is optional. When one is provided, the router dispatches
+OUTPUT-mode navigation actions to it. When it is absent, those actions
+silently no-op so the router is still usable for sessions that do not
+care about output navigation.
 """
 
 from __future__ import annotations
@@ -26,6 +32,7 @@ from asat.event_bus import EventBus
 from asat.events import Event, EventType
 from asat.keys import Key, Modifier
 from asat.notebook import FocusMode, NotebookCursor
+from asat.output_cursor import OutputCursor
 
 
 BindingMap = dict[FocusMode, dict[Key, str]]
@@ -37,12 +44,19 @@ def default_bindings() -> BindingMap:
     NOTEBOOK mode:
         Up/Down move between cells, Home/End jump to ends,
         Enter enters input mode on the focused cell,
-        Ctrl+N appends a fresh cell and enters input mode.
+        Ctrl+N appends a fresh cell and enters input mode,
+        Ctrl+O opens the captured output of the focused cell.
 
     INPUT mode:
         Backspace deletes the last character,
         Enter submits the current command,
         Escape commits and returns to notebook mode.
+
+    OUTPUT mode:
+        Up/Down walk one line at a time,
+        PageUp/PageDown jump a page,
+        Home/End jump to the first or last captured line,
+        Escape returns to notebook mode.
     """
     return {
         FocusMode.NOTEBOOK: {
@@ -52,11 +66,21 @@ def default_bindings() -> BindingMap:
             kc.END: "move_to_bottom",
             kc.ENTER: "enter_input",
             Key.combo("n", Modifier.CTRL): "new_cell",
+            Key.combo("o", Modifier.CTRL): "view_output",
         },
         FocusMode.INPUT: {
             kc.BACKSPACE: "backspace",
             kc.ENTER: "submit",
             kc.ESCAPE: "exit_input",
+        },
+        FocusMode.OUTPUT: {
+            kc.UP: "output_line_up",
+            kc.DOWN: "output_line_down",
+            kc.PAGE_UP: "output_page_up",
+            kc.PAGE_DOWN: "output_page_down",
+            kc.HOME: "output_to_start",
+            kc.END: "output_to_end",
+            kc.ESCAPE: "exit_output",
         },
     }
 
@@ -71,11 +95,13 @@ class InputRouter:
         cursor: NotebookCursor,
         bus: EventBus,
         bindings: Optional[BindingMap] = None,
+        output_cursor: Optional[OutputCursor] = None,
     ) -> None:
-        """Attach the router to a cursor and an event bus."""
+        """Attach the router to a cursor, event bus, and optional output cursor."""
         self._cursor = cursor
         self._bus = bus
         self._bindings = bindings if bindings is not None else default_bindings()
+        self._output_cursor = output_cursor
 
     @property
     def bindings(self) -> BindingMap:
@@ -118,7 +144,7 @@ class InputRouter:
         self._publish_action(action, key, payload_extra)
 
     def _action_handler(self, action: str) -> Callable[[], None]:
-        """Map an action name to a zero-argument callable on the cursor."""
+        """Map an action name to a zero-argument callable."""
         handlers: dict[str, Callable[[], None]] = {
             "move_up": lambda: self._cursor.move_up(),
             "move_down": lambda: self._cursor.move_down(),
@@ -128,10 +154,39 @@ class InputRouter:
             "exit_input": lambda: self._cursor.exit_input_mode(),
             "new_cell": lambda: self._cursor.new_cell(),
             "backspace": lambda: self._cursor.backspace(),
+            "view_output": lambda: self._cursor.view_output_mode(),
+            "exit_output": lambda: self._cursor.exit_output_mode(),
+            "output_line_up": lambda: self._with_output_cursor(
+                lambda oc: oc.move_line_up()
+            ),
+            "output_line_down": lambda: self._with_output_cursor(
+                lambda oc: oc.move_line_down()
+            ),
+            "output_page_up": lambda: self._with_output_cursor(
+                lambda oc: oc.move_page_up()
+            ),
+            "output_page_down": lambda: self._with_output_cursor(
+                lambda oc: oc.move_page_down()
+            ),
+            "output_to_start": lambda: self._with_output_cursor(
+                lambda oc: oc.move_to_start()
+            ),
+            "output_to_end": lambda: self._with_output_cursor(
+                lambda oc: oc.move_to_end()
+            ),
         }
         if action not in handlers:
             raise KeyError(f"Unknown action: {action}")
         return handlers[action]
+
+    def _with_output_cursor(
+        self,
+        operation: Callable[[OutputCursor], object],
+    ) -> None:
+        """Run an output-cursor operation only if a cursor is attached."""
+        if self._output_cursor is None:
+            return
+        operation(self._output_cursor)
 
     def _publish_key(self, key: Key) -> None:
         """Publish a KEY_PRESSED event describing the keystroke."""

--- a/asat/notebook.py
+++ b/asat/notebook.py
@@ -164,6 +164,38 @@ class NotebookCursor:
         )
         return self._state
 
+    def view_output_mode(self) -> Optional[FocusState]:
+        """Switch from notebook to output mode on the focused cell.
+
+        OUTPUT mode is where line-level navigation through a cell's
+        captured output happens. The cursor simply flips its mode;
+        attaching an OutputCursor to the appropriate buffer is the
+        caller's job.
+        """
+        if self._state.mode != FocusMode.NOTEBOOK or self._state.cell_id is None:
+            return None
+        self._transition(
+            FocusState(
+                mode=FocusMode.OUTPUT,
+                cell_id=self._state.cell_id,
+                input_buffer="",
+            )
+        )
+        return self._state
+
+    def exit_output_mode(self) -> Optional[FocusState]:
+        """Return to notebook mode from output mode."""
+        if self._state.mode != FocusMode.OUTPUT or self._state.cell_id is None:
+            return None
+        self._transition(
+            FocusState(
+                mode=FocusMode.NOTEBOOK,
+                cell_id=self._state.cell_id,
+                input_buffer="",
+            )
+        )
+        return self._state
+
     def insert_character(self, character: str) -> None:
         """Append a character to the input buffer while in INPUT mode."""
         if self._state.mode != FocusMode.INPUT:

--- a/asat/output_buffer.py
+++ b/asat/output_buffer.py
@@ -1,0 +1,191 @@
+"""OutputBuffer: per-cell storage of streamed stdout and stderr lines.
+
+The execution kernel publishes OUTPUT_CHUNK and ERROR_CHUNK events as a
+subprocess produces each line. Those events are fine for real-time
+audio, but a blind user also needs to revisit past output: walk
+line-by-line, re-read a specific line, copy one out, or page through a
+long result. That demands a structured per-cell line store, which is
+what OutputBuffer provides.
+
+The module is split into three pieces:
+
+OutputLine is the immutable record of a single captured line.
+OutputBuffer stores the lines for one cell and exposes random access,
+    slicing, paging, and filtering by stream. It is intentionally a
+    passive container: it does not subscribe to the event bus itself.
+OutputRecorder subscribes to OUTPUT_CHUNK/ERROR_CHUNK events and
+    funnels them into per-cell OutputBuffer instances, creating a new
+    buffer the first time a cell produces output. It also publishes
+    OUTPUT_LINE_APPENDED events so downstream consumers (the output
+    cursor, a line-level audio previewer) can react without re-parsing
+    the raw chunks.
+
+All classes are stdlib-only and synchronous, matching the rest of the
+project.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterator, Optional
+
+from asat.event_bus import EventBus
+from asat.events import Event, EventType
+
+
+STDOUT = "stdout"
+STDERR = "stderr"
+
+
+@dataclass(frozen=True)
+class OutputLine:
+    """A single captured line of output.
+
+    cell_id: the cell that produced this line.
+    line_number: zero-based index within the owning buffer, assigned
+        when the line was appended.
+    stream: "stdout" or "stderr".
+    text: the captured line content with its trailing newline stripped
+        by the runner before it reached us.
+    """
+
+    cell_id: str
+    line_number: int
+    stream: str
+    text: str
+
+
+class OutputBuffer:
+    """Per-cell ordered store of captured output lines."""
+
+    def __init__(self, cell_id: str) -> None:
+        """Create an empty buffer bound to a single cell id."""
+        self._cell_id = cell_id
+        self._lines: list[OutputLine] = []
+
+    @property
+    def cell_id(self) -> str:
+        """Return the id of the cell this buffer belongs to."""
+        return self._cell_id
+
+    def __len__(self) -> int:
+        """Return the number of captured lines."""
+        return len(self._lines)
+
+    def __iter__(self) -> Iterator[OutputLine]:
+        """Iterate over captured lines in insertion order."""
+        return iter(self._lines)
+
+    def append(self, text: str, stream: str = STDOUT) -> OutputLine:
+        """Append a single line and return the newly created OutputLine.
+
+        The caller is responsible for having already split multi-line
+        chunks. This matches how the kernel emits events (one line per
+        chunk), and keeps the buffer simple.
+        """
+        if stream not in (STDOUT, STDERR):
+            raise ValueError(f"Unknown output stream: {stream!r}")
+        line = OutputLine(
+            cell_id=self._cell_id,
+            line_number=len(self._lines),
+            stream=stream,
+            text=text,
+        )
+        self._lines.append(line)
+        return line
+
+    def lines(self) -> tuple[OutputLine, ...]:
+        """Return all captured lines as an immutable tuple."""
+        return tuple(self._lines)
+
+    def line(self, line_number: int) -> OutputLine:
+        """Return the line at the given zero-based index."""
+        if line_number < 0 or line_number >= len(self._lines):
+            raise IndexError(f"line_number {line_number} is out of range")
+        return self._lines[line_number]
+
+    def page(self, start: int, size: int) -> tuple[OutputLine, ...]:
+        """Return up to size consecutive lines starting at start.
+
+        Out-of-range starts clamp to the nearest end. The returned slice
+        may be shorter than size if the buffer ends first.
+        """
+        if size <= 0:
+            raise ValueError("page size must be positive")
+        clamped_start = max(0, min(start, len(self._lines)))
+        return tuple(self._lines[clamped_start:clamped_start + size])
+
+    def lines_on_stream(self, stream: str) -> tuple[OutputLine, ...]:
+        """Return only the lines captured from the given stream."""
+        if stream not in (STDOUT, STDERR):
+            raise ValueError(f"Unknown output stream: {stream!r}")
+        return tuple(line for line in self._lines if line.stream == stream)
+
+    def clear(self) -> None:
+        """Drop every captured line. Useful when a cell is re-executed."""
+        self._lines.clear()
+
+
+class OutputRecorder:
+    """Subscribes to output events and fills per-cell OutputBuffers.
+
+    On every OUTPUT_CHUNK or ERROR_CHUNK event the recorder looks up
+    (or creates) the buffer for the owning cell, appends the line, and
+    publishes a richer OUTPUT_LINE_APPENDED event containing the new
+    line's position. Downstream consumers (cursor, audio previewer)
+    can subscribe once to OUTPUT_LINE_APPENDED rather than having to
+    reconstruct line numbers themselves.
+    """
+
+    SOURCE = "output_recorder"
+
+    def __init__(self, bus: EventBus) -> None:
+        """Attach the recorder to a bus and subscribe to stream events."""
+        self._bus = bus
+        self._buffers: dict[str, OutputBuffer] = {}
+        bus.subscribe(EventType.OUTPUT_CHUNK, self._on_stdout_chunk)
+        bus.subscribe(EventType.ERROR_CHUNK, self._on_stderr_chunk)
+
+    def buffer_for(self, cell_id: str) -> OutputBuffer:
+        """Return the buffer for a cell, creating it on first access."""
+        buffer = self._buffers.get(cell_id)
+        if buffer is None:
+            buffer = OutputBuffer(cell_id=cell_id)
+            self._buffers[cell_id] = buffer
+        return buffer
+
+    def has_buffer_for(self, cell_id: str) -> bool:
+        """Return True if a buffer has ever been created for this cell."""
+        return cell_id in self._buffers
+
+    def discard(self, cell_id: str) -> Optional[OutputBuffer]:
+        """Forget the buffer for the given cell. Returns it, or None."""
+        return self._buffers.pop(cell_id, None)
+
+    def _on_stdout_chunk(self, event: Event) -> None:
+        """Route a stdout chunk into the appropriate buffer."""
+        self._record(event, STDOUT)
+
+    def _on_stderr_chunk(self, event: Event) -> None:
+        """Route a stderr chunk into the appropriate buffer."""
+        self._record(event, STDERR)
+
+    def _record(self, event: Event, stream: str) -> None:
+        """Append one chunk line and republish an enriched event."""
+        cell_id = event.payload.get("cell_id")
+        text = event.payload.get("line")
+        if not isinstance(cell_id, str) or not isinstance(text, str):
+            return
+        line = self.buffer_for(cell_id).append(text, stream=stream)
+        self._bus.publish(
+            Event(
+                event_type=EventType.OUTPUT_LINE_APPENDED,
+                payload={
+                    "cell_id": cell_id,
+                    "line_number": line.line_number,
+                    "stream": stream,
+                    "text": text,
+                },
+                source=self.SOURCE,
+            )
+        )

--- a/asat/output_cursor.py
+++ b/asat/output_cursor.py
@@ -1,0 +1,151 @@
+"""OutputCursor: line-level navigation through a cell's captured output.
+
+When the user flips a cell into OUTPUT focus mode, keystrokes should
+walk through the cell's output one line at a time. The OutputCursor is
+the small state machine that tracks "which line is currently under the
+ear" and exposes the motions the input router binds to.
+
+The cursor holds a reference to an OutputBuffer, an integer line index,
+and a page size. It is deliberately dumb about audio: its only job is
+to move the selection and publish OUTPUT_LINE_FOCUSED events. The audio
+engine (or any other observer) can subscribe to those events and
+voice the focused line.
+
+A cursor can be attached and re-attached as focus moves between cells.
+attach() snaps to the last line of the target buffer, which is the
+most useful position for a freshly finished command. Callers can then
+call move_to_start() to jump to the top of the output.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from asat.event_bus import EventBus
+from asat.events import Event, EventType
+from asat.output_buffer import OutputBuffer, OutputLine
+
+
+DEFAULT_PAGE_SIZE = 10
+
+
+class OutputCursor:
+    """Stateful cursor over the lines of a single OutputBuffer."""
+
+    SOURCE = "output_cursor"
+
+    def __init__(
+        self,
+        bus: EventBus,
+        page_size: int = DEFAULT_PAGE_SIZE,
+    ) -> None:
+        """Create an unattached cursor bound to an event bus.
+
+        The cursor starts detached (no buffer). Call attach() to bind it
+        to a specific cell's buffer before issuing navigation commands.
+        """
+        if page_size <= 0:
+            raise ValueError("page_size must be positive")
+        self._bus = bus
+        self._page_size = page_size
+        self._buffer: Optional[OutputBuffer] = None
+        self._index: int = -1
+
+    @property
+    def page_size(self) -> int:
+        """Return the number of lines a page motion traverses."""
+        return self._page_size
+
+    @property
+    def buffer(self) -> Optional[OutputBuffer]:
+        """Return the currently attached buffer, or None if detached."""
+        return self._buffer
+
+    @property
+    def line_number(self) -> Optional[int]:
+        """Return the zero-based index of the focused line, or None."""
+        if self._buffer is None or self._index < 0:
+            return None
+        return self._index
+
+    def attach(self, buffer: OutputBuffer) -> Optional[OutputLine]:
+        """Bind the cursor to a buffer, snapping to its last line.
+
+        Returns the newly focused line, or None if the buffer is empty.
+        """
+        self._buffer = buffer
+        if len(buffer) == 0:
+            self._index = -1
+            return None
+        self._index = len(buffer) - 1
+        line = buffer.line(self._index)
+        self._publish_focus(line)
+        return line
+
+    def detach(self) -> None:
+        """Drop the attached buffer without publishing any event."""
+        self._buffer = None
+        self._index = -1
+
+    def current_line(self) -> Optional[OutputLine]:
+        """Return the currently focused OutputLine, or None if empty."""
+        if self._buffer is None or self._index < 0:
+            return None
+        if self._index >= len(self._buffer):
+            return None
+        return self._buffer.line(self._index)
+
+    def move_line_up(self) -> Optional[OutputLine]:
+        """Focus the previous line; no-op at the top."""
+        return self._seek(self._index - 1)
+
+    def move_line_down(self) -> Optional[OutputLine]:
+        """Focus the next line; no-op at the bottom."""
+        return self._seek(self._index + 1)
+
+    def move_page_up(self) -> Optional[OutputLine]:
+        """Jump up by a page; clamps at the first line."""
+        return self._seek(self._index - self._page_size)
+
+    def move_page_down(self) -> Optional[OutputLine]:
+        """Jump down by a page; clamps at the last line."""
+        return self._seek(self._index + self._page_size)
+
+    def move_to_start(self) -> Optional[OutputLine]:
+        """Focus the first line of the buffer."""
+        if self._buffer is None or len(self._buffer) == 0:
+            return None
+        return self._seek(0)
+
+    def move_to_end(self) -> Optional[OutputLine]:
+        """Focus the last line of the buffer."""
+        if self._buffer is None or len(self._buffer) == 0:
+            return None
+        return self._seek(len(self._buffer) - 1)
+
+    def _seek(self, target: int) -> Optional[OutputLine]:
+        """Clamp target into range, move, and publish if actually changed."""
+        if self._buffer is None or len(self._buffer) == 0:
+            return None
+        clamped = max(0, min(target, len(self._buffer) - 1))
+        if clamped == self._index:
+            return self._buffer.line(self._index)
+        self._index = clamped
+        line = self._buffer.line(self._index)
+        self._publish_focus(line)
+        return line
+
+    def _publish_focus(self, line: OutputLine) -> None:
+        """Publish an OUTPUT_LINE_FOCUSED event for the given line."""
+        self._bus.publish(
+            Event(
+                event_type=EventType.OUTPUT_LINE_FOCUSED,
+                payload={
+                    "cell_id": line.cell_id,
+                    "line_number": line.line_number,
+                    "stream": line.stream,
+                    "text": line.text,
+                },
+                source=self.SOURCE,
+            )
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "asat"
-version = "0.4.0"
+version = "0.5.0"
 description = "Accessible Spatial Audio Terminal"
 requires-python = ">=3.10"
 readme = { text = "Phase 1 foundation: data models and event bus.", content-type = "text/plain" }

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,266 @@
+"""Unit tests for the contextual action catalog, menu, and defaults."""
+
+from __future__ import annotations
+
+import unittest
+
+from asat.actions import (
+    ActionCatalog,
+    ActionContext,
+    ActionMenu,
+    MemoryClipboard,
+    MenuItem,
+    default_actions,
+)
+from asat.cell import Cell
+from asat.event_bus import EventBus
+from asat.events import Event, EventType
+from asat.notebook import FocusMode, NotebookCursor
+from asat.output_buffer import OutputRecorder, STDERR, STDOUT
+from asat.output_cursor import OutputCursor
+from asat.session import Session
+
+
+class _Recorder:
+    """Captures every event on a bus so tests can assert on sequences."""
+
+    def __init__(self, bus: EventBus) -> None:
+        self.events: list[Event] = []
+        bus.subscribe("*", self.events.append)
+
+    def of(self, event_type: EventType) -> list[Event]:
+        return [e for e in self.events if e.event_type == event_type]
+
+
+def _noop_handler(_context: ActionContext) -> None:
+    """Sentinel handler used to verify plumbing without side effects."""
+
+
+class ActionCatalogTests(unittest.TestCase):
+
+    def test_providers_contribute_items_in_registration_order(self) -> None:
+        catalog = ActionCatalog()
+        catalog.register(
+            FocusMode.NOTEBOOK,
+            lambda ctx: (MenuItem(id="a", label="A", handler=_noop_handler),),
+        )
+        catalog.register(
+            FocusMode.NOTEBOOK,
+            lambda ctx: (MenuItem(id="b", label="B", handler=_noop_handler),),
+        )
+        context = ActionContext(focus_mode=FocusMode.NOTEBOOK)
+        items = catalog.items_for(context)
+        self.assertEqual([item.id for item in items], ["a", "b"])
+
+    def test_unknown_mode_returns_empty(self) -> None:
+        catalog = ActionCatalog()
+        context = ActionContext(focus_mode=FocusMode.OUTPUT)
+        self.assertEqual(catalog.items_for(context), ())
+
+
+class ActionMenuTests(unittest.TestCase):
+
+    def _menu_with(self, items: list[MenuItem]) -> tuple[ActionMenu, _Recorder, EventBus]:
+        bus = EventBus()
+        catalog = ActionCatalog()
+        catalog.register(FocusMode.NOTEBOOK, lambda ctx: tuple(items))
+        menu = ActionMenu(bus, catalog)
+        return menu, _Recorder(bus), bus
+
+    def test_open_focuses_first_item_and_publishes(self) -> None:
+        items = [
+            MenuItem(id="one", label="One", handler=_noop_handler),
+            MenuItem(id="two", label="Two", handler=_noop_handler),
+        ]
+        menu, recorder, _ = self._menu_with(items)
+        opened = menu.open(ActionContext(focus_mode=FocusMode.NOTEBOOK))
+        self.assertEqual([item.id for item in opened], ["one", "two"])
+        self.assertTrue(menu.is_open)
+        self.assertEqual(menu.current_item().id, "one")
+        open_events = recorder.of(EventType.ACTION_MENU_OPENED)
+        focus_events = recorder.of(EventType.ACTION_MENU_ITEM_FOCUSED)
+        self.assertEqual(len(open_events), 1)
+        self.assertEqual(open_events[0].payload["item_ids"], ["one", "two"])
+        self.assertEqual(len(focus_events), 1)
+        self.assertEqual(focus_events[0].payload["item_id"], "one")
+
+    def test_focus_next_walks_forward_and_clamps(self) -> None:
+        items = [
+            MenuItem(id=f"i{n}", label=str(n), handler=_noop_handler)
+            for n in range(3)
+        ]
+        menu, recorder, _ = self._menu_with(items)
+        menu.open(ActionContext(focus_mode=FocusMode.NOTEBOOK))
+        menu.focus_next()
+        self.assertEqual(menu.current_item().id, "i1")
+        menu.focus_next()
+        self.assertEqual(menu.current_item().id, "i2")
+        before = len(recorder.of(EventType.ACTION_MENU_ITEM_FOCUSED))
+        menu.focus_next()
+        self.assertEqual(menu.current_item().id, "i2")
+        self.assertEqual(
+            len(recorder.of(EventType.ACTION_MENU_ITEM_FOCUSED)),
+            before,
+        )
+
+    def test_activate_calls_handler_and_closes_menu(self) -> None:
+        received: list[ActionContext] = []
+
+        def capture(context: ActionContext) -> None:
+            received.append(context)
+
+        items = [MenuItem(id="a", label="A", handler=capture)]
+        menu, recorder, _ = self._menu_with(items)
+        context = ActionContext(
+            focus_mode=FocusMode.NOTEBOOK, cell_id="cell-42"
+        )
+        menu.open(context)
+        activated = menu.activate()
+        assert activated is not None
+        self.assertEqual(activated.id, "a")
+        self.assertFalse(menu.is_open)
+        self.assertEqual(received, [context])
+        self.assertEqual(len(recorder.of(EventType.ACTION_MENU_ITEM_INVOKED)), 1)
+        self.assertEqual(len(recorder.of(EventType.ACTION_MENU_CLOSED)), 1)
+
+    def test_close_without_open_is_noop(self) -> None:
+        menu, recorder, _ = self._menu_with([])
+        menu.close()
+        self.assertEqual(recorder.of(EventType.ACTION_MENU_CLOSED), [])
+
+    def test_open_with_no_providers_emits_opened_but_stays_closed(self) -> None:
+        bus = EventBus()
+        catalog = ActionCatalog()
+        menu = ActionMenu(bus, catalog)
+        recorder = _Recorder(bus)
+        result = menu.open(ActionContext(focus_mode=FocusMode.NOTEBOOK))
+        self.assertEqual(result, ())
+        self.assertFalse(menu.is_open)
+        self.assertEqual(len(recorder.of(EventType.ACTION_MENU_OPENED)), 1)
+        self.assertEqual(recorder.of(EventType.ACTION_MENU_ITEM_FOCUSED), [])
+
+
+class DefaultActionsTests(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.bus = EventBus()
+        self.session = Session.new()
+        self.cell = Cell.new("echo hi")
+        self.session.add_cell(self.cell)
+        self.cursor = NotebookCursor(self.session, self.bus)
+        self.recorder = OutputRecorder(self.bus)
+        self.output_cursor = OutputCursor(self.bus)
+        self.clipboard = MemoryClipboard()
+        self.catalog = default_actions(
+            self.cursor,
+            self.recorder,
+            self.output_cursor,
+            self.clipboard,
+            self.bus,
+        )
+
+    def test_notebook_items_include_edit_and_explore(self) -> None:
+        context = ActionContext(
+            focus_mode=FocusMode.NOTEBOOK,
+            cell_id=self.cell.cell_id,
+        )
+        items = self.catalog.items_for(context)
+        ids = [item.id for item in items]
+        self.assertIn("enter_input", ids)
+        self.assertIn("view_output", ids)
+
+    def test_notebook_items_empty_when_no_cell(self) -> None:
+        context = ActionContext(focus_mode=FocusMode.NOTEBOOK)
+        self.assertEqual(self.catalog.items_for(context), ())
+
+    def test_view_output_handler_transitions_cursor(self) -> None:
+        self.recorder.buffer_for(self.cell.cell_id).append("line-a", STDOUT)
+        context = ActionContext(
+            focus_mode=FocusMode.NOTEBOOK,
+            cell_id=self.cell.cell_id,
+        )
+        items = self.catalog.items_for(context)
+        handler = next(item for item in items if item.id == "view_output").handler
+        handler(context)
+        self.assertEqual(self.cursor.focus.mode, FocusMode.OUTPUT)
+        self.assertEqual(self.output_cursor.line_number, 0)
+
+    def test_copy_line_uses_clipboard_and_publishes_event(self) -> None:
+        context = ActionContext(
+            focus_mode=FocusMode.OUTPUT,
+            cell_id=self.cell.cell_id,
+            line_number=2,
+            line_stream=STDOUT,
+            line_text="the line",
+        )
+        items = self.catalog.items_for(context)
+        handler = next(item for item in items if item.id == "copy_line").handler
+        handler(context)
+        self.assertEqual(self.clipboard.text, "the line")
+
+    def test_copy_all_joins_every_stream(self) -> None:
+        buffer = self.recorder.buffer_for(self.cell.cell_id)
+        buffer.append("alpha", STDOUT)
+        buffer.append("beta", STDERR)
+        buffer.append("gamma", STDOUT)
+        context = ActionContext(
+            focus_mode=FocusMode.OUTPUT,
+            cell_id=self.cell.cell_id,
+        )
+        items = self.catalog.items_for(context)
+        handler = next(item for item in items if item.id == "copy_all").handler
+        handler(context)
+        self.assertEqual(self.clipboard.text, "alpha\nbeta\ngamma")
+
+    def test_copy_stderr_only_includes_stderr_lines(self) -> None:
+        buffer = self.recorder.buffer_for(self.cell.cell_id)
+        buffer.append("ignore", STDOUT)
+        buffer.append("oops", STDERR)
+        buffer.append("still oops", STDERR)
+        context = ActionContext(
+            focus_mode=FocusMode.OUTPUT,
+            cell_id=self.cell.cell_id,
+        )
+        items = self.catalog.items_for(context)
+        handler = next(item for item in items if item.id == "copy_stderr").handler
+        handler(context)
+        self.assertEqual(self.clipboard.text, "oops\nstill oops")
+
+    def test_output_items_drop_copy_line_without_focused_line(self) -> None:
+        context = ActionContext(
+            focus_mode=FocusMode.OUTPUT,
+            cell_id=self.cell.cell_id,
+        )
+        items = self.catalog.items_for(context)
+        self.assertNotIn("copy_line", [item.id for item in items])
+        self.assertIn("exit_output", [item.id for item in items])
+
+    def test_exit_output_handler_returns_to_notebook(self) -> None:
+        self.cursor.view_output_mode()
+        context = ActionContext(
+            focus_mode=FocusMode.OUTPUT,
+            cell_id=self.cell.cell_id,
+        )
+        items = self.catalog.items_for(context)
+        handler = next(item for item in items if item.id == "exit_output").handler
+        handler(context)
+        self.assertEqual(self.cursor.focus.mode, FocusMode.NOTEBOOK)
+
+    def test_clipboard_copied_event_describes_source(self) -> None:
+        events = _Recorder(self.bus)
+        context = ActionContext(
+            focus_mode=FocusMode.OUTPUT,
+            cell_id=self.cell.cell_id,
+            line_text="hey",
+        )
+        items = self.catalog.items_for(context)
+        handler = next(item for item in items if item.id == "copy_line").handler
+        handler(context)
+        copied = events.of(EventType.CLIPBOARD_COPIED)
+        self.assertEqual(len(copied), 1)
+        self.assertEqual(copied[0].payload["source"], "line")
+        self.assertEqual(copied[0].payload["length"], 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_input_router.py
+++ b/tests/test_input_router.py
@@ -8,8 +8,22 @@ from asat.cell import Cell
 from asat.event_bus import EventBus
 from asat.events import Event, EventType
 from asat.input_router import InputRouter, default_bindings
-from asat.keys import BACKSPACE, DOWN, ENTER, ESCAPE, HOME, Key, Modifier, UP
+from asat.keys import (
+    BACKSPACE,
+    DOWN,
+    END,
+    ENTER,
+    ESCAPE,
+    HOME,
+    Key,
+    Modifier,
+    PAGE_DOWN,
+    PAGE_UP,
+    UP,
+)
 from asat.notebook import FocusMode, NotebookCursor
+from asat.output_buffer import OutputBuffer, STDOUT
+from asat.output_cursor import OutputCursor
 from asat.session import Session
 
 
@@ -159,6 +173,79 @@ class ActionEventPayloadTests(unittest.TestCase):
         actions = recorder.types_of(EventType.ACTION_INVOKED)
         self.assertEqual(actions[0].payload["action"], "move_down")
         self.assertEqual(actions[0].payload["focus_mode"], FocusMode.NOTEBOOK.value)
+
+
+class OutputModeDispatchTests(unittest.TestCase):
+
+    def _stack(
+        self,
+        lines: list[str],
+    ) -> tuple[NotebookCursor, InputRouter, OutputCursor, OutputBuffer]:
+        bus = EventBus()
+        session = Session.new()
+        cell = Cell.new("echo")
+        session.add_cell(cell)
+        cursor = NotebookCursor(session, bus)
+        output_cursor = OutputCursor(bus, page_size=2)
+        buffer = OutputBuffer(cell_id=cell.cell_id)
+        for text in lines:
+            buffer.append(text, stream=STDOUT)
+        output_cursor.attach(buffer)
+        cursor.view_output_mode()
+        router = InputRouter(cursor, bus, output_cursor=output_cursor)
+        return cursor, router, output_cursor, buffer
+
+    def test_up_moves_output_cursor_up(self) -> None:
+        _, router, output_cursor, _ = self._stack(["a", "b", "c"])
+        result = router.handle_key(UP)
+        self.assertEqual(result, "output_line_up")
+        self.assertEqual(output_cursor.line_number, 1)
+
+    def test_down_moves_output_cursor_down(self) -> None:
+        _, router, output_cursor, _ = self._stack(["a", "b", "c"])
+        output_cursor.move_to_start()
+        self.assertEqual(router.handle_key(DOWN), "output_line_down")
+        self.assertEqual(output_cursor.line_number, 1)
+
+    def test_page_up_and_page_down_use_page_size(self) -> None:
+        _, router, output_cursor, _ = self._stack(["a", "b", "c", "d", "e"])
+        router.handle_key(PAGE_UP)
+        self.assertEqual(output_cursor.line_number, 2)
+        router.handle_key(PAGE_DOWN)
+        self.assertEqual(output_cursor.line_number, 4)
+
+    def test_home_and_end_jump_to_ends(self) -> None:
+        _, router, output_cursor, _ = self._stack(["a", "b", "c"])
+        router.handle_key(HOME)
+        self.assertEqual(output_cursor.line_number, 0)
+        router.handle_key(END)
+        self.assertEqual(output_cursor.line_number, 2)
+
+    def test_escape_exits_output_mode(self) -> None:
+        cursor, router, _, _ = self._stack(["a"])
+        self.assertEqual(router.handle_key(ESCAPE), "exit_output")
+        self.assertEqual(cursor.focus.mode, FocusMode.NOTEBOOK)
+
+    def test_output_actions_noop_without_output_cursor(self) -> None:
+        bus = EventBus()
+        session = Session.new()
+        cell = Cell.new("echo")
+        session.add_cell(cell)
+        cursor = NotebookCursor(session, bus)
+        cursor.view_output_mode()
+        router = InputRouter(cursor, bus)
+        self.assertEqual(router.handle_key(UP), "output_line_up")
+
+    def test_ctrl_o_enters_output_mode_from_notebook(self) -> None:
+        bus = EventBus()
+        session = Session.new()
+        cell = Cell.new("echo")
+        session.add_cell(cell)
+        cursor = NotebookCursor(session, bus)
+        router = InputRouter(cursor, bus)
+        result = router.handle_key(Key.combo("o", Modifier.CTRL))
+        self.assertEqual(result, "view_output")
+        self.assertEqual(cursor.focus.mode, FocusMode.OUTPUT)
 
 
 class CustomBindingTests(unittest.TestCase):

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -159,5 +159,39 @@ class CursorInputModeTests(unittest.TestCase):
         self.assertEqual(len(self.session), 2)
 
 
+class CursorOutputModeTests(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.bus = EventBus()
+        self.recorder = _Recorder(self.bus)
+        self.session, self.cells = _session_with(["echo out"])
+        self.cursor = NotebookCursor(self.session, self.bus)
+
+    def test_view_output_mode_transitions(self) -> None:
+        result = self.cursor.view_output_mode()
+        assert result is not None
+        self.assertEqual(self.cursor.focus.mode, FocusMode.OUTPUT)
+        self.assertEqual(self.cursor.focus.cell_id, self.cells[0].cell_id)
+        self.assertEqual(len(self.recorder.events), 1)
+
+    def test_view_output_from_input_mode_is_noop(self) -> None:
+        self.cursor.enter_input_mode()
+        self.recorder.events.clear()
+        self.assertIsNone(self.cursor.view_output_mode())
+        self.assertEqual(self.cursor.focus.mode, FocusMode.INPUT)
+        self.assertEqual(self.recorder.events, [])
+
+    def test_exit_output_returns_to_notebook(self) -> None:
+        self.cursor.view_output_mode()
+        self.recorder.events.clear()
+        self.cursor.exit_output_mode()
+        self.assertEqual(self.cursor.focus.mode, FocusMode.NOTEBOOK)
+        self.assertEqual(len(self.recorder.events), 1)
+
+    def test_exit_output_from_notebook_is_noop(self) -> None:
+        self.assertIsNone(self.cursor.exit_output_mode())
+        self.assertEqual(self.cursor.focus.mode, FocusMode.NOTEBOOK)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_output_buffer.py
+++ b/tests/test_output_buffer.py
@@ -1,0 +1,159 @@
+"""Unit tests for OutputBuffer and OutputRecorder."""
+
+from __future__ import annotations
+
+import unittest
+
+from asat.event_bus import EventBus
+from asat.events import Event, EventType
+from asat.output_buffer import (
+    OutputBuffer,
+    OutputLine,
+    OutputRecorder,
+    STDERR,
+    STDOUT,
+)
+
+
+class _Recorder:
+    """Collects every event on a bus for assertions."""
+
+    def __init__(self, bus: EventBus) -> None:
+        self.events: list[Event] = []
+        bus.subscribe("*", self.events.append)
+
+    def of(self, event_type: EventType) -> list[Event]:
+        return [e for e in self.events if e.event_type == event_type]
+
+
+class OutputBufferTests(unittest.TestCase):
+
+    def test_append_returns_numbered_line(self) -> None:
+        buffer = OutputBuffer(cell_id="c1")
+        line = buffer.append("hello")
+        self.assertIsInstance(line, OutputLine)
+        self.assertEqual(line.cell_id, "c1")
+        self.assertEqual(line.line_number, 0)
+        self.assertEqual(line.stream, STDOUT)
+        self.assertEqual(line.text, "hello")
+
+    def test_append_numbers_increment(self) -> None:
+        buffer = OutputBuffer(cell_id="c1")
+        for text in ["a", "b", "c"]:
+            buffer.append(text)
+        self.assertEqual(len(buffer), 3)
+        numbers = [line.line_number for line in buffer]
+        self.assertEqual(numbers, [0, 1, 2])
+
+    def test_append_to_unknown_stream_raises(self) -> None:
+        buffer = OutputBuffer(cell_id="c1")
+        with self.assertRaises(ValueError):
+            buffer.append("x", stream="log")
+
+    def test_line_out_of_range_raises(self) -> None:
+        buffer = OutputBuffer(cell_id="c1")
+        buffer.append("only")
+        with self.assertRaises(IndexError):
+            buffer.line(5)
+
+    def test_page_clamps_at_end(self) -> None:
+        buffer = OutputBuffer(cell_id="c1")
+        for text in ["one", "two", "three"]:
+            buffer.append(text)
+        page = buffer.page(start=2, size=5)
+        self.assertEqual([line.text for line in page], ["three"])
+
+    def test_page_rejects_nonpositive_size(self) -> None:
+        buffer = OutputBuffer(cell_id="c1")
+        with self.assertRaises(ValueError):
+            buffer.page(start=0, size=0)
+
+    def test_lines_on_stream_filters_by_stream(self) -> None:
+        buffer = OutputBuffer(cell_id="c1")
+        buffer.append("out-a", stream=STDOUT)
+        buffer.append("err-a", stream=STDERR)
+        buffer.append("out-b", stream=STDOUT)
+        errs = buffer.lines_on_stream(STDERR)
+        self.assertEqual([line.text for line in errs], ["err-a"])
+
+    def test_clear_drops_all_lines(self) -> None:
+        buffer = OutputBuffer(cell_id="c1")
+        buffer.append("a")
+        buffer.append("b")
+        buffer.clear()
+        self.assertEqual(len(buffer), 0)
+
+
+class OutputRecorderTests(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.bus = EventBus()
+        self.recorder = OutputRecorder(self.bus)
+        self.events = _Recorder(self.bus)
+
+    def _publish_chunk(self, event_type: EventType, cell_id: str, line: str) -> None:
+        self.bus.publish(
+            Event(
+                event_type=event_type,
+                payload={"cell_id": cell_id, "line": line},
+                source="test",
+            )
+        )
+
+    def test_output_chunk_creates_buffer_on_first_event(self) -> None:
+        self.assertFalse(self.recorder.has_buffer_for("c1"))
+        self._publish_chunk(EventType.OUTPUT_CHUNK, "c1", "hello")
+        self.assertTrue(self.recorder.has_buffer_for("c1"))
+        buffer = self.recorder.buffer_for("c1")
+        self.assertEqual(len(buffer), 1)
+        self.assertEqual(buffer.line(0).text, "hello")
+        self.assertEqual(buffer.line(0).stream, STDOUT)
+
+    def test_error_chunk_labels_line_as_stderr(self) -> None:
+        self._publish_chunk(EventType.ERROR_CHUNK, "c1", "nope")
+        buffer = self.recorder.buffer_for("c1")
+        self.assertEqual(buffer.line(0).stream, STDERR)
+
+    def test_multiple_cells_get_independent_buffers(self) -> None:
+        self._publish_chunk(EventType.OUTPUT_CHUNK, "c1", "from c1")
+        self._publish_chunk(EventType.OUTPUT_CHUNK, "c2", "from c2")
+        self.assertEqual(self.recorder.buffer_for("c1").line(0).text, "from c1")
+        self.assertEqual(self.recorder.buffer_for("c2").line(0).text, "from c2")
+
+    def test_records_are_mirrored_as_output_line_appended(self) -> None:
+        self._publish_chunk(EventType.OUTPUT_CHUNK, "c1", "first")
+        self._publish_chunk(EventType.ERROR_CHUNK, "c1", "second")
+        appended = self.events.of(EventType.OUTPUT_LINE_APPENDED)
+        self.assertEqual(len(appended), 2)
+        self.assertEqual(appended[0].payload["line_number"], 0)
+        self.assertEqual(appended[0].payload["stream"], STDOUT)
+        self.assertEqual(appended[1].payload["line_number"], 1)
+        self.assertEqual(appended[1].payload["stream"], STDERR)
+
+    def test_malformed_events_are_ignored(self) -> None:
+        self.bus.publish(
+            Event(
+                event_type=EventType.OUTPUT_CHUNK,
+                payload={"cell_id": None, "line": "skip"},
+                source="test",
+            )
+        )
+        self.bus.publish(
+            Event(
+                event_type=EventType.OUTPUT_CHUNK,
+                payload={"cell_id": "c1"},
+                source="test",
+            )
+        )
+        self.assertFalse(self.recorder.has_buffer_for("c1"))
+        self.assertEqual(self.events.of(EventType.OUTPUT_LINE_APPENDED), [])
+
+    def test_discard_removes_buffer(self) -> None:
+        self._publish_chunk(EventType.OUTPUT_CHUNK, "c1", "hi")
+        dropped = self.recorder.discard("c1")
+        self.assertIsNotNone(dropped)
+        self.assertFalse(self.recorder.has_buffer_for("c1"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_output_cursor.py
+++ b/tests/test_output_cursor.py
@@ -1,0 +1,150 @@
+"""Unit tests for OutputCursor."""
+
+from __future__ import annotations
+
+import unittest
+
+from asat.event_bus import EventBus
+from asat.events import Event, EventType
+from asat.output_buffer import OutputBuffer, STDERR, STDOUT
+from asat.output_cursor import OutputCursor
+
+
+class _Recorder:
+    """Collects FOCUS events fired by the cursor for assertions."""
+
+    def __init__(self, bus: EventBus) -> None:
+        self.events: list[Event] = []
+        bus.subscribe(EventType.OUTPUT_LINE_FOCUSED, self.events.append)
+
+
+def _buffer_with(cell_id: str, lines: list[tuple[str, str]]) -> OutputBuffer:
+    """Create a buffer pre-populated with (text, stream) entries."""
+    buffer = OutputBuffer(cell_id=cell_id)
+    for text, stream in lines:
+        buffer.append(text, stream=stream)
+    return buffer
+
+
+class AttachAndNavigateTests(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.bus = EventBus()
+        self.recorder = _Recorder(self.bus)
+        self.cursor = OutputCursor(self.bus, page_size=3)
+        self.buffer = _buffer_with(
+            "c1",
+            [
+                ("one", STDOUT),
+                ("two", STDOUT),
+                ("three", STDERR),
+                ("four", STDOUT),
+                ("five", STDOUT),
+            ],
+        )
+
+    def test_attach_snaps_to_last_line(self) -> None:
+        line = self.cursor.attach(self.buffer)
+        assert line is not None
+        self.assertEqual(line.text, "five")
+        self.assertEqual(self.cursor.line_number, 4)
+        self.assertEqual(len(self.recorder.events), 1)
+
+    def test_attach_on_empty_buffer_returns_none(self) -> None:
+        empty = OutputBuffer(cell_id="empty")
+        result = self.cursor.attach(empty)
+        self.assertIsNone(result)
+        self.assertIsNone(self.cursor.line_number)
+        self.assertEqual(self.recorder.events, [])
+
+    def test_move_line_up_walks_toward_start(self) -> None:
+        self.cursor.attach(self.buffer)
+        self.cursor.move_line_up()
+        self.cursor.move_line_up()
+        self.assertEqual(self.cursor.line_number, 2)
+        self.assertEqual(self.cursor.current_line().text, "three")
+
+    def test_move_line_up_clamps_at_top(self) -> None:
+        self.cursor.attach(self.buffer)
+        self.cursor.move_to_start()
+        self.recorder.events.clear()
+        result = self.cursor.move_line_up()
+        assert result is not None
+        self.assertEqual(result.line_number, 0)
+        self.assertEqual(self.recorder.events, [])
+
+    def test_move_line_down_clamps_at_bottom(self) -> None:
+        self.cursor.attach(self.buffer)
+        self.recorder.events.clear()
+        result = self.cursor.move_line_down()
+        assert result is not None
+        self.assertEqual(result.line_number, 4)
+        self.assertEqual(self.recorder.events, [])
+
+    def test_page_up_jumps_by_page_size(self) -> None:
+        self.cursor.attach(self.buffer)
+        self.cursor.move_page_up()
+        self.assertEqual(self.cursor.line_number, 1)
+
+    def test_page_down_clamps_within_buffer(self) -> None:
+        self.cursor.attach(self.buffer)
+        self.cursor.move_to_start()
+        self.cursor.move_page_down()
+        self.assertEqual(self.cursor.line_number, 3)
+        self.cursor.move_page_down()
+        self.assertEqual(self.cursor.line_number, 4)
+
+    def test_move_to_start_and_end(self) -> None:
+        self.cursor.attach(self.buffer)
+        self.cursor.move_to_start()
+        self.assertEqual(self.cursor.line_number, 0)
+        self.cursor.move_to_end()
+        self.assertEqual(self.cursor.line_number, 4)
+
+
+class DetachedCursorTests(unittest.TestCase):
+
+    def test_detached_cursor_ignores_motion(self) -> None:
+        bus = EventBus()
+        cursor = OutputCursor(bus)
+        self.assertIsNone(cursor.move_line_up())
+        self.assertIsNone(cursor.move_line_down())
+        self.assertIsNone(cursor.move_to_start())
+        self.assertIsNone(cursor.current_line())
+
+    def test_detach_clears_state(self) -> None:
+        bus = EventBus()
+        cursor = OutputCursor(bus)
+        buffer = _buffer_with("c1", [("a", STDOUT)])
+        cursor.attach(buffer)
+        cursor.detach()
+        self.assertIsNone(cursor.buffer)
+        self.assertIsNone(cursor.line_number)
+
+    def test_invalid_page_size_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            OutputCursor(EventBus(), page_size=0)
+
+
+class FocusEventTests(unittest.TestCase):
+
+    def test_focus_event_contains_line_metadata(self) -> None:
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        cursor = OutputCursor(bus)
+        buffer = _buffer_with(
+            "c1",
+            [("first", STDOUT), ("second", STDERR)],
+        )
+        cursor.attach(buffer)
+        cursor.move_line_up()
+        payloads = [event.payload for event in recorder.events]
+        self.assertEqual(payloads[0]["line_number"], 1)
+        self.assertEqual(payloads[0]["stream"], STDERR)
+        self.assertEqual(payloads[1]["line_number"], 0)
+        self.assertEqual(payloads[1]["stream"], STDOUT)
+        self.assertEqual(payloads[1]["text"], "first")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Phase 5 adds the pieces a blind user needs to revisit and act on a cell's output without ever seeing the screen. It introduces four new modules and extends two.

**New modules**

- `asat/output_buffer.py` — `OutputLine`, `OutputBuffer`, `OutputRecorder`. The recorder subscribes to `OUTPUT_CHUNK` / `ERROR_CHUNK` events and maintains a per-cell buffer of numbered lines tagged by stream. It republishes each append as an enriched `OUTPUT_LINE_APPENDED` event.
- `asat/output_cursor.py` — `OutputCursor` walks the lines of a single `OutputBuffer`. Supports line-by-line motion, configurable page jumps, and home/end. Publishes `OUTPUT_LINE_FOCUSED` so the audio engine can voice the focused line.
- `asat/actions.py` — `ActionContext`, `MenuItem`, `ActionCatalog`, `ActionMenu`, and the `Clipboard` protocol plus a `MemoryClipboard` impl. `default_actions(...)` wires up the built-in providers: NOTEBOOK (edit command, explore output), INPUT (submit, cancel editing), OUTPUT (copy focused line, copy all, copy stderr only, return to notebook). Copies route through `Clipboard` and publish `CLIPBOARD_COPIED`.

**Extensions**

- `asat/notebook.py` — `NotebookCursor.view_output_mode()` and `exit_output_mode()` transitions between NOTEBOOK and OUTPUT.
- `asat/input_router.py` — OUTPUT-mode bindings (Up/Down, PageUp/PageDown, Home/End, Escape) routed to an optional `OutputCursor`; Ctrl+O in NOTEBOOK opens the output view.
- `asat/events.py` — new `EventType` members: `OUTPUT_LINE_APPENDED`, `OUTPUT_LINE_FOCUSED`, `ACTION_MENU_OPENED`/`CLOSED`/`ITEM_FOCUSED`/`ITEM_INVOKED`, `CLIPBOARD_COPIED`.

**Tests**

53 new unit tests across `test_output_buffer.py`, `test_output_cursor.py`, `test_actions.py`, plus OUTPUT-mode coverage added to `test_notebook.py` and `test_input_router.py`. Full suite: **217 passing** (≈0.65 s), all stdlib.

## Test plan

- [x] `python -m unittest discover -s tests -t .` — 217 tests pass
- [x] No external deps introduced; stdlib only
- [x] `__init__.py` re-exports the new public surface; version bumped to 0.5.0
- [ ] Review that binding layout (Up/Down vs PageUp/PageDown in OUTPUT mode) feels right for keyboard-only use
- [ ] Review that the `default_actions` item labels will voice well through the TTS engine
