### PR TITLE
Phase 6: ANSI parsing and interactive TUI menu detection

### DIFF
--- a/asat/__init__.py
+++ b/asat/__init__.py
@@ -8,12 +8,17 @@ sinks.
 Phase 4 added the input and state router: abstract Key value type,
 NotebookCursor for non-visual navigation between cells, and an
 InputRouter that dispatches keystrokes to focus-aware actions.
-Phase 5 adds output parsing and the contextual action system:
+Phase 5 added output parsing and the contextual action system:
 OutputBuffer and OutputRecorder capture streamed lines per cell,
 OutputCursor walks them line-by-line, and the ActionCatalog /
 ActionMenu pair exposes focus-driven affordances such as copying a
 line, copying stderr, or returning to the notebook.
-The ANSI interactivity layer will follow in a later phase.
+Phase 6 adds the ANSI / interactive TUI mapping layer: an AnsiParser
+tokenizes raw program output, VirtualScreen replays the tokens onto a
+grid, the interactive-menu detector extracts a structured menu model
+from the grid, and TuiBridge glues them together so a live TUI stream
+emits INTERACTIVE_MENU_DETECTED / UPDATED / CLEARED events that the
+audio engine can voice natively.
 """
 
 from asat.actions import (
@@ -24,6 +29,15 @@ from asat.actions import (
     MemoryClipboard,
     MenuItem,
     default_actions,
+)
+from asat.ansi import (
+    AnsiParser,
+    CSIToken,
+    ControlToken,
+    EscapeToken,
+    OSCToken,
+    TextToken,
+    Token,
 )
 from asat.audio import (
     AudioBuffer,
@@ -41,27 +55,34 @@ from asat.events import Event, EventType
 from asat.execution import ExecutionMode, ExecutionRequest, ExecutionResult
 from asat.hrtf import HRTFProfile, Spatializer, convolve
 from asat.input_router import BindingMap, InputRouter, default_bindings
+from asat.interactive import InteractiveMenu, MenuItemView, detect
 from asat.kernel import ExecutionKernel
 from asat.keys import Key, Modifier
 from asat.notebook import FocusMode, FocusState, NotebookCursor
 from asat.output_buffer import OutputBuffer, OutputLine, OutputRecorder
 from asat.output_cursor import OutputCursor
 from asat.runner import ProcessRunner
+from asat.screen import Cell as ScreenCell, ScreenSnapshot, VirtualScreen
 from asat.session import Session
 from asat.tts import ToneTTSEngine, TTSEngine
+from asat.tui_bridge import TuiBridge
 
 __all__ = [
     "ActionCatalog",
     "ActionContext",
     "ActionMenu",
+    "AnsiParser",
     "AudioBuffer",
     "AudioSink",
     "BindingMap",
+    "CSIToken",
     "Cell",
     "CellStatus",
     "ChannelLayout",
     "Clipboard",
+    "ControlToken",
     "DEFAULT_SAMPLE_RATE",
+    "EscapeToken",
     "Event",
     "EventBus",
     "EventType",
@@ -73,23 +94,32 @@ __all__ = [
     "FocusState",
     "HRTFProfile",
     "InputRouter",
+    "InteractiveMenu",
     "Key",
     "MemoryClipboard",
     "MemorySink",
     "MenuItem",
+    "MenuItemView",
     "Modifier",
     "NotebookCursor",
+    "OSCToken",
     "OutputBuffer",
     "OutputCursor",
     "OutputLine",
     "OutputRecorder",
     "ProcessRunner",
+    "ScreenCell",
+    "ScreenSnapshot",
     "Session",
     "SpatialAudioEngine",
     "SpatialPosition",
     "Spatializer",
     "TTSEngine",
+    "TextToken",
+    "Token",
     "ToneTTSEngine",
+    "TuiBridge",
+    "VirtualScreen",
     "VoicePreset",
     "VoiceProfile",
     "VoiceRouter",
@@ -97,7 +127,8 @@ __all__ = [
     "convolve",
     "default_actions",
     "default_bindings",
+    "detect",
     "write_wav",
 ]
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/asat/ansi.py
+++ b/asat/ansi.py
@@ -1,0 +1,240 @@
+"""ANSI escape sequence tokenizer.
+
+Real terminal programs speak a mix of plain text and escape sequences
+controlling cursor position, colours, and screen clears. Before ASAT
+can make a TUI accessible it has to understand that stream. This
+module turns a raw string into a list of Tokens that later stages
+(the virtual screen, the interactive menu detector) can consume
+without re-parsing bytes.
+
+The parser only tokenizes. It does not interpret. All semantics (what
+a cursor-up command does, which SGR parameter toggles reverse video)
+live in screen.py so this module can be exercised in isolation.
+
+Supported sequences:
+
+    CSI (Control Sequence Introducer): ESC [ params final
+        where params is digits separated by ';', optionally preceded
+        by an intermediate private marker byte like '?'. The final
+        byte is a single letter. SGR sequences (final 'm') are the
+        most common. Cursor moves use letters A-H, J, K, etc.
+
+    OSC (Operating System Command): ESC ] body ST
+        The terminator ST can be BEL (0x07) or ESC \\. The body is
+        captured as opaque text. OSC is mostly used for window titles
+        and hyperlinks which we tokenize but ignore downstream.
+
+    ESC <char>: a bare escape followed by one byte that is not '[' or
+        ']'. Produces an EscapeToken. Covers things like ESC 7 (save
+        cursor) that we may want to match on later.
+
+    Text: any run of bytes that is not ESC, LF, CR, TAB, or BS.
+
+    Control: LF (\\n), CR (\\r), TAB (\\t), BS (\\b), BEL (\\a).
+
+Incomplete sequences at the end of a feed are held until the next
+feed call, so chunk boundaries never corrupt tokenization.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+ESC = "\x1b"
+BEL = "\x07"
+BACKSPACE_CHAR = "\x08"
+CR = "\r"
+LF = "\n"
+TAB = "\t"
+
+CONTROL_CHARS = {LF, CR, TAB, BACKSPACE_CHAR, BEL}
+
+
+@dataclass(frozen=True)
+class TextToken:
+    """A run of printable characters with no control bytes."""
+
+    text: str
+
+
+@dataclass(frozen=True)
+class ControlToken:
+    """A single control character such as CR, LF, TAB, BS, or BEL."""
+
+    char: str
+
+
+@dataclass(frozen=True)
+class CSIToken:
+    """A parsed CSI escape sequence.
+
+    params: the decoded parameter list (integers). A missing parameter
+        is represented as -1 so callers can apply per-command defaults.
+    private: the private marker byte if present (e.g. '?'), else None.
+    final: the single final byte that identifies the command.
+    raw: the exact source substring, useful for logging.
+    """
+
+    params: tuple[int, ...]
+    private: Optional[str]
+    final: str
+    raw: str
+
+
+@dataclass(frozen=True)
+class OSCToken:
+    """An Operating System Command payload."""
+
+    body: str
+    raw: str
+
+
+@dataclass(frozen=True)
+class EscapeToken:
+    """A bare ESC followed by a single command byte."""
+
+    char: str
+    raw: str
+
+
+Token = TextToken | ControlToken | CSIToken | OSCToken | EscapeToken
+
+
+@dataclass
+class AnsiParser:
+    """Stateful ANSI tokenizer that tolerates split sequences across feeds.
+
+    Holds any partial escape sequence left at the end of a feed and
+    prepends it to the next chunk. feed() returns the list of tokens
+    recognized so far. Calling finish() flushes any buffered plain
+    text as a TextToken and returns residual ESC state as-is.
+    """
+
+    _carry: str = field(default="")
+
+    def feed(self, data: str) -> list[Token]:
+        """Consume more input and return newly produced tokens."""
+        text = self._carry + data
+        self._carry = ""
+        tokens: list[Token] = []
+        index = 0
+        length = len(text)
+        while index < length:
+            char = text[index]
+            if char == ESC:
+                consumed, token = self._try_parse_escape(text, index)
+                if consumed == 0:
+                    self._carry = text[index:]
+                    return tokens
+                if token is not None:
+                    tokens.append(token)
+                index += consumed
+                continue
+            if char in CONTROL_CHARS:
+                tokens.append(ControlToken(char=char))
+                index += 1
+                continue
+            end = index
+            while end < length and text[end] != ESC and text[end] not in CONTROL_CHARS:
+                end += 1
+            tokens.append(TextToken(text=text[index:end]))
+            index = end
+        return tokens
+
+    def finish(self) -> list[Token]:
+        """Flush buffered plain text as a token; drop residual partial ESC."""
+        if not self._carry:
+            return []
+        leftover = self._carry
+        self._carry = ""
+        if leftover.startswith(ESC):
+            return []
+        return [TextToken(text=leftover)]
+
+    def _try_parse_escape(
+        self,
+        text: str,
+        start: int,
+    ) -> tuple[int, Optional[Token]]:
+        """Attempt to parse an escape sequence beginning at start.
+
+        Returns (consumed_chars, token). If consumed_chars == 0 the
+        sequence is incomplete and the caller should buffer it.
+        """
+        length = len(text)
+        if start + 1 >= length:
+            return 0, None
+        second = text[start + 1]
+        if second == "[":
+            return self._parse_csi(text, start)
+        if second == "]":
+            return self._parse_osc(text, start)
+        return 2, EscapeToken(char=second, raw=text[start:start + 2])
+
+    def _parse_csi(
+        self,
+        text: str,
+        start: int,
+    ) -> tuple[int, Optional[Token]]:
+        """Parse ESC [ params final, returning the CSI token or incomplete."""
+        index = start + 2
+        length = len(text)
+        private: Optional[str] = None
+        if index < length and text[index] in "?><!":
+            private = text[index]
+            index += 1
+        param_start = index
+        while index < length and (text[index].isdigit() or text[index] == ";"):
+            index += 1
+        if index >= length:
+            return 0, None
+        final = text[index]
+        if not ("A" <= final <= "Z" or "a" <= final <= "z"):
+            return 0, None
+        raw = text[start:index + 1]
+        params = _parse_params(text[param_start:index])
+        return index + 1 - start, CSIToken(
+            params=params,
+            private=private,
+            final=final,
+            raw=raw,
+        )
+
+    def _parse_osc(
+        self,
+        text: str,
+        start: int,
+    ) -> tuple[int, Optional[Token]]:
+        """Parse ESC ] body ST. ST may be BEL or ESC \\."""
+        body_start = start + 2
+        length = len(text)
+        index = body_start
+        while index < length:
+            if text[index] == BEL:
+                raw = text[start:index + 1]
+                body = text[body_start:index]
+                return index + 1 - start, OSCToken(body=body, raw=raw)
+            if text[index] == ESC and index + 1 < length and text[index + 1] == "\\":
+                raw = text[start:index + 2]
+                body = text[body_start:index]
+                return index + 2 - start, OSCToken(body=body, raw=raw)
+            index += 1
+        return 0, None
+
+
+def _parse_params(segment: str) -> tuple[int, ...]:
+    """Split a CSI parameter segment into integers; empty fields become -1."""
+    if not segment:
+        return ()
+    out: list[int] = []
+    for piece in segment.split(";"):
+        if piece == "":
+            out.append(-1)
+        else:
+            try:
+                out.append(int(piece))
+            except ValueError:
+                out.append(-1)
+    return tuple(out)

