### PR TITLE
Refactor + docs pass: R2 / R4 / R5 / D1

### DIFF
--- a/asat/cell.py
+++ b/asat/cell.py
@@ -1,9 +1,23 @@
 """Cell model: one input/output interaction in the notebook.
 
 A Cell records a single command submission and the resulting output.
-It is the atomic unit of the notebook workflow. Cells are intentionally
-dumb data containers. All mutation logic lives in the Session class or
-in later-phase modules (execution kernel, parser).
+It is the atomic unit of the notebook workflow.
+
+Mutation policy
+---------------
+Cell is the only non-frozen dataclass in the core data layer, and that
+is deliberate: its state changes over an execution lifecycle
+(PENDING -> RUNNING -> COMPLETED/FAILED/CANCELLED) and every mutation
+needs to update `updated_at` atomically. To keep the rules simple:
+
+* Only two callers are allowed to mutate a Cell:
+    - ExecutionKernel (mark_running, mark_completed, mark_cancelled)
+    - NotebookCursor  (update_command on edit-in-place)
+* Every mutation goes through one of the `mark_*` / `update_command`
+  methods so the timestamp and status stay consistent.
+* Any consumer that wants a stable view while handling an event must
+  call Cell.snapshot() to get a defensive copy that will not change
+  under its feet when the original mutates later.
 
 Fields are ordered so the most important identity information is read
 first by a screen reader: id, command, timestamp, then outputs, then
@@ -106,6 +120,27 @@ class Cell:
         self.exit_code = None
         self.status = CellStatus.PENDING
         self.updated_at = utcnow()
+
+    def snapshot(self) -> "Cell":
+        """Return a detached copy of this cell at the current moment.
+
+        Subscribers that cache cell state from an event must use this
+        rather than the original reference: the kernel may mutate the
+        source Cell immediately after publishing the event, and the
+        metadata dict is deep-copied so later edits do not leak in.
+        """
+        return Cell(
+            cell_id=self.cell_id,
+            command=self.command,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+            stdout=self.stdout,
+            stderr=self.stderr,
+            exit_code=self.exit_code,
+            status=self.status,
+            parent_id=self.parent_id,
+            metadata=dict(self.metadata),
+        )
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize this cell to a JSON-compatible dictionary."""

--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -36,6 +36,24 @@ from asat.output_cursor import OutputCursor
 
 
 BindingMap = dict[FocusMode, dict[Key, str]]
+ActionHandler = Callable[[], Optional[dict[str, object]]]
+
+
+def _void(fn: Callable[..., object]) -> ActionHandler:
+    """Wrap a side-effecting callable so it matches the ActionHandler shape.
+
+    Cursor motion helpers return various convenience values (the Cell
+    that moved into focus, the new FocusState, etc.) that the router
+    does not care about. _void invokes the underlying method, discards
+    its return value, and reports None so the dispatch table's type is
+    uniform.
+    """
+
+    def wrapper() -> None:
+        fn()
+        return None
+
+    return wrapper
 
 
 def default_bindings() -> BindingMap:
@@ -130,32 +148,44 @@ class InputRouter:
         return None
 
     def _invoke(self, action: str, key: Key) -> None:
-        """Run a named action and publish ACTION_INVOKED for it."""
-        payload_extra: dict[str, object] = {}
-        if action == "submit":
-            cell = self._cursor.submit()
-            if cell is not None:
-                payload_extra = {
-                    "cell_id": cell.cell_id,
-                    "command": cell.command,
-                }
-        else:
-            self._action_handler(action)()
-        self._publish_action(action, key, payload_extra)
+        """Run a named action and publish ACTION_INVOKED for it.
 
-    def _action_handler(self, action: str) -> Callable[[], None]:
-        """Map an action name to a zero-argument callable."""
-        handlers: dict[str, Callable[[], None]] = {
-            "move_up": lambda: self._cursor.move_up(),
-            "move_down": lambda: self._cursor.move_down(),
-            "move_to_top": lambda: self._cursor.move_to_top(),
-            "move_to_bottom": lambda: self._cursor.move_to_bottom(),
-            "enter_input": lambda: self._cursor.enter_input_mode(),
-            "exit_input": lambda: self._cursor.exit_input_mode(),
-            "new_cell": lambda: self._cursor.new_cell(),
-            "backspace": lambda: self._cursor.backspace(),
-            "view_output": lambda: self._cursor.view_output_mode(),
-            "exit_output": lambda: self._cursor.exit_output_mode(),
+        Every handler returns an optional dict of extra payload fields
+        to merge into the ACTION_INVOKED event. Most simple motions do
+        not contribute extras and return None; "submit" uses the hook
+        to attach the submitted command's cell_id and text.
+        """
+        handler = self._action_handler(action)
+        extra = handler() or {}
+        self._publish_action(action, key, extra)
+
+    def _submit(self) -> Optional[dict[str, object]]:
+        """Commit the current input buffer and return submission extras."""
+        cell = self._cursor.submit()
+        if cell is None:
+            return None
+        return {"cell_id": cell.cell_id, "command": cell.command}
+
+    def _action_handler(self, action: str) -> ActionHandler:
+        """Map an action name to a zero-argument callable.
+
+        Handlers return an optional dict of extra payload fields. Only
+        "submit" contributes extras today; every other handler runs a
+        side effect and returns None via _void, which discards whatever
+        the underlying cursor method returned.
+        """
+        handlers: dict[str, ActionHandler] = {
+            "move_up": _void(self._cursor.move_up),
+            "move_down": _void(self._cursor.move_down),
+            "move_to_top": _void(self._cursor.move_to_top),
+            "move_to_bottom": _void(self._cursor.move_to_bottom),
+            "enter_input": _void(self._cursor.enter_input_mode),
+            "exit_input": _void(self._cursor.exit_input_mode),
+            "new_cell": _void(self._cursor.new_cell),
+            "backspace": _void(self._cursor.backspace),
+            "view_output": _void(self._cursor.view_output_mode),
+            "exit_output": _void(self._cursor.exit_output_mode),
+            "submit": self._submit,
             "output_line_up": lambda: self._with_output_cursor(
                 lambda oc: oc.move_line_up()
             ),

--- a/asat/screen.py
+++ b/asat/screen.py
@@ -35,7 +35,7 @@ state with the screen.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Callable, ClassVar
 
 from asat.ansi import (
     CSIToken,
@@ -82,6 +82,14 @@ class ScreenSnapshot:
         return tuple(cell.attrs for cell in self.rows[row_index])
 
 
+def _param_or(token: CSIToken, index: int, default: int) -> int:
+    """Return the param at index or default when missing or -1."""
+    if index >= len(token.params):
+        return default
+    value = token.params[index]
+    return default if value < 0 else value
+
+
 @dataclass
 class VirtualScreen:
     """Mutable 2D grid updated by applying ANSI tokens."""
@@ -102,6 +110,21 @@ class VirtualScreen:
     def cursor(self) -> tuple[int, int]:
         """Return (row, col) of the current cursor position."""
         return self._cursor_row, self._cursor_col
+
+    @property
+    def cursor_row(self) -> int:
+        """Zero-based row index of the cursor."""
+        return self._cursor_row
+
+    @property
+    def cursor_col(self) -> int:
+        """Zero-based column index of the cursor."""
+        return self._cursor_col
+
+    @property
+    def attrs(self) -> frozenset[str]:
+        """Current SGR attribute set applied to newly written cells."""
+        return self._attrs
 
     def apply(self, token: Token) -> None:
         """Mutate the screen by applying a single token."""
@@ -168,8 +191,8 @@ class VirtualScreen:
             self._cursor_col = min(next_stop, self.cols - 1)
 
     def _apply_csi(self, token: CSIToken) -> None:
-        """Dispatch a CSI token to the matching handler."""
-        handler = _CSI_HANDLERS.get(token.final)
+        """Dispatch a CSI token to the matching bound method."""
+        handler = self._CSI_HANDLERS.get(token.final)
         if handler is None:
             return
         handler(self, token)
@@ -182,131 +205,108 @@ class VirtualScreen:
         self._cursor_row = max(0, min(self._cursor_row, self.rows - 1))
         self._cursor_col = max(0, min(self._cursor_col, self.cols - 1))
 
+    def _cursor_up(self, token: CSIToken) -> None:
+        """CUU: move cursor up N rows, clamping at top."""
+        self._cursor_row -= max(1, _param_or(token, 0, 1))
+        self._clamp_cursor()
 
-def _param_or(token: CSIToken, index: int, default: int) -> int:
-    """Return the param at index or default when missing or -1."""
-    if index >= len(token.params):
-        return default
-    value = token.params[index]
-    return default if value < 0 else value
+    def _cursor_down(self, token: CSIToken) -> None:
+        """CUD: move cursor down N rows, clamping at bottom."""
+        self._cursor_row += max(1, _param_or(token, 0, 1))
+        self._clamp_cursor()
 
+    def _cursor_forward(self, token: CSIToken) -> None:
+        """CUF: move cursor right N columns."""
+        self._cursor_col += max(1, _param_or(token, 0, 1))
+        self._clamp_cursor()
 
-def _cursor_up(screen: VirtualScreen, token: CSIToken) -> None:
-    """CUU: move cursor up N rows, clamping at top."""
-    screen._cursor_row -= max(1, _param_or(token, 0, 1))
-    screen._clamp_cursor()
+    def _cursor_back(self, token: CSIToken) -> None:
+        """CUB: move cursor left N columns."""
+        self._cursor_col -= max(1, _param_or(token, 0, 1))
+        self._clamp_cursor()
 
+    def _cursor_position(self, token: CSIToken) -> None:
+        """CUP: absolute cursor position (one-based)."""
+        self._cursor_row = max(1, _param_or(token, 0, 1)) - 1
+        self._cursor_col = max(1, _param_or(token, 1, 1)) - 1
+        self._clamp_cursor()
 
-def _cursor_down(screen: VirtualScreen, token: CSIToken) -> None:
-    """CUD: move cursor down N rows, clamping at bottom."""
-    screen._cursor_row += max(1, _param_or(token, 0, 1))
-    screen._clamp_cursor()
+    def _set_column(self, token: CSIToken) -> None:
+        """CHA: move cursor to absolute column (one-based)."""
+        self._cursor_col = max(1, _param_or(token, 0, 1)) - 1
+        self._clamp_cursor()
 
+    def _erase_in_display(self, token: CSIToken) -> None:
+        """ED: erase in display. 0=after cursor, 1=before, 2=all."""
+        mode = _param_or(token, 0, 0)
+        if mode == 2:
+            self.reset()
+            return
+        if mode == 0:
+            self._erase_line_from_cursor()
+            for row_index in range(self._cursor_row + 1, self.rows):
+                self._grid[row_index] = self._blank_row()
+        elif mode == 1:
+            self._erase_line_to_cursor()
+            for row_index in range(0, self._cursor_row):
+                self._grid[row_index] = self._blank_row()
 
-def _cursor_forward(screen: VirtualScreen, token: CSIToken) -> None:
-    """CUF: move cursor right N columns."""
-    screen._cursor_col += max(1, _param_or(token, 0, 1))
-    screen._clamp_cursor()
+    def _erase_in_line(self, token: CSIToken) -> None:
+        """EL: erase in line. 0=to end, 1=to start, 2=entire row."""
+        mode = _param_or(token, 0, 0)
+        if mode == 0:
+            self._erase_line_from_cursor()
+        elif mode == 1:
+            self._erase_line_to_cursor()
+        elif mode == 2:
+            self._grid[self._cursor_row] = self._blank_row()
 
+    def _erase_line_from_cursor(self) -> None:
+        """Blank cells from the cursor column to the end of the current row."""
+        row = self._grid[self._cursor_row]
+        for col in range(self._cursor_col, self.cols):
+            row[col] = Cell()
 
-def _cursor_back(screen: VirtualScreen, token: CSIToken) -> None:
-    """CUB: move cursor left N columns."""
-    screen._cursor_col -= max(1, _param_or(token, 0, 1))
-    screen._clamp_cursor()
+    def _erase_line_to_cursor(self) -> None:
+        """Blank cells from column 0 to and including the cursor column."""
+        row = self._grid[self._cursor_row]
+        for col in range(0, self._cursor_col + 1):
+            row[col] = Cell()
 
+    def _sgr(self, token: CSIToken) -> None:
+        """SGR: apply Select Graphic Rendition updates to current attributes."""
+        params = token.params or (0,)
+        attrs = set(self._attrs)
+        for raw in params:
+            code = 0 if raw < 0 else raw
+            if code == 0:
+                attrs.clear()
+            elif code == 1:
+                attrs.add(ATTR_BOLD)
+            elif code == 2:
+                attrs.add(ATTR_DIM)
+            elif code == 4:
+                attrs.add(ATTR_UNDERLINE)
+            elif code == 7:
+                attrs.add(ATTR_REVERSE)
+            elif code == 22:
+                attrs.discard(ATTR_BOLD)
+                attrs.discard(ATTR_DIM)
+            elif code == 24:
+                attrs.discard(ATTR_UNDERLINE)
+            elif code == 27:
+                attrs.discard(ATTR_REVERSE)
+        self._attrs = frozenset(attrs)
 
-def _cursor_position(screen: VirtualScreen, token: CSIToken) -> None:
-    """CUP: absolute cursor position (one-based)."""
-    row = max(1, _param_or(token, 0, 1)) - 1
-    col = max(1, _param_or(token, 1, 1)) - 1
-    screen._cursor_row = row
-    screen._cursor_col = col
-    screen._clamp_cursor()
-
-
-def _erase_in_display(screen: VirtualScreen, token: CSIToken) -> None:
-    """ED: erase in display. 0=after cursor, 1=before, 2=all."""
-    mode = _param_or(token, 0, 0)
-    if mode == 2:
-        screen.reset()
-        return
-    if mode == 0:
-        _erase_line_from_cursor(screen)
-        for row_index in range(screen._cursor_row + 1, screen.rows):
-            screen._grid[row_index] = screen._blank_row()
-    elif mode == 1:
-        _erase_line_to_cursor(screen)
-        for row_index in range(0, screen._cursor_row):
-            screen._grid[row_index] = screen._blank_row()
-
-
-def _erase_in_line(screen: VirtualScreen, token: CSIToken) -> None:
-    """EL: erase in line. 0=to end, 1=to start, 2=entire row."""
-    mode = _param_or(token, 0, 0)
-    if mode == 0:
-        _erase_line_from_cursor(screen)
-    elif mode == 1:
-        _erase_line_to_cursor(screen)
-    elif mode == 2:
-        screen._grid[screen._cursor_row] = screen._blank_row()
-
-
-def _erase_line_from_cursor(screen: VirtualScreen) -> None:
-    """Blank cells from the cursor column to the end of the row."""
-    row = screen._grid[screen._cursor_row]
-    for col in range(screen._cursor_col, screen.cols):
-        row[col] = Cell()
-
-
-def _erase_line_to_cursor(screen: VirtualScreen) -> None:
-    """Blank cells from column 0 to and including the cursor column."""
-    row = screen._grid[screen._cursor_row]
-    for col in range(0, screen._cursor_col + 1):
-        row[col] = Cell()
-
-
-def _sgr(screen: VirtualScreen, token: CSIToken) -> None:
-    """SGR: apply Select Graphic Rendition updates to current attributes."""
-    params = token.params or (0,)
-    attrs = set(screen._attrs)
-    for raw in params:
-        code = 0 if raw < 0 else raw
-        if code == 0:
-            attrs.clear()
-        elif code == 1:
-            attrs.add(ATTR_BOLD)
-        elif code == 2:
-            attrs.add(ATTR_DIM)
-        elif code == 4:
-            attrs.add(ATTR_UNDERLINE)
-        elif code == 7:
-            attrs.add(ATTR_REVERSE)
-        elif code == 22:
-            attrs.discard(ATTR_BOLD)
-            attrs.discard(ATTR_DIM)
-        elif code == 24:
-            attrs.discard(ATTR_UNDERLINE)
-        elif code == 27:
-            attrs.discard(ATTR_REVERSE)
-    screen._attrs = frozenset(attrs)
-
-
-def _set_column(screen: VirtualScreen, token: CSIToken) -> None:
-    """CHA: move cursor to absolute column (one-based)."""
-    col = max(1, _param_or(token, 0, 1)) - 1
-    screen._cursor_col = col
-    screen._clamp_cursor()
-
-
-_CSI_HANDLERS = {
-    "A": _cursor_up,
-    "B": _cursor_down,
-    "C": _cursor_forward,
-    "D": _cursor_back,
-    "G": _set_column,
-    "H": _cursor_position,
-    "f": _cursor_position,
-    "J": _erase_in_display,
-    "K": _erase_in_line,
-    "m": _sgr,
-}
+    _CSI_HANDLERS: ClassVar[dict[str, Callable[["VirtualScreen", CSIToken], None]]] = {
+        "A": _cursor_up,
+        "B": _cursor_down,
+        "C": _cursor_forward,
+        "D": _cursor_back,
+        "G": _set_column,
+        "H": _cursor_position,
+        "f": _cursor_position,
+        "J": _erase_in_display,
+        "K": _erase_in_line,
+        "m": _sgr,
+    }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,170 @@
+# ASAT Architecture
+
+This document describes how the Accessible Spatial Audio Terminal is
+organised. It is the first file a new contributor should read. Every
+design choice prioritises blind developers on Windows using a screen
+reader: keyboard-only operation, predictable event ordering, and
+self-voicing feedback without ever depending on colour or layout.
+
+## Goals
+
+* Self-voicing: every state change produces an auditable event.
+* Keyboard-first: no action requires a mouse, a pointer, or screen
+  coordinates.
+* Standard library only (Python >= 3.10): zero third-party runtime
+  dependencies. External backends (TTS engines, sound output) plug in
+  behind small `Protocol`-based interfaces.
+* Hyper-modular: each concern lives in its own file so contributions
+  can land independently and each module can be read in one sitting.
+* Deterministic: the `EventBus` runs synchronously and publishes to
+  handlers in registration order so tests and audio output never race.
+
+## Layered module map
+
+Modules are grouped here by layer. Arrows point from a caller to the
+module it depends on. Nothing below a layer calls into the layer above
+it; the event bus is the sole backchannel.
+
+```
+           +-----------------------------+
+           |  Presentation (future)      |
+           |  :settings editor, TUI skin |
+           +---------------+-------------+
+                           |
+           +---------------v-------------+
+           |  Audio engine               |
+           |  audio.py  audio_engine.py  |
+           |  audio_sink.py  tts.py      |
+           |  hrtf.py                    |
+           +---------------+-------------+
+                           |
+           +---------------v-------------+
+           |  Interaction layer          |
+           |  input_router.py            |
+           |  notebook.py  actions.py    |
+           |  output_cursor.py           |
+           +---------------+-------------+
+                           |
+           +---------------v-------------+
+           |  Parsing & TUI bridge       |
+           |  ansi.py  screen.py         |
+           |  interactive.py             |
+           |  tui_bridge.py              |
+           +---------------+-------------+
+                           |
+           +---------------v-------------+
+           |  Execution kernel           |
+           |  kernel.py  runner.py       |
+           |  execution.py               |
+           +---------------+-------------+
+                           |
+           +---------------v-------------+
+           |  Data + bus (foundation)    |
+           |  cell.py  session.py        |
+           |  events.py  event_bus.py    |
+           |  output_buffer.py           |
+           |  common.py  keys.py         |
+           +-----------------------------+
+```
+
+## Core value objects
+
+* `Cell` (`asat/cell.py`) – one notebook input/output interaction.
+  The only non-frozen core dataclass. See `asat/cell.py` docstring for
+  the mutation policy; subscribers that need a stable view call
+  `Cell.snapshot()`.
+* `Session` (`asat/session.py`) – ordered list of cells with save /
+  load.
+* `Event` (`asat/events.py`) – immutable `(event_type, payload,
+  source, timestamp)` record. Every publisher creates one via the
+  `publish_event(...)` helper in `asat/event_bus.py`.
+* `Key` (`asat/keys.py`) – frozen `(name, char, modifiers)` triple.
+  All input goes through this shape before reaching the router, which
+  keeps platform adapters pluggable.
+
+## Event bus
+
+`EventBus` (`asat/event_bus.py`) is a synchronous in-process
+publish/subscribe router. Subscribers register with either a concrete
+`EventType` or the `WILDCARD` ("*") string. Publishers use the
+`publish_event(bus, event_type, payload, *, source)` helper so the
+boilerplate of building `Event` objects stays in one place.
+
+Publishing order is strictly exact-type subscribers first, then
+wildcard subscribers. If any handler raises, the bus collects
+exceptions and re-raises an `EventBusError` after every handler has
+had a chance to react. This matters for audio: a broken voice must
+never silence the rest of the pipeline.
+
+## Event categories
+
+The authoritative list lives in `asat/events.py`. See
+[EVENTS.md](EVENTS.md) for each category, the producer, and the
+typical payload shape.
+
+## Focus model
+
+The user is always in exactly one of three focus modes, owned by
+`NotebookCursor` (`asat/notebook.py`):
+
+* `NOTEBOOK` – walking between cells.
+* `INPUT` – typing a command into the active cell.
+* `OUTPUT` – stepping line-by-line through a cell's captured output.
+
+Mode transitions publish `FOCUS_CHANGED`. The `InputRouter`
+(`asat/input_router.py`) looks up a keystroke under the current mode
+to find an action name, runs the matching handler, and publishes
+`KEY_PRESSED` + `ACTION_INVOKED`. See [INPUT.md](INPUT.md) for the
+binding table (to be added alongside the audio framework).
+
+## Execution path
+
+1. User types a command; `InputRouter` runs the `submit` action.
+2. `NotebookCursor.submit()` commits the input buffer into the
+   focused Cell and returns it.
+3. `ExecutionKernel.run(cell)` publishes `COMMAND_SUBMITTED`,
+   `COMMAND_STARTED`, streams `OUTPUT_CHUNK` / `ERROR_CHUNK`, then
+   either `COMMAND_COMPLETED` (exit code 0) or `COMMAND_FAILED`.
+4. `OutputRecorder` (`asat/output_buffer.py`) subscribes to the chunk
+   events and fills per-cell `OutputBuffer` instances, re-publishing
+   `OUTPUT_LINE_APPENDED` with structured per-line data.
+5. `TuiBridge` (`asat/tui_bridge.py`) can also consume raw stream text
+   to detect interactive menus via `AnsiParser` + `VirtualScreen` +
+   `interactive.detect(...)`, emitting `SCREEN_UPDATED` and the
+   `INTERACTIVE_MENU_*` lifecycle events.
+
+## Audio pipeline (Phase 3, to be rewired by the upcoming SoundBank)
+
+Today's `audio_engine.py` hard-codes a small routing table from event
+type to voice. The audio customization framework described in
+[AUDIO.md](AUDIO.md) (upcoming) replaces that table with a data-driven
+`SoundBank` so every event in the bus can be re-skinned via a JSON
+file edited through the in-terminal `:settings` mode.
+
+## Testing
+
+Every module ships a matching `tests/test_<module>.py` built on
+`unittest`. The full suite runs in under a second and is the
+expectation on every PR:
+
+```
+python -m unittest discover -s tests -t .
+```
+
+## Phase history
+
+The repo grew in strict phase-gated PRs. Each phase added a single
+layer and left the one below it unchanged:
+
+| Phase | Theme                                          |
+|-------|------------------------------------------------|
+| 1     | Data models + event bus                        |
+| 2     | Execution kernel + subprocess runner           |
+| 3     | Spatial audio engine (TTS, HRTF, sinks)        |
+| 4     | Input router + notebook cursor                 |
+| 5     | Output buffering + contextual action menu      |
+| 6     | ANSI parsing + virtual screen + menu detection |
+
+Future phases will land the audio customization framework (SoundBank,
+parametric sounds, generic AudioEngine, integrated settings editor)
+plus Windows-native TTS and sink adapters.

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -1,0 +1,157 @@
+# Event reference
+
+Every cross-module interaction in ASAT is an `Event` flowing through
+the `EventBus`. This page is the authoritative list: every category,
+the producer, and the payload fields a subscriber can rely on.
+
+`EventType` values are defined in `asat/events.py`. Publishers build
+and dispatch events via `publish_event(bus, event_type, payload, *,
+source)` from `asat/event_bus.py`.
+
+All events share the same envelope:
+
+| Field        | Type                  | Notes                                         |
+|--------------|-----------------------|-----------------------------------------------|
+| `event_type` | `EventType`           | The category (see tables below).              |
+| `payload`    | `dict[str, Any]`      | Shape depends on the category.                |
+| `source`     | `str`                 | Short name of the publishing module.          |
+| `timestamp`  | `datetime` (UTC)      | Set automatically at construction time.       |
+
+When designing a new subscriber, key off `event_type` only. `source`
+is informational (useful for debug logs or filtering) and can change
+over time.
+
+---
+
+## Session lifecycle
+
+Producer: `Session` serialization helpers (phase-2-onward caller code;
+no module publishes these automatically yet).
+
+| EventType         | Payload keys                      |
+|-------------------|-----------------------------------|
+| `SESSION_CREATED` | `session_id`                      |
+| `SESSION_LOADED`  | `session_id`, `path`              |
+| `SESSION_SAVED`   | `session_id`, `path`              |
+
+## Cell lifecycle
+
+Producer: `Session` mutators + `NotebookCursor` operations.
+
+| EventType      | Payload keys                             |
+|----------------|------------------------------------------|
+| `CELL_CREATED` | `cell_id`, `command`                     |
+| `CELL_UPDATED` | `cell_id`, `command`                     |
+| `CELL_REMOVED` | `cell_id`                                |
+| `CELL_MOVED`   | `cell_id`, `old_index`, `new_index`      |
+
+## Execution kernel
+
+Producer: `asat.kernel.ExecutionKernel` (`source="kernel"`).
+
+| EventType           | Payload keys                                         |
+|---------------------|------------------------------------------------------|
+| `COMMAND_SUBMITTED` | `cell_id`, `command`                                 |
+| `COMMAND_STARTED`   | `cell_id`                                            |
+| `COMMAND_COMPLETED` | `cell_id`, `exit_code`, `timed_out`                  |
+| `COMMAND_FAILED`    | `cell_id`, `exit_code`, `timed_out` or `error`/`error_type` when launch itself failed |
+| `COMMAND_CANCELLED` | `cell_id`                                            |
+
+## Output streaming
+
+Producer: `asat.kernel.ExecutionKernel` as the subprocess streams.
+
+| EventType      | Payload keys               |
+|----------------|----------------------------|
+| `OUTPUT_CHUNK` | `cell_id`, `line`          |
+| `ERROR_CHUNK`  | `cell_id`, `line`          |
+
+## Input + focus router
+
+Producer: `asat.input_router.InputRouter` (`source="input_router"`)
+and `asat.notebook.NotebookCursor` (`source="notebook"`).
+
+| EventType        | Payload keys                                                                   | Source          |
+|------------------|--------------------------------------------------------------------------------|-----------------|
+| `FOCUS_CHANGED`  | `old_mode`, `new_mode`, `old_cell_id`, `new_cell_id`, `input_buffer`           | `notebook`      |
+| `KEY_PRESSED`    | `name`, `char`, `modifiers`                                                    | `input_router`  |
+| `ACTION_INVOKED` | `action`, `focus_mode`, `cell_id`, `key_name`, plus action-specific extras     | `input_router`  |
+
+`ACTION_INVOKED` extras:
+
+* `submit` → `cell_id` (of the submitted cell), `command`
+* Every other action → no extras today
+
+## Output buffering and cursor
+
+Producers:
+
+* `asat.output_buffer.OutputRecorder` (`source="output_recorder"`)
+* `asat.output_cursor.OutputCursor` (`source="output_cursor"`)
+
+| EventType              | Payload keys                                          |
+|------------------------|-------------------------------------------------------|
+| `OUTPUT_LINE_APPENDED` | `cell_id`, `line_number`, `stream`, `text`            |
+| `OUTPUT_LINE_FOCUSED`  | `cell_id`, `line_number`, `stream`, `text`            |
+
+`stream` is always one of `"stdout"` or `"stderr"`.
+
+## Contextual action menu
+
+Producer: `asat.actions.ActionMenu` (`source="action_menu"`) plus the
+helper defined in `default_actions(...)` (`source="actions"`).
+
+| EventType                   | Payload keys                                                   |
+|-----------------------------|----------------------------------------------------------------|
+| `ACTION_MENU_OPENED`        | `focus_mode`, `cell_id`, `item_ids`, `labels`                  |
+| `ACTION_MENU_CLOSED`        | `focus_mode`, `cell_id`                                        |
+| `ACTION_MENU_ITEM_FOCUSED`  | `item_id`, `label`, `index`                                    |
+| `ACTION_MENU_ITEM_INVOKED`  | `item_id`, `label`, `focus_mode`, `cell_id`                    |
+
+## Clipboard
+
+Producer: `default_actions()` copy handlers (`source="actions"`).
+
+| EventType          | Payload keys                             |
+|--------------------|------------------------------------------|
+| `CLIPBOARD_COPIED` | `cell_id`, `source`, `length`            |
+
+`source` here is the *logical* label for what got copied
+(`"line"`, `"all"`, `"stderr"`, etc.), not the publishing module.
+
+## ANSI + interactive TUI mapping
+
+Producer: `asat.tui_bridge.TuiBridge` (`source="tui_bridge"`).
+
+| EventType                    | Payload keys                                                                 |
+|------------------------------|------------------------------------------------------------------------------|
+| `SCREEN_UPDATED`             | `cell_id`, `cursor_row`, `cursor_col`, `rows`                                |
+| `INTERACTIVE_MENU_DETECTED`  | `cell_id`, `detection`, `selected_index`, `selected_text`, `items`           |
+| `INTERACTIVE_MENU_UPDATED`   | same as `DETECTED`                                                           |
+| `INTERACTIVE_MENU_CLEARED`   | `cell_id`                                                                    |
+
+`detection` is one of `"reverse_video"` or `"prefix_marker"`. `items`
+is a tuple of dicts with `row`, `text`, `selected`.
+
+## Audio engine
+
+Producer: `asat.audio_engine.VoiceRouter` today; to be replaced by the
+data-driven `AudioEngine` described in [AUDIO.md](AUDIO.md).
+
+| EventType           | Payload keys                           |
+|---------------------|----------------------------------------|
+| `AUDIO_SPOKEN`      | `event_type`, `text`, `voice_id`       |
+| `AUDIO_INTERRUPTED` | `event_type`                           |
+
+---
+
+## Adding a new event
+
+1. Add the member to the `EventType` enum in `asat/events.py`.
+2. Document the payload in this file under the appropriate section.
+3. Publish it via `publish_event(bus, EventType.X, payload, source=...)`
+   from the producing module. Never hand-roll `Event(...)` — the
+   helper keeps construction uniform for future audit/correlation
+   fields.
+4. If the event is user-facing, add a default binding in the upcoming
+   SoundBank so it has an audio reaction out of the box.

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -103,5 +103,36 @@ class CellSerializationTests(unittest.TestCase):
         self.assertIsInstance(data["created_at"], str)
 
 
+class CellSnapshotTests(unittest.TestCase):
+    """snapshot() returns a detached copy safe to hand to subscribers."""
+
+    def test_snapshot_preserves_all_fields(self) -> None:
+        cell = Cell.new("echo hi", parent_id="p1")
+        cell.mark_completed(stdout="hi\n", stderr="", exit_code=0)
+        cell.metadata["label"] = "one"
+        snap = cell.snapshot()
+        self.assertEqual(snap.cell_id, cell.cell_id)
+        self.assertEqual(snap.command, cell.command)
+        self.assertEqual(snap.stdout, cell.stdout)
+        self.assertEqual(snap.exit_code, cell.exit_code)
+        self.assertEqual(snap.status, cell.status)
+        self.assertEqual(snap.parent_id, cell.parent_id)
+        self.assertEqual(snap.metadata, {"label": "one"})
+
+    def test_snapshot_is_detached_from_source(self) -> None:
+        cell = Cell.new("echo hi")
+        snap = cell.snapshot()
+        cell.mark_completed(stdout="done\n", stderr="", exit_code=0)
+        self.assertEqual(snap.stdout, "")
+        self.assertEqual(snap.status, CellStatus.PENDING)
+
+    def test_snapshot_metadata_is_independent(self) -> None:
+        cell = Cell.new("echo hi")
+        cell.metadata["k"] = "v"
+        snap = cell.snapshot()
+        cell.metadata["k"] = "mutated"
+        self.assertEqual(snap.metadata, {"k": "v"})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Four small, foundation-level changes batched together ahead of the audio customization framework. All behaviour-preserving; 271 tests pass.

### R2: encapsulate VirtualScreen CSI handlers
- Converted the ten CSI handler functions from module-level to bound methods on `VirtualScreen`; dispatch table is now a `ClassVar`.
- Added read-only `cursor_row`, `cursor_col`, and `attrs` properties.

### R4: Cell mutation policy + `snapshot()`
- Expanded `cell.py` docstring: only `ExecutionKernel` and `NotebookCursor` may mutate a Cell, and all mutation goes through the `mark_*` / `update_command` helpers.
- Added `Cell.snapshot()` returning a detached copy (metadata dict independently copied) so the upcoming audio engine can cache cell state from an event safely.

### R5: unify InputRouter action dispatch
- `_invoke()` no longer branches on `action == "submit"`. Every dispatch-table entry is an `ActionHandler` returning `Optional[dict[str, object]]` of extras to merge into `ACTION_INVOKED`.
- Side-effecting cursor helpers are wrapped in a tiny `_void()` so their incidental return values are discarded; `"submit"` is a regular entry backed by a small `_submit` helper.

### D1: docs/ skeleton
- `docs/ARCHITECTURE.md` – layered module map, value objects, event bus semantics, focus model, execution path, phase history.
- `docs/EVENTS.md` – authoritative payload reference for every `EventType`, grouped by producer, with a checklist for adding new events.

## Why

Everything here lays foundation for the audio customization framework: stable public APIs on `VirtualScreen`, a safe snapshot for `Cell`, a symmetric action table, and a written reference so new sound bindings can be proposed without reverse-engineering the code. Landing these together keeps the PR queue short — each change is tightly scoped to one file or one doc.

## Test plan

- [x] `python -m unittest discover -s tests -t .` — 271 passed (+3 new snapshot tests)
- [x] No public API removed, only added
- [x] `_cursor_` privates only accessed inside `VirtualScreen`
- [x] Docs render correctly as GitHub markdown