### PR TITLE
R1: consolidate utcnow/new_id helpers into asat.common

### DIFF
--- a/asat/cell.py
+++ b/asat/cell.py
@@ -12,11 +12,12 @@ status and lineage.
 
 from __future__ import annotations
 
-import uuid
 from dataclasses import dataclass, field, asdict
-from datetime import datetime, timezone
+from datetime import datetime
 from enum import Enum
 from typing import Any, Optional
+
+from asat.common import new_id, utcnow
 
 
 class CellStatus(str, Enum):
@@ -34,16 +35,6 @@ class CellStatus(str, Enum):
     COMPLETED = "completed"
     FAILED = "failed"
     CANCELLED = "cancelled"
-
-
-def _utcnow() -> datetime:
-    """Return the current UTC time with an explicit timezone."""
-    return datetime.now(timezone.utc)
-
-
-def _new_id() -> str:
-    """Return a fresh random identifier as a hex string."""
-    return uuid.uuid4().hex
 
 
 @dataclass
@@ -75,9 +66,9 @@ class Cell:
         cell. It lets the session preserve the original cell as history
         while treating the new cell as its branch.
         """
-        now = _utcnow()
+        now = utcnow()
         return cls(
-            cell_id=_new_id(),
+            cell_id=new_id(),
             command=command,
             created_at=now,
             updated_at=now,
@@ -87,7 +78,7 @@ class Cell:
     def mark_running(self) -> None:
         """Transition this cell to the RUNNING state."""
         self.status = CellStatus.RUNNING
-        self.updated_at = _utcnow()
+        self.updated_at = utcnow()
 
     def mark_completed(self, stdout: str, stderr: str, exit_code: int) -> None:
         """Record a completed execution and set status from the exit code."""
@@ -95,12 +86,12 @@ class Cell:
         self.stderr = stderr
         self.exit_code = exit_code
         self.status = CellStatus.COMPLETED if exit_code == 0 else CellStatus.FAILED
-        self.updated_at = _utcnow()
+        self.updated_at = utcnow()
 
     def mark_cancelled(self) -> None:
         """Record that the user cancelled this cell before completion."""
         self.status = CellStatus.CANCELLED
-        self.updated_at = _utcnow()
+        self.updated_at = utcnow()
 
     def update_command(self, new_command: str) -> None:
         """Edit the input command and reset output-related state.
@@ -114,7 +105,7 @@ class Cell:
         self.stderr = ""
         self.exit_code = None
         self.status = CellStatus.PENDING
-        self.updated_at = _utcnow()
+        self.updated_at = utcnow()
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize this cell to a JSON-compatible dictionary."""

--- a/asat/common.py
+++ b/asat/common.py
@@ -1,0 +1,31 @@
+"""Shared internal helpers used across asat modules.
+
+This module is the single source of truth for tiny utilities that would
+otherwise be duplicated in several files. Keeping them here makes it
+obvious where to add the next piece of cross-cutting plumbing and keeps
+individual modules focused on their real responsibilities.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+
+def utcnow() -> datetime:
+    """Return the current UTC time with an explicit timezone.
+
+    Always use this instead of ``datetime.utcnow()`` so timestamps carry
+    tzinfo and round-trip cleanly through ``isoformat``.
+    """
+    return datetime.now(timezone.utc)
+
+
+def new_id() -> str:
+    """Return a fresh random identifier as a hex string.
+
+    Used for cell ids, session ids, and anywhere else we need a short
+    collision-resistant identifier without exposing uuid details to the
+    calling module.
+    """
+    return uuid.uuid4().hex

--- a/asat/events.py
+++ b/asat/events.py
@@ -13,9 +13,11 @@ parser modules.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime
 from enum import Enum
 from typing import Any
+
+from asat.common import utcnow
 
 
 class EventType(str, Enum):
@@ -98,11 +100,6 @@ class EventType(str, Enum):
     AUDIO_INTERRUPTED = "audio.interrupted"
 
 
-def _utcnow() -> datetime:
-    """Return the current UTC time with an explicit timezone."""
-    return datetime.now(timezone.utc)
-
-
 @dataclass(frozen=True)
 class Event:
     """An immutable record of something that happened.
@@ -117,4 +114,4 @@ class Event:
     event_type: EventType
     payload: dict[str, Any] = field(default_factory=dict)
     source: str = ""
-    timestamp: datetime = field(default_factory=_utcnow)
+    timestamp: datetime = field(default_factory=utcnow)

--- a/asat/session.py
+++ b/asat/session.py
@@ -10,23 +10,13 @@ from the execution kernel, input router, and audio engine.
 from __future__ import annotations
 
 import json
-import uuid
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterator, Optional
 
 from asat.cell import Cell
-
-
-def _utcnow() -> datetime:
-    """Return the current UTC time with an explicit timezone."""
-    return datetime.now(timezone.utc)
-
-
-def _new_id() -> str:
-    """Return a fresh random identifier as a hex string."""
-    return uuid.uuid4().hex
+from asat.common import new_id, utcnow
 
 
 class SessionError(Exception):
@@ -53,8 +43,8 @@ class Session:
     @classmethod
     def new(cls) -> "Session":
         """Create a fresh empty session."""
-        now = _utcnow()
-        return cls(session_id=_new_id(), created_at=now, updated_at=now)
+        now = utcnow()
+        return cls(session_id=new_id(), created_at=now, updated_at=now)
 
     def __len__(self) -> int:
         """Return the number of cells currently in the session."""
@@ -78,7 +68,7 @@ class Session:
         else:
             self._check_position(position, allow_end=True)
             self.cells.insert(position, cell)
-        self.updated_at = _utcnow()
+        self.updated_at = utcnow()
         return cell
 
     def remove_cell(self, cell_id: str) -> Cell:
@@ -90,7 +80,7 @@ class Session:
         removed = self.cells.pop(index)
         if self.active_cell_id == cell_id:
             self.active_cell_id = None
-        self.updated_at = _utcnow()
+        self.updated_at = utcnow()
         return removed
 
     def move_cell(self, cell_id: str, new_position: int) -> None:
@@ -104,7 +94,7 @@ class Session:
         self._check_position(new_position, allow_end=False)
         cell = self.cells.pop(current)
         self.cells.insert(new_position, cell)
-        self.updated_at = _utcnow()
+        self.updated_at = utcnow()
 
     def get_cell(self, cell_id: str) -> Cell:
         """Return the cell with the given id or raise SessionError."""
@@ -123,7 +113,7 @@ class Session:
         if cell_id is not None:
             self._require_index(cell_id)
         self.active_cell_id = cell_id
-        self.updated_at = _utcnow()
+        self.updated_at = utcnow()
 
     def active_cell(self) -> Optional[Cell]:
         """Return the currently focused cell, or None if no cell is focused."""


### PR DESCRIPTION
## Summary

First refactor PR on the road to the audio customization framework. Pure code motion, zero behavior change.

- New `asat/common.py` holds `utcnow()` and `new_id()` as the single source of truth for cross-cutting helpers.
- Removed three duplicate `_utcnow()` definitions (`cell.py`, `events.py`, `session.py`) and two duplicate `_new_id()` definitions (`cell.py`, `session.py`).
- All 266 existing tests pass unchanged.

## Why

The upcoming sound-bank, generic audio engine, and keyboard-only settings editor will all need timestamps and ids. Centralising these tiny helpers now means future modules import from one place rather than each growing a private copy.

## Test plan

- [x] `python -m unittest discover -s tests -t .` — 266 passed
- [x] `grep _utcnow asat/` returns nothing
- [x] `grep _new_id asat/` returns nothing