--- a/asat/events.py
+++ b/asat/events.py
@@ -49,6 +49,10 @@ class EventType(str, Enum):
     Clipboard:
         CLIPBOARD_COPIED
 
+    ANSI and interactive TUI mapping:
+        SCREEN_UPDATED, INTERACTIVE_MENU_DETECTED,
+        INTERACTIVE_MENU_UPDATED, INTERACTIVE_MENU_CLEARED
+
     Audio engine:
         AUDIO_SPOKEN, AUDIO_INTERRUPTED
     """
@@ -84,6 +88,11 @@ class EventType(str, Enum):
     ACTION_MENU_ITEM_INVOKED = "menu.item.invoked"
 
     CLIPBOARD_COPIED = "clipboard.copied"
+
+    SCREEN_UPDATED = "screen.updated"
+    INTERACTIVE_MENU_DETECTED = "tui.menu.detected"
+    INTERACTIVE_MENU_UPDATED = "tui.menu.updated"
+    INTERACTIVE_MENU_CLEARED = "tui.menu.cleared"
 
     AUDIO_SPOKEN = "audio.spoken"
     AUDIO_INTERRUPTED = "audio.interrupted"

--- a/asat/interactive.py
+++ b/asat/interactive.py
@@ -1,0 +1,216 @@
+"""Interactive TUI menu detection.
+
+Many CLI programs present choices as a list of lines where one line is
+highlighted (with reverse video or a leading marker like '>'). A blind
+user cannot see that highlight, so ASAT extracts the list structure
+from a VirtualScreen snapshot and exposes it as a data model the
+audio engine can voice natively.
+
+Two detection strategies are tried in order:
+
+Reverse-video strategy
+    The snapshot likely shows a menu when exactly one contiguous block
+    of rows contains at least one cell with the ATTR_REVERSE
+    attribute. That row is treated as the selected item, and the
+    contiguous non-empty rows immediately above and below it form the
+    remaining items.
+
+Prefix-marker strategy
+    If no reverse-video row is found, scan for two or more consecutive
+    non-empty rows whose first non-blank character is a common marker.
+    One row having a distinguished marker (">", "*", "->" or "=>")
+    while its neighbours use something neutral (whitespace, "-", or
+    the unselected form "[ ]") is treated as the selected item.
+
+Both strategies produce the same `InteractiveMenu` value so callers
+do not need to know which heuristic fired.
+
+Detection is intentionally conservative: when nothing looks menu-like,
+detect() returns None so downstream consumers can stay in plain-text
+mode. False positives would be worse than false negatives here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from asat.screen import ATTR_REVERSE, ScreenSnapshot
+
+
+SELECTED_MARKERS = (">", "*", "→", "▶", "●", "=>")
+UNSELECTED_MARKERS = (" ", "-", "○", "·", "[", "·")
+
+
+@dataclass(frozen=True)
+class MenuItemView:
+    """One item in a detected interactive menu."""
+
+    row: int
+    text: str
+    selected: bool
+
+
+@dataclass(frozen=True)
+class InteractiveMenu:
+    """A detected interactive menu shown on a VirtualScreen snapshot."""
+
+    items: tuple[MenuItemView, ...]
+    selected_index: int
+    detection: str
+
+    @property
+    def selected_text(self) -> str:
+        """Return the text of the currently selected item."""
+        if not self.items:
+            return ""
+        return self.items[self.selected_index].text
+
+
+def detect(snapshot: ScreenSnapshot) -> Optional[InteractiveMenu]:
+    """Return an InteractiveMenu if one can be inferred from snapshot."""
+    menu = _detect_reverse_video(snapshot)
+    if menu is not None:
+        return menu
+    return _detect_prefix_marker(snapshot)
+
+
+def _detect_reverse_video(snapshot: ScreenSnapshot) -> Optional[InteractiveMenu]:
+    """Find the row whose cells carry ATTR_REVERSE; grow items around it."""
+    reverse_rows = [
+        index
+        for index in range(len(snapshot.rows))
+        if _row_has_reverse(snapshot, index)
+    ]
+    if len(reverse_rows) != 1:
+        return None
+    selected_row = reverse_rows[0]
+    text_rows = snapshot.text_rows()
+    if not text_rows[selected_row].strip():
+        return None
+    items = _expand_contiguous_items(text_rows, selected_row)
+    if len(items) < 2:
+        return None
+    selected_index = _find_index(items, selected_row)
+    return InteractiveMenu(
+        items=items,
+        selected_index=selected_index,
+        detection="reverse_video",
+    )
+
+
+def _detect_prefix_marker(snapshot: ScreenSnapshot) -> Optional[InteractiveMenu]:
+    """Look for a pointer-style marker row among contiguous lines."""
+    text_rows = snapshot.text_rows()
+    groups = _contiguous_non_empty_groups(text_rows)
+    for group_start, group_end in groups:
+        selected_row = _find_marker_row(text_rows, group_start, group_end)
+        if selected_row is None:
+            continue
+        items = tuple(
+            MenuItemView(
+                row=row,
+                text=text_rows[row],
+                selected=row == selected_row,
+            )
+            for row in range(group_start, group_end + 1)
+        )
+        selected_index = _find_index(items, selected_row)
+        if len(items) < 2:
+            continue
+        return InteractiveMenu(
+            items=items,
+            selected_index=selected_index,
+            detection="prefix_marker",
+        )
+    return None
+
+
+def _row_has_reverse(snapshot: ScreenSnapshot, row_index: int) -> bool:
+    """Return True if any non-blank cell on the row has ATTR_REVERSE."""
+    for cell in snapshot.rows[row_index]:
+        if ATTR_REVERSE in cell.attrs and cell.char != " ":
+            return True
+    return False
+
+
+def _expand_contiguous_items(
+    text_rows: tuple[str, ...],
+    selected_row: int,
+) -> tuple[MenuItemView, ...]:
+    """Collect contiguous non-empty rows around selected_row as items."""
+    start = selected_row
+    while start - 1 >= 0 and text_rows[start - 1].strip():
+        start -= 1
+    end = selected_row
+    while end + 1 < len(text_rows) and text_rows[end + 1].strip():
+        end += 1
+    return tuple(
+        MenuItemView(
+            row=row,
+            text=text_rows[row],
+            selected=row == selected_row,
+        )
+        for row in range(start, end + 1)
+    )
+
+
+def _contiguous_non_empty_groups(
+    text_rows: tuple[str, ...],
+) -> list[tuple[int, int]]:
+    """Return (start, end) index pairs for runs of non-empty rows."""
+    groups: list[tuple[int, int]] = []
+    start: Optional[int] = None
+    for index, row in enumerate(text_rows):
+        if row.strip():
+            if start is None:
+                start = index
+        else:
+            if start is not None:
+                groups.append((start, index - 1))
+                start = None
+    if start is not None:
+        groups.append((start, len(text_rows) - 1))
+    return groups
+
+
+def _find_marker_row(
+    text_rows: tuple[str, ...],
+    group_start: int,
+    group_end: int,
+) -> Optional[int]:
+    """Pick the row in [start, end] that starts with a selection marker.
+
+    Only one row in the group may carry a selection marker; otherwise
+    we consider the group ambiguous and return None.
+    """
+    candidates = [
+        row
+        for row in range(group_start, group_end + 1)
+        if _starts_with_selected_marker(text_rows[row])
+    ]
+    if len(candidates) != 1:
+        return None
+    return candidates[0]
+
+
+def _starts_with_selected_marker(row: str) -> bool:
+    """Return True if the row's first non-blank token looks selected."""
+    trimmed = row.lstrip()
+    if not trimmed:
+        return False
+    for marker in SELECTED_MARKERS:
+        if trimmed.startswith(marker):
+            return True
+    return False
+
+
+def _find_index(
+    items: tuple[MenuItemView, ...],
+    row: int,
+) -> int:
+    """Return the index of the item whose source row matches."""
+    for index, item in enumerate(items):
+        if item.row == row:
+            return index
+    return 0

