### PR TITLE
R3: unified publish_event helper replaces inline Event construction

### DIFF
--- a/asat/actions.py
+++ b/asat/actions.py
@@ -37,8 +37,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, Optional, Protocol
 
-from asat.event_bus import EventBus
-from asat.events import Event, EventType
+from asat.event_bus import EventBus, publish_event
+from asat.events import EventType
 from asat.notebook import FocusMode, NotebookCursor
 from asat.output_buffer import OutputRecorder, STDERR, STDOUT
 from asat.output_cursor import OutputCursor
@@ -162,15 +162,14 @@ class ActionMenu:
         self._index = -1
         context = self._context
         self._context = None
-        self._bus.publish(
-            Event(
-                event_type=EventType.ACTION_MENU_CLOSED,
-                payload={
-                    "focus_mode": context.focus_mode.value if context else None,
-                    "cell_id": context.cell_id if context else None,
-                },
-                source=self.SOURCE,
-            )
+        publish_event(
+            self._bus,
+            EventType.ACTION_MENU_CLOSED,
+            {
+                "focus_mode": context.focus_mode.value if context else None,
+                "cell_id": context.cell_id if context else None,
+            },
+            source=self.SOURCE,
         )
 
     def current_item(self) -> Optional[MenuItem]:
@@ -197,17 +196,16 @@ class ActionMenu:
         context = self._context
         if item is None or context is None:
             return None
-        self._bus.publish(
-            Event(
-                event_type=EventType.ACTION_MENU_ITEM_INVOKED,
-                payload={
-                    "item_id": item.id,
-                    "label": item.label,
-                    "focus_mode": context.focus_mode.value,
-                    "cell_id": context.cell_id,
-                },
-                source=self.SOURCE,
-            )
+        publish_event(
+            self._bus,
+            EventType.ACTION_MENU_ITEM_INVOKED,
+            {
+                "item_id": item.id,
+                "label": item.label,
+                "focus_mode": context.focus_mode.value,
+                "cell_id": context.cell_id,
+            },
+            source=self.SOURCE,
         )
         item.handler(context)
         self.close()
@@ -231,31 +229,29 @@ class ActionMenu:
         items: tuple[MenuItem, ...],
     ) -> None:
         """Publish ACTION_MENU_OPENED with the item labels for this context."""
-        self._bus.publish(
-            Event(
-                event_type=EventType.ACTION_MENU_OPENED,
-                payload={
-                    "focus_mode": context.focus_mode.value,
-                    "cell_id": context.cell_id,
-                    "item_ids": [item.id for item in items],
-                    "labels": [item.label for item in items],
-                },
-                source=self.SOURCE,
-            )
+        publish_event(
+            self._bus,
+            EventType.ACTION_MENU_OPENED,
+            {
+                "focus_mode": context.focus_mode.value,
+                "cell_id": context.cell_id,
+                "item_ids": [item.id for item in items],
+                "labels": [item.label for item in items],
+            },
+            source=self.SOURCE,
         )
 
     def _publish_focus(self, item: MenuItem) -> None:
         """Publish ACTION_MENU_ITEM_FOCUSED for the given item."""
-        self._bus.publish(
-            Event(
-                event_type=EventType.ACTION_MENU_ITEM_FOCUSED,
-                payload={
-                    "item_id": item.id,
-                    "label": item.label,
-                    "index": self._index,
-                },
-                source=self.SOURCE,
-            )
+        publish_event(
+            self._bus,
+            EventType.ACTION_MENU_ITEM_FOCUSED,
+            {
+                "item_id": item.id,
+                "label": item.label,
+                "index": self._index,
+            },
+            source=self.SOURCE,
         )
 
 
@@ -281,16 +277,15 @@ def default_actions(
     def _copy(context: ActionContext, text: str, source_label: str) -> None:
         """Store text on the clipboard and publish CLIPBOARD_COPIED."""
         clipboard.set_text(text)
-        bus.publish(
-            Event(
-                event_type=EventType.CLIPBOARD_COPIED,
-                payload={
-                    "cell_id": context.cell_id,
-                    "source": source_label,
-                    "length": len(text),
-                },
-                source="actions",
-            )
+        publish_event(
+            bus,
+            EventType.CLIPBOARD_COPIED,
+            {
+                "cell_id": context.cell_id,
+                "source": source_label,
+                "length": len(text),
+            },
+            source="actions",
         )
 
     def notebook_items(context: ActionContext) -> tuple[MenuItem, ...]:

--- a/asat/event_bus.py
+++ b/asat/event_bus.py
@@ -14,7 +14,7 @@ re-raised together after all handlers have had a chance to react.
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Callable
+from typing import Any, Callable
 
 from asat.events import Event, EventType
 
@@ -22,6 +22,23 @@ from asat.events import Event, EventType
 Handler = Callable[[Event], None]
 
 WILDCARD = "*"
+
+
+def publish_event(
+    bus: "EventBus",
+    event_type: EventType,
+    payload: dict[str, Any],
+    *,
+    source: str,
+) -> None:
+    """Build an Event and publish it on the bus in one call.
+
+    Every producer in the codebase goes through this helper so there is
+    one place to change if Event construction ever grows a new required
+    field (for example a correlation id or a priority). Keyword-only
+    source avoids accidental swaps with payload.
+    """
+    bus.publish(Event(event_type=event_type, payload=payload, source=source))
 
 
 class EventBusError(Exception):

--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -28,8 +28,8 @@ from __future__ import annotations
 from typing import Callable, Optional
 
 from asat import keys as kc
-from asat.event_bus import EventBus
-from asat.events import Event, EventType
+from asat.event_bus import EventBus, publish_event
+from asat.events import EventType
 from asat.keys import Key, Modifier
 from asat.notebook import FocusMode, NotebookCursor
 from asat.output_cursor import OutputCursor
@@ -190,16 +190,15 @@ class InputRouter:
 
     def _publish_key(self, key: Key) -> None:
         """Publish a KEY_PRESSED event describing the keystroke."""
-        self._bus.publish(
-            Event(
-                event_type=EventType.KEY_PRESSED,
-                payload={
-                    "name": key.name,
-                    "char": key.char,
-                    "modifiers": sorted(m.value for m in key.modifiers),
-                },
-                source=self.SOURCE,
-            )
+        publish_event(
+            self._bus,
+            EventType.KEY_PRESSED,
+            {
+                "name": key.name,
+                "char": key.char,
+                "modifiers": sorted(m.value for m in key.modifiers),
+            },
+            source=self.SOURCE,
         )
 
     def _publish_action(
@@ -216,10 +215,9 @@ class InputRouter:
             "key_name": key.name,
         }
         payload.update(extra)
-        self._bus.publish(
-            Event(
-                event_type=EventType.ACTION_INVOKED,
-                payload=payload,
-                source=self.SOURCE,
-            )
+        publish_event(
+            self._bus,
+            EventType.ACTION_INVOKED,
+            payload,
+            source=self.SOURCE,
         )

--- a/asat/kernel.py
+++ b/asat/kernel.py
@@ -28,8 +28,8 @@ from pathlib import Path
 from typing import Optional
 
 from asat.cell import Cell
-from asat.event_bus import EventBus
-from asat.events import Event, EventType
+from asat.event_bus import EventBus, publish_event
+from asat.events import EventType
 from asat.execution import ExecutionMode, ExecutionRequest, ExecutionResult
 from asat.runner import ProcessRunner
 
@@ -153,6 +153,4 @@ class ExecutionKernel:
 
     def _publish(self, event_type: EventType, **payload) -> None:
         """Publish an Event on the bus with the kernel as the source."""
-        self._bus.publish(
-            Event(event_type=event_type, payload=payload, source=self.SOURCE)
-        )
+        publish_event(self._bus, event_type, payload, source=self.SOURCE)

--- a/asat/notebook.py
+++ b/asat/notebook.py
@@ -24,8 +24,8 @@ from enum import Enum
 from typing import Optional
 
 from asat.cell import Cell
-from asat.event_bus import EventBus
-from asat.events import Event, EventType
+from asat.event_bus import EventBus, publish_event
+from asat.events import EventType
 from asat.session import Session
 
 
@@ -260,16 +260,15 @@ class NotebookCursor:
             return
         old_state = self._state
         self._state = new_state
-        self._bus.publish(
-            Event(
-                event_type=EventType.FOCUS_CHANGED,
-                payload={
-                    "old_mode": old_state.mode.value,
-                    "new_mode": new_state.mode.value,
-                    "old_cell_id": old_state.cell_id,
-                    "new_cell_id": new_state.cell_id,
-                    "input_buffer": new_state.input_buffer,
-                },
-                source=self.SOURCE,
-            )
+        publish_event(
+            self._bus,
+            EventType.FOCUS_CHANGED,
+            {
+                "old_mode": old_state.mode.value,
+                "new_mode": new_state.mode.value,
+                "old_cell_id": old_state.cell_id,
+                "new_cell_id": new_state.cell_id,
+                "input_buffer": new_state.input_buffer,
+            },
+            source=self.SOURCE,
         )

--- a/asat/output_buffer.py
+++ b/asat/output_buffer.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterator, Optional
 
-from asat.event_bus import EventBus
+from asat.event_bus import EventBus, publish_event
 from asat.events import Event, EventType
 
 
@@ -177,15 +177,14 @@ class OutputRecorder:
         if not isinstance(cell_id, str) or not isinstance(text, str):
             return
         line = self.buffer_for(cell_id).append(text, stream=stream)
-        self._bus.publish(
-            Event(
-                event_type=EventType.OUTPUT_LINE_APPENDED,
-                payload={
-                    "cell_id": cell_id,
-                    "line_number": line.line_number,
-                    "stream": stream,
-                    "text": text,
-                },
-                source=self.SOURCE,
-            )
+        publish_event(
+            self._bus,
+            EventType.OUTPUT_LINE_APPENDED,
+            {
+                "cell_id": cell_id,
+                "line_number": line.line_number,
+                "stream": stream,
+                "text": text,
+            },
+            source=self.SOURCE,
         )

--- a/asat/output_cursor.py
+++ b/asat/output_cursor.py
@@ -21,8 +21,8 @@ from __future__ import annotations
 
 from typing import Optional
 
-from asat.event_bus import EventBus
-from asat.events import Event, EventType
+from asat.event_bus import EventBus, publish_event
+from asat.events import EventType
 from asat.output_buffer import OutputBuffer, OutputLine
 
 
@@ -137,15 +137,14 @@ class OutputCursor:
 
     def _publish_focus(self, line: OutputLine) -> None:
         """Publish an OUTPUT_LINE_FOCUSED event for the given line."""
-        self._bus.publish(
-            Event(
-                event_type=EventType.OUTPUT_LINE_FOCUSED,
-                payload={
-                    "cell_id": line.cell_id,
-                    "line_number": line.line_number,
-                    "stream": line.stream,
-                    "text": line.text,
-                },
-                source=self.SOURCE,
-            )
+        publish_event(
+            self._bus,
+            EventType.OUTPUT_LINE_FOCUSED,
+            {
+                "cell_id": line.cell_id,
+                "line_number": line.line_number,
+                "stream": line.stream,
+                "text": line.text,
+            },
+            source=self.SOURCE,
         )

--- a/asat/tui_bridge.py
+++ b/asat/tui_bridge.py
@@ -32,8 +32,8 @@ from dataclasses import asdict
 from typing import Optional
 
 from asat.ansi import AnsiParser
-from asat.event_bus import EventBus
-from asat.events import Event, EventType
+from asat.event_bus import EventBus, publish_event
+from asat.events import EventType
 from asat.interactive import InteractiveMenu, detect
 from asat.screen import DEFAULT_COLS, DEFAULT_ROWS, VirtualScreen
 
@@ -125,17 +125,16 @@ class TuiBridge:
     def _publish_screen_update(self) -> None:
         """Publish a SCREEN_UPDATED event containing the text rows."""
         snapshot = self._screen.snapshot()
-        self._bus.publish(
-            Event(
-                event_type=EventType.SCREEN_UPDATED,
-                payload={
-                    "cell_id": self._cell_id,
-                    "cursor_row": snapshot.cursor_row,
-                    "cursor_col": snapshot.cursor_col,
-                    "rows": snapshot.text_rows(),
-                },
-                source=self.SOURCE,
-            )
+        publish_event(
+            self._bus,
+            EventType.SCREEN_UPDATED,
+            {
+                "cell_id": self._cell_id,
+                "cursor_row": snapshot.cursor_row,
+                "cursor_col": snapshot.cursor_col,
+                "rows": snapshot.text_rows(),
+            },
+            source=self.SOURCE,
         )
 
     def _publish_menu_event(
@@ -144,28 +143,26 @@ class TuiBridge:
         menu: InteractiveMenu,
     ) -> None:
         """Publish a menu lifecycle event describing the detected items."""
-        self._bus.publish(
-            Event(
-                event_type=event_type,
-                payload={
-                    "cell_id": self._cell_id,
-                    "detection": menu.detection,
-                    "selected_index": menu.selected_index,
-                    "selected_text": menu.selected_text,
-                    "items": [asdict(item) for item in menu.items],
-                },
-                source=self.SOURCE,
-            )
+        publish_event(
+            self._bus,
+            event_type,
+            {
+                "cell_id": self._cell_id,
+                "detection": menu.detection,
+                "selected_index": menu.selected_index,
+                "selected_text": menu.selected_text,
+                "items": [asdict(item) for item in menu.items],
+            },
+            source=self.SOURCE,
         )
 
     def _publish_menu_cleared(self) -> None:
         """Publish INTERACTIVE_MENU_CLEARED without menu contents."""
-        self._bus.publish(
-            Event(
-                event_type=EventType.INTERACTIVE_MENU_CLEARED,
-                payload={"cell_id": self._cell_id},
-                source=self.SOURCE,
-            )
+        publish_event(
+            self._bus,
+            EventType.INTERACTIVE_MENU_CLEARED,
+            {"cell_id": self._cell_id},
+            source=self.SOURCE,
         )
 
 

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import unittest
 
-from asat.event_bus import EventBus, EventBusError, WILDCARD
+from asat.event_bus import EventBus, EventBusError, WILDCARD, publish_event
 from asat.events import Event, EventType
 
 
@@ -108,6 +108,30 @@ class EventBusErrorIsolationTests(unittest.TestCase):
         with self.assertRaises(EventBusError) as ctx:
             bus.publish(Event(event_type=EventType.CELL_CREATED))
         self.assertEqual(len(ctx.exception.errors), 2)
+
+
+class PublishEventHelperTests(unittest.TestCase):
+
+    def test_publish_event_builds_and_dispatches_event(self) -> None:
+        bus = EventBus()
+        received: list[Event] = []
+        bus.subscribe(WILDCARD, received.append)
+        publish_event(
+            bus,
+            EventType.CELL_CREATED,
+            {"cell_id": "abc"},
+            source="test",
+        )
+        self.assertEqual(len(received), 1)
+        event = received[0]
+        self.assertEqual(event.event_type, EventType.CELL_CREATED)
+        self.assertEqual(event.payload, {"cell_id": "abc"})
+        self.assertEqual(event.source, "test")
+
+    def test_source_is_keyword_only(self) -> None:
+        bus = EventBus()
+        with self.assertRaises(TypeError):
+            publish_event(bus, EventType.CELL_CREATED, {}, "positional")  # type: ignore[misc]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Second refactor PR on the road to the audio customization framework. Still pure code motion — no runtime behavior change.

- Adds `publish_event(bus, event_type, payload, *, source)` to `asat.event_bus`.
- Migrates every producer to it: `actions`, `input_router`, `kernel`, `notebook`, `output_buffer`, `output_cursor`, `tui_bridge`.
- Removed the now-unused `from asat.events import Event` from seven modules.

## Why

Fourteen call sites were constructing `Event(event_type=..., payload=..., source=...)` inline, then calling `bus.publish(...)` on it. Funnelling them through one helper means:

- Adding a new Event field (correlation id, priority, tracing context) touches one line instead of fourteen.
- The upcoming audio engine will add many more producers; landing the convention before that sprawl keeps things tidy.
- `source` is keyword-only, so future producers cannot accidentally swap it with payload.

## Test plan

- [x] `python -m unittest discover -s tests -t .` — 268 passed (+2 new helper tests)
- [x] `grep "Event(" asat/` returns only the helper itself
- [x] No source strings or payload shapes changed