--- a/asat/screen.py
+++ b/asat/screen.py
@@ -1,0 +1,312 @@
+"""VirtualScreen: applies ANSI tokens to a 2D cell grid.
+
+A TUI draws by sending a sequence of ANSI tokens: move the cursor,
+write a character, set a colour attribute, clear a line, repeat. To
+reason about what the user is seeing we need to replay that sequence
+into a grid that remembers the resulting cells. VirtualScreen is that
+grid.
+
+It is deliberately small: it handles the tokens most commonly used by
+interactive menus and progress bars, and ignores the rest. In
+particular it implements:
+
+    Plain text output (advances cursor, wraps at right margin).
+    CR / LF (\\r moves to column 0; \\n moves down one row).
+    BS (\\b moves cursor left).
+    CUU / CUD / CUF / CUB (ESC [ n A/B/C/D) cursor moves.
+    CUP (ESC [ r;c H or ESC [ r;c f) absolute cursor position.
+    ED  (ESC [ n J) erase in display, modes 0/1/2.
+    EL  (ESC [ n K) erase in line, modes 0/1/2.
+    SGR (ESC [ ... m) for reverse video and the common bold/bright
+        attributes that menu detectors look for. Unknown SGR
+        parameters are tracked verbatim so downstream heuristics can
+        key on them without losing information.
+
+Cursor positions are stored zero-based internally; ANSI addresses
+them one-based, which is handled in the CSI handlers.
+
+VirtualScreen exposes a snapshot() method that returns an immutable
+ScreenSnapshot: text per row (with trailing spaces trimmed), the
+attribute set for each cell on each row, and the cursor position.
+The menu detector operates on snapshots so it never shares mutable
+state with the screen.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from asat.ansi import (
+    CSIToken,
+    ControlToken,
+    EscapeToken,
+    OSCToken,
+    TextToken,
+    Token,
+)
+
+
+DEFAULT_COLS = 80
+DEFAULT_ROWS = 24
+
+ATTR_REVERSE = "reverse"
+ATTR_BOLD = "bold"
+ATTR_UNDERLINE = "underline"
+ATTR_DIM = "dim"
+
+
+@dataclass(frozen=True)
+class Cell:
+    """One character cell on the virtual screen."""
+
+    char: str = " "
+    attrs: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
+class ScreenSnapshot:
+    """Immutable view of the virtual screen at a point in time."""
+
+    rows: tuple[tuple[Cell, ...], ...]
+    cursor_row: int
+    cursor_col: int
+    cols: int
+
+    def text_rows(self) -> tuple[str, ...]:
+        """Return each row as a string with trailing spaces trimmed."""
+        return tuple("".join(cell.char for cell in row).rstrip() for row in self.rows)
+
+    def row_attrs(self, row_index: int) -> tuple[frozenset[str], ...]:
+        """Return the per-cell attribute set for the given row."""
+        return tuple(cell.attrs for cell in self.rows[row_index])
+
+
+@dataclass
+class VirtualScreen:
+    """Mutable 2D grid updated by applying ANSI tokens."""
+
+    rows: int = DEFAULT_ROWS
+    cols: int = DEFAULT_COLS
+    _grid: list[list[Cell]] = field(default_factory=list)
+    _cursor_row: int = 0
+    _cursor_col: int = 0
+    _attrs: frozenset[str] = field(default_factory=frozenset)
+
+    def __post_init__(self) -> None:
+        """Allocate a fresh blank grid if one was not provided."""
+        if not self._grid:
+            self._grid = [self._blank_row() for _ in range(self.rows)]
+
+    @property
+    def cursor(self) -> tuple[int, int]:
+        """Return (row, col) of the current cursor position."""
+        return self._cursor_row, self._cursor_col
+
+    def apply(self, token: Token) -> None:
+        """Mutate the screen by applying a single token."""
+        if isinstance(token, TextToken):
+            self._write_text(token.text)
+        elif isinstance(token, ControlToken):
+            self._apply_control(token.char)
+        elif isinstance(token, CSIToken):
+            self._apply_csi(token)
+        elif isinstance(token, EscapeToken):
+            self._apply_escape(token)
+        elif isinstance(token, OSCToken):
+            pass
+
+    def apply_all(self, tokens: list[Token]) -> None:
+        """Apply each token in order."""
+        for token in tokens:
+            self.apply(token)
+
+    def snapshot(self) -> ScreenSnapshot:
+        """Return an immutable copy of the current grid and cursor."""
+        rows = tuple(tuple(row) for row in self._grid)
+        return ScreenSnapshot(
+            rows=rows,
+            cursor_row=self._cursor_row,
+            cursor_col=self._cursor_col,
+            cols=self.cols,
+        )
+
+    def reset(self) -> None:
+        """Clear the grid, reset attributes, and park the cursor at home."""
+        self._grid = [self._blank_row() for _ in range(self.rows)]
+        self._cursor_row = 0
+        self._cursor_col = 0
+        self._attrs = frozenset()
+
+    def _blank_row(self) -> list[Cell]:
+        """Return a fresh row filled with blank cells."""
+        return [Cell() for _ in range(self.cols)]
+
+    def _write_text(self, text: str) -> None:
+        """Write a run of printable characters at the cursor."""
+        for char in text:
+            if self._cursor_col >= self.cols:
+                self._cursor_col = self.cols - 1
+            row = self._grid[self._cursor_row]
+            row[self._cursor_col] = Cell(char=char, attrs=self._attrs)
+            self._cursor_col += 1
+            if self._cursor_col >= self.cols:
+                self._cursor_col = self.cols - 1
+
+    def _apply_control(self, char: str) -> None:
+        """Handle CR, LF, BS, TAB, BEL."""
+        if char == "\r":
+            self._cursor_col = 0
+        elif char == "\n":
+            if self._cursor_row < self.rows - 1:
+                self._cursor_row += 1
+        elif char == "\b":
+            if self._cursor_col > 0:
+                self._cursor_col -= 1
+        elif char == "\t":
+            next_stop = ((self._cursor_col // 8) + 1) * 8
+            self._cursor_col = min(next_stop, self.cols - 1)
+
+    def _apply_csi(self, token: CSIToken) -> None:
+        """Dispatch a CSI token to the matching handler."""
+        handler = _CSI_HANDLERS.get(token.final)
+        if handler is None:
+            return
+        handler(self, token)
+
+    def _apply_escape(self, _token: EscapeToken) -> None:
+        """Bare ESC commands are ignored for now."""
+
+    def _clamp_cursor(self) -> None:
+        """Keep the cursor inside the screen bounds."""
+        self._cursor_row = max(0, min(self._cursor_row, self.rows - 1))
+        self._cursor_col = max(0, min(self._cursor_col, self.cols - 1))
+
+
+def _param_or(token: CSIToken, index: int, default: int) -> int:
+    """Return the param at index or default when missing or -1."""
+    if index >= len(token.params):
+        return default
+    value = token.params[index]
+    return default if value < 0 else value
+
+
+def _cursor_up(screen: VirtualScreen, token: CSIToken) -> None:
+    """CUU: move cursor up N rows, clamping at top."""
+    screen._cursor_row -= max(1, _param_or(token, 0, 1))
+    screen._clamp_cursor()
+
+
+def _cursor_down(screen: VirtualScreen, token: CSIToken) -> None:
+    """CUD: move cursor down N rows, clamping at bottom."""
+    screen._cursor_row += max(1, _param_or(token, 0, 1))
+    screen._clamp_cursor()
+
+
+def _cursor_forward(screen: VirtualScreen, token: CSIToken) -> None:
+    """CUF: move cursor right N columns."""
+    screen._cursor_col += max(1, _param_or(token, 0, 1))
+    screen._clamp_cursor()
+
+
+def _cursor_back(screen: VirtualScreen, token: CSIToken) -> None:
+    """CUB: move cursor left N columns."""
+    screen._cursor_col -= max(1, _param_or(token, 0, 1))
+    screen._clamp_cursor()
+
+
+def _cursor_position(screen: VirtualScreen, token: CSIToken) -> None:
+    """CUP: absolute cursor position (one-based)."""
+    row = max(1, _param_or(token, 0, 1)) - 1
+    col = max(1, _param_or(token, 1, 1)) - 1
+    screen._cursor_row = row
+    screen._cursor_col = col
+    screen._clamp_cursor()
+
+
+def _erase_in_display(screen: VirtualScreen, token: CSIToken) -> None:
+    """ED: erase in display. 0=after cursor, 1=before, 2=all."""
+    mode = _param_or(token, 0, 0)
+    if mode == 2:
+        screen.reset()
+        return
+    if mode == 0:
+        _erase_line_from_cursor(screen)
+        for row_index in range(screen._cursor_row + 1, screen.rows):
+            screen._grid[row_index] = screen._blank_row()
+    elif mode == 1:
+        _erase_line_to_cursor(screen)
+        for row_index in range(0, screen._cursor_row):
+            screen._grid[row_index] = screen._blank_row()
+
+
+def _erase_in_line(screen: VirtualScreen, token: CSIToken) -> None:
+    """EL: erase in line. 0=to end, 1=to start, 2=entire row."""
+    mode = _param_or(token, 0, 0)
+    if mode == 0:
+        _erase_line_from_cursor(screen)
+    elif mode == 1:
+        _erase_line_to_cursor(screen)
+    elif mode == 2:
+        screen._grid[screen._cursor_row] = screen._blank_row()
+
+
+def _erase_line_from_cursor(screen: VirtualScreen) -> None:
+    """Blank cells from the cursor column to the end of the row."""
+    row = screen._grid[screen._cursor_row]
+    for col in range(screen._cursor_col, screen.cols):
+        row[col] = Cell()
+
+
+def _erase_line_to_cursor(screen: VirtualScreen) -> None:
+    """Blank cells from column 0 to and including the cursor column."""
+    row = screen._grid[screen._cursor_row]
+    for col in range(0, screen._cursor_col + 1):
+        row[col] = Cell()
+
+
+def _sgr(screen: VirtualScreen, token: CSIToken) -> None:
+    """SGR: apply Select Graphic Rendition updates to current attributes."""
+    params = token.params or (0,)
+    attrs = set(screen._attrs)
+    for raw in params:
+        code = 0 if raw < 0 else raw
+        if code == 0:
+            attrs.clear()
+        elif code == 1:
+            attrs.add(ATTR_BOLD)
+        elif code == 2:
+            attrs.add(ATTR_DIM)
+        elif code == 4:
+            attrs.add(ATTR_UNDERLINE)
+        elif code == 7:
+            attrs.add(ATTR_REVERSE)
+        elif code == 22:
+            attrs.discard(ATTR_BOLD)
+            attrs.discard(ATTR_DIM)
+        elif code == 24:
+            attrs.discard(ATTR_UNDERLINE)
+        elif code == 27:
+            attrs.discard(ATTR_REVERSE)
+    screen._attrs = frozenset(attrs)
+
+
+def _set_column(screen: VirtualScreen, token: CSIToken) -> None:
+    """CHA: move cursor to absolute column (one-based)."""
+    col = max(1, _param_or(token, 0, 1)) - 1
+    screen._cursor_col = col
+    screen._clamp_cursor()
+
+
+_CSI_HANDLERS = {
+    "A": _cursor_up,
+    "B": _cursor_down,
+    "C": _cursor_forward,
+    "D": _cursor_back,
+    "G": _set_column,
+    "H": _cursor_position,
+    "f": _cursor_position,
+    "J": _erase_in_display,
+    "K": _erase_in_line,
+    "m": _sgr,
+}

--- a/asat/tui_bridge.py
+++ b/asat/tui_bridge.py
@@ -1,0 +1,181 @@
+"""TuiBridge: glue between a raw program stream and the menu detector.
+
+The parser, virtual screen, and menu detector are each pure-function
+style components. TuiBridge composes them so a caller can push raw
+text from a running TUI in and get interactive-menu events out.
+
+A bridge belongs to a single cell and a single process stream. It
+holds:
+
+    An AnsiParser that tolerates chunks split mid-sequence.
+    A VirtualScreen that replays tokens into a grid.
+    The most recently detected InteractiveMenu (or None).
+
+Each feed() call:
+
+    1. Tokenizes the new text.
+    2. Applies the tokens to the screen.
+    3. Runs the menu detector on the fresh snapshot.
+    4. Emits SCREEN_UPDATED plus a menu lifecycle event when the menu
+       state transitions.
+
+The bridge is deliberately not wired to any bus event by default.
+Line-level OUTPUT_CHUNK events strip the sub-line detail that TUIs
+depend on (cursor moves, in-place redraws), so a future phase will
+introduce a raw-byte stream that can feed the bridge. Until then the
+bridge is driven by callers (or tests) directly through feed().
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Optional
+
+from asat.ansi import AnsiParser
+from asat.event_bus import EventBus
+from asat.events import Event, EventType
+from asat.interactive import InteractiveMenu, detect
+from asat.screen import DEFAULT_COLS, DEFAULT_ROWS, VirtualScreen
+
+
+class TuiBridge:
+    """Turns a raw TUI stream into menu-lifecycle events."""
+
+    SOURCE = "tui_bridge"
+
+    def __init__(
+        self,
+        bus: EventBus,
+        cell_id: str,
+        rows: int = DEFAULT_ROWS,
+        cols: int = DEFAULT_COLS,
+    ) -> None:
+        """Create a bridge bound to a cell with a fresh parser and screen."""
+        self._bus = bus
+        self._cell_id = cell_id
+        self._parser = AnsiParser()
+        self._screen = VirtualScreen(rows=rows, cols=cols)
+        self._menu: Optional[InteractiveMenu] = None
+
+    @property
+    def cell_id(self) -> str:
+        """Return the cell id this bridge belongs to."""
+        return self._cell_id
+
+    @property
+    def screen(self) -> VirtualScreen:
+        """Return the virtual screen the bridge is maintaining."""
+        return self._screen
+
+    @property
+    def current_menu(self) -> Optional[InteractiveMenu]:
+        """Return the most recently detected menu, or None."""
+        return self._menu
+
+    def feed(self, data: str) -> Optional[InteractiveMenu]:
+        """Consume more stream bytes and run detection.
+
+        Returns the currently detected menu (or None). Publishes
+        SCREEN_UPDATED and, on transitions, INTERACTIVE_MENU_DETECTED /
+        INTERACTIVE_MENU_UPDATED / INTERACTIVE_MENU_CLEARED.
+        """
+        if not data:
+            return self._menu
+        tokens = self._parser.feed(data)
+        if not tokens:
+            return self._menu
+        self._screen.apply_all(tokens)
+        self._publish_screen_update()
+        new_menu = detect(self._screen.snapshot())
+        self._transition_menu(new_menu)
+        return self._menu
+
+    def finish(self) -> Optional[InteractiveMenu]:
+        """Flush any buffered text and return the final menu state."""
+        tokens = self._parser.finish()
+        if tokens:
+            self._screen.apply_all(tokens)
+            self._publish_screen_update()
+            new_menu = detect(self._screen.snapshot())
+            self._transition_menu(new_menu)
+        return self._menu
+
+    def reset(self) -> None:
+        """Clear the screen and the detected menu; publish CLEARED if needed."""
+        self._screen.reset()
+        self._parser = AnsiParser()
+        self._transition_menu(None)
+
+    def _transition_menu(self, new_menu: Optional[InteractiveMenu]) -> None:
+        """Compare the new menu to the previous and emit the right event."""
+        previous = self._menu
+        self._menu = new_menu
+        if new_menu is None and previous is None:
+            return
+        if new_menu is not None and previous is None:
+            self._publish_menu_event(EventType.INTERACTIVE_MENU_DETECTED, new_menu)
+            return
+        if new_menu is None and previous is not None:
+            self._publish_menu_cleared()
+            return
+        assert new_menu is not None and previous is not None
+        if not _menus_equivalent(previous, new_menu):
+            self._publish_menu_event(EventType.INTERACTIVE_MENU_UPDATED, new_menu)
+
+    def _publish_screen_update(self) -> None:
+        """Publish a SCREEN_UPDATED event containing the text rows."""
+        snapshot = self._screen.snapshot()
+        self._bus.publish(
+            Event(
+                event_type=EventType.SCREEN_UPDATED,
+                payload={
+                    "cell_id": self._cell_id,
+                    "cursor_row": snapshot.cursor_row,
+                    "cursor_col": snapshot.cursor_col,
+                    "rows": snapshot.text_rows(),
+                },
+                source=self.SOURCE,
+            )
+        )
+
+    def _publish_menu_event(
+        self,
+        event_type: EventType,
+        menu: InteractiveMenu,
+    ) -> None:
+        """Publish a menu lifecycle event describing the detected items."""
+        self._bus.publish(
+            Event(
+                event_type=event_type,
+                payload={
+                    "cell_id": self._cell_id,
+                    "detection": menu.detection,
+                    "selected_index": menu.selected_index,
+                    "selected_text": menu.selected_text,
+                    "items": [asdict(item) for item in menu.items],
+                },
+                source=self.SOURCE,
+            )
+        )
+
+    def _publish_menu_cleared(self) -> None:
+        """Publish INTERACTIVE_MENU_CLEARED without menu contents."""
+        self._bus.publish(
+            Event(
+                event_type=EventType.INTERACTIVE_MENU_CLEARED,
+                payload={"cell_id": self._cell_id},
+                source=self.SOURCE,
+            )
+        )
+
+
+def _menus_equivalent(a: InteractiveMenu, b: InteractiveMenu) -> bool:
+    """Return True when two menus show the same items and selection."""
+    if a.selected_index != b.selected_index:
+        return False
+    if len(a.items) != len(b.items):
+        return False
+    for left, right in zip(a.items, b.items):
+        if left.text != right.text or left.selected != right.selected:
+            return False
+    return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "asat"
-version = "0.5.0"
+version = "0.6.0"
 description = "Accessible Spatial Audio Terminal"
 requires-python = ">=3.10"
 readme = { text = "Phase 1 foundation: data models and event bus.", content-type = "text/plain" }

--- a/tests/test_ansi.py
+++ b/tests/test_ansi.py
@@ -1,0 +1,146 @@
+"""Unit tests for the AnsiParser tokenizer."""
+
+from __future__ import annotations
+
+import unittest
+
+from asat.ansi import (
+    AnsiParser,
+    CSIToken,
+    ControlToken,
+    EscapeToken,
+    OSCToken,
+    TextToken,
+)
+
+
+class PlainTextTests(unittest.TestCase):
+
+    def test_feeding_plain_text_emits_single_token(self) -> None:
+        parser = AnsiParser()
+        tokens = parser.feed("hello world")
+        self.assertEqual(len(tokens), 1)
+        self.assertIsInstance(tokens[0], TextToken)
+        self.assertEqual(tokens[0].text, "hello world")
+
+    def test_control_characters_are_isolated(self) -> None:
+        parser = AnsiParser()
+        tokens = parser.feed("a\r\nb\t\bc")
+        kinds = [type(t).__name__ for t in tokens]
+        self.assertEqual(
+            kinds,
+            [
+                "TextToken",
+                "ControlToken",
+                "ControlToken",
+                "TextToken",
+                "ControlToken",
+                "ControlToken",
+                "TextToken",
+            ],
+        )
+
+
+class CSIParsingTests(unittest.TestCase):
+
+    def test_clear_screen_has_final_J_and_params(self) -> None:
+        parser = AnsiParser()
+        tokens = parser.feed("\x1b[2J")
+        self.assertEqual(len(tokens), 1)
+        assert isinstance(tokens[0], CSIToken)
+        self.assertEqual(tokens[0].final, "J")
+        self.assertEqual(tokens[0].params, (2,))
+        self.assertIsNone(tokens[0].private)
+        self.assertEqual(tokens[0].raw, "\x1b[2J")
+
+    def test_sgr_with_multiple_params(self) -> None:
+        parser = AnsiParser()
+        tokens = parser.feed("\x1b[1;31;4m")
+        assert isinstance(tokens[0], CSIToken)
+        self.assertEqual(tokens[0].final, "m")
+        self.assertEqual(tokens[0].params, (1, 31, 4))
+
+    def test_empty_param_becomes_sentinel(self) -> None:
+        parser = AnsiParser()
+        tokens = parser.feed("\x1b[;5H")
+        assert isinstance(tokens[0], CSIToken)
+        self.assertEqual(tokens[0].params, (-1, 5))
+
+    def test_private_marker_captured(self) -> None:
+        parser = AnsiParser()
+        tokens = parser.feed("\x1b[?25l")
+        assert isinstance(tokens[0], CSIToken)
+        self.assertEqual(tokens[0].private, "?")
+        self.assertEqual(tokens[0].final, "l")
+        self.assertEqual(tokens[0].params, (25,))
+
+
+class OSCAndEscTests(unittest.TestCase):
+
+    def test_osc_with_bel_terminator(self) -> None:
+        parser = AnsiParser()
+        tokens = parser.feed("\x1b]0;title\x07")
+        self.assertEqual(len(tokens), 1)
+        assert isinstance(tokens[0], OSCToken)
+        self.assertEqual(tokens[0].body, "0;title")
+
+    def test_osc_with_st_terminator(self) -> None:
+        parser = AnsiParser()
+        tokens = parser.feed("\x1b]8;;https://x\x1b\\")
+        self.assertEqual(len(tokens), 1)
+        assert isinstance(tokens[0], OSCToken)
+        self.assertEqual(tokens[0].body, "8;;https://x")
+
+    def test_bare_escape_command(self) -> None:
+        parser = AnsiParser()
+        tokens = parser.feed("\x1b7")
+        self.assertEqual(len(tokens), 1)
+        assert isinstance(tokens[0], EscapeToken)
+        self.assertEqual(tokens[0].char, "7")
+
+
+class IncompleteSequenceTests(unittest.TestCase):
+
+    def test_split_csi_is_buffered_across_feeds(self) -> None:
+        parser = AnsiParser()
+        first = parser.feed("\x1b[1;3")
+        self.assertEqual(first, [])
+        second = parser.feed("1m")
+        self.assertEqual(len(second), 1)
+        assert isinstance(second[0], CSIToken)
+        self.assertEqual(second[0].params, (1, 31))
+        self.assertEqual(second[0].final, "m")
+
+    def test_split_osc_is_buffered_until_terminator(self) -> None:
+        parser = AnsiParser()
+        first = parser.feed("\x1b]0;hel")
+        self.assertEqual(first, [])
+        second = parser.feed("lo\x07")
+        self.assertEqual(len(second), 1)
+        assert isinstance(second[0], OSCToken)
+        self.assertEqual(second[0].body, "0;hello")
+
+    def test_finish_returns_buffered_plain_text(self) -> None:
+        parser = AnsiParser()
+        parser.feed("x")
+        parser.feed("\x1b[")
+        residual = parser.finish()
+        self.assertEqual(residual, [])
+
+
+class MixedStreamTests(unittest.TestCase):
+
+    def test_real_world_mix_of_tokens(self) -> None:
+        parser = AnsiParser()
+        stream = "hello\x1b[1;31m world\x1b[0m\r\n"
+        tokens = parser.feed(stream)
+        text_runs = [t for t in tokens if isinstance(t, TextToken)]
+        csis = [t for t in tokens if isinstance(t, CSIToken)]
+        controls = [t for t in tokens if isinstance(t, ControlToken)]
+        self.assertEqual([t.text for t in text_runs], ["hello", " world"])
+        self.assertEqual([t.params for t in csis], [(1, 31), (0,)])
+        self.assertEqual([c.char for c in controls], ["\r", "\n"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1,0 +1,125 @@
+"""Unit tests for the interactive menu detector."""
+
+from __future__ import annotations
+
+import unittest
+
+from asat.ansi import AnsiParser
+from asat.interactive import InteractiveMenu, detect
+from asat.screen import VirtualScreen
+
+
+def _screen_from(stream: str, rows: int = 10, cols: int = 30) -> VirtualScreen:
+    """Apply an ANSI stream to a fresh screen and return it."""
+    screen = VirtualScreen(rows=rows, cols=cols)
+    screen.apply_all(AnsiParser().feed(stream))
+    return screen
+
+
+class ReverseVideoStrategyTests(unittest.TestCase):
+
+    def test_detects_menu_with_reverse_video_selected_row(self) -> None:
+        stream = (
+            "apple\r\n"
+            "\x1b[7mbanana\x1b[0m\r\n"
+            "cherry\r\n"
+        )
+        menu = detect(_screen_from(stream).snapshot())
+        assert menu is not None
+        self.assertEqual(menu.detection, "reverse_video")
+        self.assertEqual(
+            [item.text for item in menu.items],
+            ["apple", "banana", "cherry"],
+        )
+        self.assertEqual(menu.selected_index, 1)
+        self.assertEqual(menu.selected_text, "banana")
+
+    def test_first_row_reverse_is_valid_selection(self) -> None:
+        stream = (
+            "\x1b[7mfirst\x1b[0m\r\n"
+            "second\r\n"
+        )
+        menu = detect(_screen_from(stream).snapshot())
+        assert menu is not None
+        self.assertEqual(menu.selected_index, 0)
+
+    def test_multiple_reverse_rows_skips_detection(self) -> None:
+        stream = (
+            "\x1b[7mone\x1b[0m\r\n"
+            "\x1b[7mtwo\x1b[0m\r\n"
+        )
+        menu = detect(_screen_from(stream).snapshot())
+        self.assertIsNone(menu)
+
+    def test_reverse_on_blank_row_is_ignored(self) -> None:
+        stream = "\x1b[7m   \x1b[0m\r\n"
+        self.assertIsNone(detect(_screen_from(stream).snapshot()))
+
+    def test_single_item_is_not_considered_a_menu(self) -> None:
+        stream = "\x1b[7monly\x1b[0m\r\n"
+        self.assertIsNone(detect(_screen_from(stream).snapshot()))
+
+
+class PrefixMarkerStrategyTests(unittest.TestCase):
+
+    def test_detects_menu_with_greater_than_marker(self) -> None:
+        stream = (
+            "  apple\r\n"
+            "> banana\r\n"
+            "  cherry\r\n"
+        )
+        menu = detect(_screen_from(stream).snapshot())
+        assert menu is not None
+        self.assertEqual(menu.detection, "prefix_marker")
+        self.assertEqual(menu.selected_index, 1)
+        self.assertEqual(menu.selected_text.strip(), "> banana")
+
+    def test_detects_menu_with_arrow_marker(self) -> None:
+        stream = "→ first\r\n  second\r\n"
+        menu = detect(_screen_from(stream).snapshot())
+        assert menu is not None
+        self.assertEqual(menu.selected_index, 0)
+
+    def test_two_marker_rows_are_ambiguous(self) -> None:
+        stream = "> a\r\n> b\r\n"
+        self.assertIsNone(detect(_screen_from(stream).snapshot()))
+
+    def test_single_line_group_is_ignored(self) -> None:
+        stream = "> lonely\r\n"
+        self.assertIsNone(detect(_screen_from(stream).snapshot()))
+
+
+class NoMenuTests(unittest.TestCase):
+
+    def test_plain_text_returns_none(self) -> None:
+        stream = "nothing special here\r\nsecond line"
+        self.assertIsNone(detect(_screen_from(stream).snapshot()))
+
+    def test_blank_screen_returns_none(self) -> None:
+        self.assertIsNone(detect(VirtualScreen().snapshot()))
+
+
+class MenuStructureTests(unittest.TestCase):
+
+    def test_selected_flag_set_only_on_selected_item(self) -> None:
+        stream = "\x1b[7mA\x1b[0m\r\nB\r\nC\r\n"
+        menu = detect(_screen_from(stream).snapshot())
+        assert menu is not None
+        selected_flags = [item.selected for item in menu.items]
+        self.assertEqual(selected_flags, [True, False, False])
+
+    def test_items_track_screen_row_numbers(self) -> None:
+        stream = (
+            "\r\n"
+            "\r\n"
+            "a\r\n"
+            "\x1b[7mb\x1b[0m\r\n"
+            "c\r\n"
+        )
+        menu = detect(_screen_from(stream).snapshot())
+        assert menu is not None
+        self.assertEqual([item.row for item in menu.items], [2, 3, 4])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -1,0 +1,125 @@
+"""Unit tests for the VirtualScreen."""
+
+from __future__ import annotations
+
+import unittest
+
+from asat.ansi import AnsiParser
+from asat.screen import ATTR_BOLD, ATTR_REVERSE, VirtualScreen
+
+
+def _apply(stream: str, rows: int = 5, cols: int = 20) -> VirtualScreen:
+    """Tokenize a stream and apply it to a fresh screen."""
+    screen = VirtualScreen(rows=rows, cols=cols)
+    screen.apply_all(AnsiParser().feed(stream))
+    return screen
+
+
+class TextAndCursorTests(unittest.TestCase):
+
+    def test_plain_text_fills_first_row_and_advances_cursor(self) -> None:
+        screen = _apply("hello")
+        snapshot = screen.snapshot()
+        self.assertEqual(snapshot.text_rows()[0], "hello")
+        self.assertEqual(snapshot.cursor_col, 5)
+        self.assertEqual(snapshot.cursor_row, 0)
+
+    def test_newline_moves_cursor_down(self) -> None:
+        screen = _apply("hi\nby")
+        snapshot = screen.snapshot()
+        self.assertEqual(snapshot.text_rows()[0], "hi")
+        self.assertEqual(snapshot.text_rows()[1][2:4], "by")
+        self.assertEqual(snapshot.cursor_row, 1)
+
+    def test_carriage_return_moves_to_column_zero(self) -> None:
+        screen = _apply("abc\rX")
+        snapshot = screen.snapshot()
+        self.assertEqual(snapshot.text_rows()[0], "Xbc")
+
+    def test_backspace_moves_cursor_left(self) -> None:
+        screen = _apply("ab\bc")
+        snapshot = screen.snapshot()
+        self.assertEqual(snapshot.text_rows()[0], "ac")
+
+
+class CursorCommandTests(unittest.TestCase):
+
+    def test_cup_positions_cursor_absolutely(self) -> None:
+        screen = _apply("\x1b[3;5HX", rows=6, cols=20)
+        snapshot = screen.snapshot()
+        self.assertEqual(snapshot.cursor_row, 2)
+        self.assertEqual(snapshot.cursor_col, 5)
+        self.assertEqual(snapshot.rows[2][4].char, "X")
+
+    def test_cuu_cub_combine_for_in_place_redraw(self) -> None:
+        screen = _apply("hello\x1b[3D" + "__")
+        snapshot = screen.snapshot()
+        self.assertEqual(snapshot.text_rows()[0], "he__o")
+
+    def test_cha_sets_absolute_column(self) -> None:
+        screen = _apply("abcdef\x1b[3G*")
+        snapshot = screen.snapshot()
+        self.assertEqual(snapshot.text_rows()[0], "ab*def")
+
+
+class EraseTests(unittest.TestCase):
+
+    def test_erase_to_end_of_line_clears_from_cursor(self) -> None:
+        screen = _apply("abcdef\x1b[3D\x1b[K")
+        snapshot = screen.snapshot()
+        self.assertEqual(snapshot.text_rows()[0], "abc")
+
+    def test_erase_entire_line_clears_full_row(self) -> None:
+        screen = _apply("abcdef\x1b[2K")
+        snapshot = screen.snapshot()
+        self.assertEqual(snapshot.text_rows()[0], "")
+
+    def test_erase_display_full_resets_grid(self) -> None:
+        screen = _apply("line1\nline2\x1b[2J")
+        snapshot = screen.snapshot()
+        self.assertEqual(snapshot.text_rows(), tuple([""] * 5))
+
+
+class AttributeTests(unittest.TestCase):
+
+    def test_sgr_reverse_marks_cells(self) -> None:
+        screen = _apply("a\x1b[7mbc\x1b[0md")
+        snapshot = screen.snapshot()
+        row_attrs = snapshot.row_attrs(0)
+        self.assertNotIn(ATTR_REVERSE, row_attrs[0])
+        self.assertIn(ATTR_REVERSE, row_attrs[1])
+        self.assertIn(ATTR_REVERSE, row_attrs[2])
+        self.assertNotIn(ATTR_REVERSE, row_attrs[3])
+
+    def test_sgr_bold_and_reset_on_zero(self) -> None:
+        screen = _apply("\x1b[1mX\x1b[0mY")
+        snapshot = screen.snapshot()
+        row_attrs = snapshot.row_attrs(0)
+        self.assertIn(ATTR_BOLD, row_attrs[0])
+        self.assertNotIn(ATTR_BOLD, row_attrs[1])
+
+    def test_sgr_without_params_resets_attributes(self) -> None:
+        screen = _apply("\x1b[1mX\x1b[mY")
+        snapshot = screen.snapshot()
+        self.assertNotIn(ATTR_BOLD, snapshot.row_attrs(0)[1])
+
+
+class ResetAndSnapshotTests(unittest.TestCase):
+
+    def test_reset_returns_to_clean_state(self) -> None:
+        screen = _apply("hello")
+        screen.reset()
+        snapshot = screen.snapshot()
+        self.assertEqual((snapshot.cursor_row, snapshot.cursor_col), (0, 0))
+        self.assertEqual(snapshot.text_rows()[0], "")
+
+    def test_snapshot_is_immutable_view(self) -> None:
+        screen = VirtualScreen(rows=3, cols=5)
+        screen.apply_all(AnsiParser().feed("hi"))
+        snapshot = screen.snapshot()
+        screen.apply_all(AnsiParser().feed("xy"))
+        self.assertEqual(snapshot.text_rows()[0], "hi")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tui_bridge.py
+++ b/tests/test_tui_bridge.py
@@ -1,0 +1,139 @@
+"""Unit tests for TuiBridge."""
+
+from __future__ import annotations
+
+import unittest
+
+from asat.event_bus import EventBus
+from asat.events import Event, EventType
+from asat.tui_bridge import TuiBridge
+
+
+class _Recorder:
+    """Capture every event on a bus so tests can assert ordering."""
+
+    def __init__(self, bus: EventBus) -> None:
+        self.events: list[Event] = []
+        bus.subscribe("*", self.events.append)
+
+    def of(self, event_type: EventType) -> list[Event]:
+        return [event for event in self.events if event.event_type == event_type]
+
+
+class ScreenUpdateTests(unittest.TestCase):
+
+    def test_feed_publishes_screen_updated_with_rows(self) -> None:
+        bus = EventBus()
+        events = _Recorder(bus)
+        bridge = TuiBridge(bus, cell_id="c1", rows=4, cols=10)
+        bridge.feed("hello")
+        screen_events = events.of(EventType.SCREEN_UPDATED)
+        self.assertEqual(len(screen_events), 1)
+        self.assertEqual(screen_events[0].payload["cell_id"], "c1")
+        self.assertEqual(screen_events[0].payload["rows"][0], "hello")
+
+    def test_empty_feed_emits_no_events(self) -> None:
+        bus = EventBus()
+        events = _Recorder(bus)
+        bridge = TuiBridge(bus, cell_id="c1")
+        bridge.feed("")
+        self.assertEqual(events.events, [])
+
+
+class MenuLifecycleTests(unittest.TestCase):
+
+    def _reverse_video_menu(self) -> str:
+        return (
+            "\x1b[2J\x1b[1;1H"
+            "apple\r\n"
+            "\x1b[7mbanana\x1b[0m\r\n"
+            "cherry\r\n"
+        )
+
+    def test_first_detection_publishes_detected_event(self) -> None:
+        bus = EventBus()
+        events = _Recorder(bus)
+        bridge = TuiBridge(bus, cell_id="c1", rows=6, cols=20)
+        bridge.feed(self._reverse_video_menu())
+        detected = events.of(EventType.INTERACTIVE_MENU_DETECTED)
+        self.assertEqual(len(detected), 1)
+        payload = detected[0].payload
+        self.assertEqual(payload["selected_text"], "banana")
+        self.assertEqual(payload["selected_index"], 1)
+        self.assertEqual(payload["detection"], "reverse_video")
+        self.assertEqual(len(payload["items"]), 3)
+
+    def test_selection_change_publishes_updated_event(self) -> None:
+        bus = EventBus()
+        bridge = TuiBridge(bus, cell_id="c1", rows=6, cols=20)
+        bridge.feed(self._reverse_video_menu())
+        events = _Recorder(bus)
+        redraw = (
+            "\x1b[2J\x1b[1;1H"
+            "apple\r\n"
+            "banana\r\n"
+            "\x1b[7mcherry\x1b[0m\r\n"
+        )
+        bridge.feed(redraw)
+        updated = events.of(EventType.INTERACTIVE_MENU_UPDATED)
+        self.assertEqual(len(updated), 1)
+        self.assertEqual(updated[0].payload["selected_text"], "cherry")
+
+    def test_menu_disappearing_publishes_cleared(self) -> None:
+        bus = EventBus()
+        bridge = TuiBridge(bus, cell_id="c1", rows=6, cols=20)
+        bridge.feed(self._reverse_video_menu())
+        events = _Recorder(bus)
+        bridge.feed("\x1b[2J\x1b[1;1Hno menu here\r\n")
+        cleared = events.of(EventType.INTERACTIVE_MENU_CLEARED)
+        self.assertEqual(len(cleared), 1)
+        self.assertEqual(cleared[0].payload["cell_id"], "c1")
+
+    def test_stable_menu_does_not_emit_updated(self) -> None:
+        bus = EventBus()
+        bridge = TuiBridge(bus, cell_id="c1", rows=6, cols=20)
+        bridge.feed(self._reverse_video_menu())
+        events = _Recorder(bus)
+        bridge.feed(self._reverse_video_menu())
+        self.assertEqual(events.of(EventType.INTERACTIVE_MENU_UPDATED), [])
+
+
+class SplitChunkTests(unittest.TestCase):
+
+    def test_csi_split_across_feeds_still_produces_menu(self) -> None:
+        bus = EventBus()
+        bridge = TuiBridge(bus, cell_id="c1", rows=6, cols=20)
+        parts = [
+            "\x1b[2J",
+            "\x1b[1;1H",
+            "one\r\n",
+            "\x1b[7mtwo",
+            "\x1b[0m\r\n",
+            "three\r\n",
+        ]
+        for part in parts:
+            bridge.feed(part)
+        self.assertIsNotNone(bridge.current_menu)
+        assert bridge.current_menu is not None
+        self.assertEqual(bridge.current_menu.selected_text, "two")
+
+
+class ResetTests(unittest.TestCase):
+
+    def test_reset_clears_current_menu_and_emits_cleared(self) -> None:
+        bus = EventBus()
+        bridge = TuiBridge(bus, cell_id="c1", rows=6, cols=20)
+        bridge.feed(
+            "apple\r\n"
+            "\x1b[7mbanana\x1b[0m\r\n"
+            "cherry\r\n"
+        )
+        assert bridge.current_menu is not None
+        events = _Recorder(bus)
+        bridge.reset()
+        self.assertIsNone(bridge.current_menu)
+        self.assertEqual(len(events.of(EventType.INTERACTIVE_MENU_CLEARED)), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Phase 6 is the final planned phase of the ASAT roadmap. It closes the loop from "a TUI is drawing arrow-key menus on stdout" to "ASAT knows there is a menu, what's on it, and which item is selected" — entirely in stdlib Python.

**New modules**

- `asat/ansi.py` — `AnsiParser` tokenizes a raw stream into `TextToken` / `ControlToken` / `CSIToken` / `OSCToken` / `EscapeToken`. Handles split sequences across `feed()` calls, private-marker CSI, OSC with BEL or ST terminator.
- `asat/screen.py` — `VirtualScreen` replays tokens onto a 2D grid of `Cell`s. Supports CUU/CUD/CUF/CUB/CUP/CHA, ED/EL erases (modes 0/1/2), SGR for reverse/bold/dim/underline, CR/LF/BS/TAB. `ScreenSnapshot` is an immutable view with text rows and per-cell attribute sets.
- `asat/interactive.py` — `detect(snapshot) -> Optional[InteractiveMenu]` runs two heuristics in order: reverse-video row (the standard fzf/nano/curses style) and prefix-marker row (`>`, `→`, `▶`, `=>` etc.). Produces a structured `InteractiveMenu(items, selected_index, detection)` or None when nothing looks menu-like.
- `asat/tui_bridge.py` — `TuiBridge` composes parser + screen + detector against a single cell. Each `feed()` call publishes `SCREEN_UPDATED` and a transition-aware `INTERACTIVE_MENU_DETECTED` / `INTERACTIVE_MENU_UPDATED` / `INTERACTIVE_MENU_CLEARED`.

**Event additions**

`SCREEN_UPDATED`, `INTERACTIVE_MENU_DETECTED`, `INTERACTIVE_MENU_UPDATED`, `INTERACTIVE_MENU_CLEARED`.

**Tests**

49 new unit tests across `test_ansi.py`, `test_screen.py`, `test_interactive.py`, `test_tui_bridge.py`. Full suite: **266 passing** (≈0.55 s), all stdlib.

**Scope note (intentional)**

Phase 6 delivers the detection pipeline but does not yet wire a raw-byte subprocess stream into `TuiBridge`, nor does it route user key input back to the subprocess. The existing `OUTPUT_CHUNK` events emit lines with trailing newlines stripped, which is fine for plain output but loses the sub-line cursor moves TUIs rely on. A follow-up can add a PTY-based raw stream and stdin write-back for full two-way interaction; the parser/screen/detector ship ready for that integration.

## Test plan

- [x] `python -m unittest discover -s tests -t .` — 266 tests pass
- [x] No external deps introduced; stdlib only
- [x] `__init__.py` re-exports the new public surface; version bumped to 0.6.0
- [ ] Review that the two detector heuristics cover the TUIs you use most often, and flag any (`fzf --reverse`, `gh pr`, `git add -p`) that need additional patterns
- [ ] Confirm the scope note above — wiring into a raw byte stream and stdin write-back is intended for a follow-up
