### PR TITLE
A1: SoundBank data model and JSON schema

### DIFF
--- a/asat/sound_bank.py
+++ b/asat/sound_bank.py
@@ -1,0 +1,420 @@
+"""SoundBank: the data model behind ASAT's parametric audio framework.
+
+A SoundBank tells the runtime what to do when each Event flies past on
+the bus. Rather than hard-coding a table in Python (which Phase 3's
+VoiceRouter does today) the mapping lives in data:
+
+    Voice       - a parametric TTS configuration. Engine, rate, pitch,
+                  volume, plus a spatial azimuth and elevation so the
+                  eventual audio engine can place voices in HRTF space.
+    SoundRecipe - a parametric non-speech cue. Recipes are categorised
+                  by `kind` (tone, chord, sample, silence) and their
+                  concrete parameters live in `params`. The generator
+                  phase (A2) consumes these to synthesise audio.
+    EventBinding - glue: given an EventType, optionally pick a voice
+                   and a sound recipe, decorate the narration with a
+                   template string, gate with a predicate, and order
+                   against sibling bindings via priority.
+
+The whole bank round-trips through JSON (see
+`asat/sound_bank_schema.json` for the file shape) so an end user can
+tune audio from a text editor or the upcoming in-terminal `:settings`
+mode.
+
+This module only handles the data layer: parsing, validating, looking
+up. Interpreting predicates and rendering templates is the AudioEngine
+(phase A3); synthesising sounds is the generator layer (phase A2).
+Keeping those layers separate means the bank can be stored, diffed,
+and tested without the audio stack running.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Optional
+
+
+SCHEMA_VERSION = 1
+
+SOUND_KINDS = ("tone", "chord", "sample", "silence")
+
+
+class SoundBankError(ValueError):
+    """Raised when a SoundBank document fails structural validation."""
+
+
+@dataclass(frozen=True)
+class Voice:
+    """Parametric TTS configuration for a single narrator voice.
+
+    `id` is the stable handle other records reference. `engine` names
+    the TTS backend (the Phase 3 stub engine, a future Windows SAPI
+    adapter, etc.); the empty string means "the default engine".
+
+    Rate / pitch / volume are multipliers around 1.0 so a user can
+    nudge a voice brighter or calmer without knowing absolute units.
+
+    Azimuth and elevation are degrees in the listener-centred HRTF
+    frame: azimuth ranges -180..180 (0 = straight ahead, +90 = right
+    ear), elevation ranges -90..90 (0 = eye level, +90 = overhead).
+    """
+
+    id: str
+    engine: str = ""
+    rate: float = 1.0
+    pitch: float = 1.0
+    volume: float = 1.0
+    azimuth: float = 0.0
+    elevation: float = 0.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this voice to a JSON-compatible dictionary."""
+        return {
+            "id": self.id,
+            "engine": self.engine,
+            "rate": self.rate,
+            "pitch": self.pitch,
+            "volume": self.volume,
+            "azimuth": self.azimuth,
+            "elevation": self.elevation,
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "Voice":
+        """Rebuild a Voice from a previously serialized mapping."""
+        _require(isinstance(data, Mapping), "voice entry must be a mapping")
+        _require("id" in data and isinstance(data["id"], str), "voice.id is required")
+        return cls(
+            id=data["id"],
+            engine=str(data.get("engine", "")),
+            rate=_positive_float(data.get("rate", 1.0), "voice.rate"),
+            pitch=_positive_float(data.get("pitch", 1.0), "voice.pitch"),
+            volume=_non_negative_float(data.get("volume", 1.0), "voice.volume"),
+            azimuth=_angle(data.get("azimuth", 0.0), "voice.azimuth", -180.0, 180.0),
+            elevation=_angle(data.get("elevation", 0.0), "voice.elevation", -90.0, 90.0),
+            metadata=dict(data.get("metadata", {}) or {}),
+        )
+
+
+@dataclass(frozen=True)
+class SoundRecipe:
+    """Parametric non-speech cue.
+
+    `kind` drives interpretation. Phase A2 will ship generators for
+    each supported kind; unknown kinds fail validation to keep JSON
+    files honest.
+
+    Common supported kinds:
+
+    tone
+        params: frequency (Hz), duration (s), waveform (str), attack,
+        release (s), harmonics (list of partial multipliers).
+    chord
+        params: frequencies (list[Hz]), duration, waveform, spread.
+    sample
+        params: path (str), loop (bool), start (s), end (s).
+    silence
+        params: duration (s). Useful for explicit gaps.
+
+    All recipes share `volume`, `azimuth`, `elevation` so the spatial
+    framework can place cues the same way it places voices.
+    """
+
+    id: str
+    kind: str
+    params: dict[str, Any] = field(default_factory=dict)
+    volume: float = 1.0
+    azimuth: float = 0.0
+    elevation: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this recipe to a JSON-compatible dictionary."""
+        return {
+            "id": self.id,
+            "kind": self.kind,
+            "params": dict(self.params),
+            "volume": self.volume,
+            "azimuth": self.azimuth,
+            "elevation": self.elevation,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "SoundRecipe":
+        """Rebuild a SoundRecipe from a previously serialized mapping."""
+        _require(isinstance(data, Mapping), "sound entry must be a mapping")
+        _require("id" in data and isinstance(data["id"], str), "sound.id is required")
+        kind = str(data.get("kind", ""))
+        _require(
+            kind in SOUND_KINDS,
+            f"sound.kind must be one of {SOUND_KINDS}, got {kind!r}",
+        )
+        params = data.get("params", {}) or {}
+        _require(isinstance(params, Mapping), "sound.params must be a mapping")
+        return cls(
+            id=data["id"],
+            kind=kind,
+            params=dict(params),
+            volume=_non_negative_float(data.get("volume", 1.0), "sound.volume"),
+            azimuth=_angle(data.get("azimuth", 0.0), "sound.azimuth", -180.0, 180.0),
+            elevation=_angle(data.get("elevation", 0.0), "sound.elevation", -90.0, 90.0),
+        )
+
+
+@dataclass(frozen=True)
+class EventBinding:
+    """Route one EventType to an optional voice, sound, and template.
+
+    `event_type` matches an `EventType.value` string (e.g. "cell.created").
+    `voice_id` / `sound_id` reference records in the same bank; at least
+    one of them must be set so the binding has some audible effect.
+
+    `say_template` is a Python `str.format_map`-style template rendered
+    against the event payload. Missing keys render as empty string
+    (handled by the engine in phase A3).
+
+    `predicate` is an opaque expression string the AudioEngine will
+    parse in A3. For A1 it is stored verbatim so the editor can round
+    trip it through JSON without loss.
+
+    `priority` orders sibling bindings when multiple match the same
+    event: higher priority runs first. `enabled=False` keeps a binding
+    in the bank but silences it without losing its parameters.
+    """
+
+    id: str
+    event_type: str
+    voice_id: Optional[str] = None
+    sound_id: Optional[str] = None
+    say_template: str = ""
+    predicate: str = ""
+    priority: int = 100
+    enabled: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this binding to a JSON-compatible dictionary."""
+        return {
+            "id": self.id,
+            "event_type": self.event_type,
+            "voice_id": self.voice_id,
+            "sound_id": self.sound_id,
+            "say_template": self.say_template,
+            "predicate": self.predicate,
+            "priority": self.priority,
+            "enabled": self.enabled,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "EventBinding":
+        """Rebuild an EventBinding from a previously serialized mapping."""
+        _require(isinstance(data, Mapping), "binding entry must be a mapping")
+        _require("id" in data and isinstance(data["id"], str), "binding.id is required")
+        _require(
+            "event_type" in data and isinstance(data["event_type"], str),
+            "binding.event_type is required",
+        )
+        voice_id = data.get("voice_id")
+        sound_id = data.get("sound_id")
+        say_template = str(data.get("say_template", ""))
+        _require(
+            voice_id or sound_id or say_template,
+            f"binding {data['id']!r} must set voice_id, sound_id, or say_template",
+        )
+        return cls(
+            id=data["id"],
+            event_type=data["event_type"],
+            voice_id=_optional_str(voice_id, "binding.voice_id"),
+            sound_id=_optional_str(sound_id, "binding.sound_id"),
+            say_template=say_template,
+            predicate=str(data.get("predicate", "")),
+            priority=int(data.get("priority", 100)),
+            enabled=bool(data.get("enabled", True)),
+        )
+
+
+@dataclass(frozen=True)
+class SoundBank:
+    """Complete audio configuration: voices + sounds + bindings.
+
+    A SoundBank is immutable. To edit one, build a new instance via
+    `replace_binding`, `with_voice`, etc. (added in A5) or mutate
+    through the upcoming settings editor which serialises via JSON.
+    """
+
+    voices: tuple[Voice, ...] = ()
+    sounds: tuple[SoundRecipe, ...] = ()
+    bindings: tuple[EventBinding, ...] = ()
+    version: int = SCHEMA_VERSION
+
+    def voice_for(self, voice_id: str) -> Optional[Voice]:
+        """Return the voice with this id, or None if it is missing."""
+        for voice in self.voices:
+            if voice.id == voice_id:
+                return voice
+        return None
+
+    def sound_for(self, sound_id: str) -> Optional[SoundRecipe]:
+        """Return the sound recipe with this id, or None if absent."""
+        for sound in self.sounds:
+            if sound.id == sound_id:
+                return sound
+        return None
+
+    def bindings_for(self, event_type: str, *, include_disabled: bool = False) -> tuple[EventBinding, ...]:
+        """Return bindings matching event_type, sorted by priority desc.
+
+        Enabled bindings come first by default; pass include_disabled
+        when an editor needs to surface the full list.
+        """
+        matches = [
+            binding
+            for binding in self.bindings
+            if binding.event_type == event_type
+            and (include_disabled or binding.enabled)
+        ]
+        matches.sort(key=lambda b: b.priority, reverse=True)
+        return tuple(matches)
+
+    def validate(self) -> None:
+        """Raise SoundBankError if internal references are inconsistent.
+
+        The JSON loader performs per-field validation; this method
+        catches cross-record issues the loader cannot: duplicate ids,
+        bindings that reference a missing voice or sound.
+        """
+        _unique_ids(self.voices, "voice")
+        _unique_ids(self.sounds, "sound")
+        _unique_ids(self.bindings, "binding")
+        voice_ids = {voice.id for voice in self.voices}
+        sound_ids = {sound.id for sound in self.sounds}
+        for binding in self.bindings:
+            if binding.voice_id is not None and binding.voice_id not in voice_ids:
+                raise SoundBankError(
+                    f"binding {binding.id!r} references unknown voice_id {binding.voice_id!r}"
+                )
+            if binding.sound_id is not None and binding.sound_id not in sound_ids:
+                raise SoundBankError(
+                    f"binding {binding.id!r} references unknown sound_id {binding.sound_id!r}"
+                )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the entire bank to a JSON-compatible dictionary."""
+        return {
+            "version": self.version,
+            "voices": [voice.to_dict() for voice in self.voices],
+            "sounds": [sound.to_dict() for sound in self.sounds],
+            "bindings": [binding.to_dict() for binding in self.bindings],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "SoundBank":
+        """Rebuild a SoundBank from a previously serialized mapping."""
+        _require(isinstance(data, Mapping), "sound bank must be a mapping")
+        version = int(data.get("version", SCHEMA_VERSION))
+        if version != SCHEMA_VERSION:
+            raise SoundBankError(
+                f"unsupported sound bank version {version} (expected {SCHEMA_VERSION})"
+            )
+        voices = tuple(Voice.from_dict(item) for item in data.get("voices", []) or ())
+        sounds = tuple(SoundRecipe.from_dict(item) for item in data.get("sounds", []) or ())
+        bindings = tuple(
+            EventBinding.from_dict(item) for item in data.get("bindings", []) or ()
+        )
+        bank = cls(voices=voices, sounds=sounds, bindings=bindings, version=version)
+        bank.validate()
+        return bank
+
+    @classmethod
+    def load(cls, path: Path | str) -> "SoundBank":
+        """Read a SoundBank from a JSON file previously written by save."""
+        source = Path(path)
+        try:
+            data = json.loads(source.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise SoundBankError(f"{source} is not valid JSON: {exc}") from exc
+        return cls.from_dict(data)
+
+    def save(self, path: Path | str) -> None:
+        """Write the bank as pretty-printed JSON to the given path."""
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(self.to_dict(), indent=2), encoding="utf-8")
+
+    def with_replaced(
+        self,
+        *,
+        voices: Optional[Iterable[Voice]] = None,
+        sounds: Optional[Iterable[SoundRecipe]] = None,
+        bindings: Optional[Iterable[EventBinding]] = None,
+    ) -> "SoundBank":
+        """Return a copy with any of the three lists replaced wholesale.
+
+        Kept tight on purpose: the full editor (A5) will provide
+        finer-grained helpers, but tests and migrations often want a
+        blunt "swap this section" operation.
+        """
+        return replace(
+            self,
+            voices=tuple(voices) if voices is not None else self.voices,
+            sounds=tuple(sounds) if sounds is not None else self.sounds,
+            bindings=tuple(bindings) if bindings is not None else self.bindings,
+        )
+
+
+def _require(condition: bool, message: str) -> None:
+    """Raise SoundBankError if condition is false."""
+    if not condition:
+        raise SoundBankError(message)
+
+
+def _positive_float(value: Any, label: str) -> float:
+    """Parse value as a float > 0 or raise SoundBankError."""
+    number = _as_float(value, label)
+    if number <= 0:
+        raise SoundBankError(f"{label} must be > 0, got {number}")
+    return number
+
+
+def _non_negative_float(value: Any, label: str) -> float:
+    """Parse value as a float >= 0 or raise SoundBankError."""
+    number = _as_float(value, label)
+    if number < 0:
+        raise SoundBankError(f"{label} must be >= 0, got {number}")
+    return number
+
+
+def _angle(value: Any, label: str, low: float, high: float) -> float:
+    """Parse value as a float clamped to [low, high]."""
+    number = _as_float(value, label)
+    if number < low or number > high:
+        raise SoundBankError(f"{label} must be in [{low}, {high}], got {number}")
+    return number
+
+
+def _as_float(value: Any, label: str) -> float:
+    """Best-effort float coercion with a clear error message."""
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise SoundBankError(f"{label} must be a number, got {value!r}") from exc
+
+
+def _optional_str(value: Any, label: str) -> Optional[str]:
+    """Coerce None-or-str cleanly, rejecting other types."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value or None
+    raise SoundBankError(f"{label} must be a string or null, got {type(value).__name__}")
+
+
+def _unique_ids(items: Iterable[Any], kind: str) -> None:
+    """Raise if any two items share the same `.id`."""
+    seen: set[str] = set()
+    for item in items:
+        if item.id in seen:
+            raise SoundBankError(f"duplicate {kind} id: {item.id!r}")
+        seen.add(item.id)

--- a/asat/sound_bank_schema.json
+++ b/asat/sound_bank_schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://asat.local/schemas/sound_bank.v1.json",
+  "title": "ASAT SoundBank",
+  "description": "Persisted form of asat.sound_bank.SoundBank. Consumed by both the runtime loader and the in-terminal :settings editor.",
+  "type": "object",
+  "required": ["version"],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version. Incremented when the on-disk shape changes; loaders refuse mismatched versions."
+    },
+    "voices": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/voice" },
+      "default": []
+    },
+    "sounds": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/sound" },
+      "default": []
+    },
+    "bindings": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/binding" },
+      "default": []
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "voice": {
+      "type": "object",
+      "required": ["id"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "engine": { "type": "string", "default": "" },
+        "rate": { "type": "number", "exclusiveMinimum": 0, "default": 1.0 },
+        "pitch": { "type": "number", "exclusiveMinimum": 0, "default": 1.0 },
+        "volume": { "type": "number", "minimum": 0, "default": 1.0 },
+        "azimuth": { "type": "number", "minimum": -180, "maximum": 180, "default": 0 },
+        "elevation": { "type": "number", "minimum": -90, "maximum": 90, "default": 0 },
+        "metadata": { "type": "object", "additionalProperties": true, "default": {} }
+      },
+      "additionalProperties": false
+    },
+    "sound": {
+      "type": "object",
+      "required": ["id", "kind"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "kind": {
+          "type": "string",
+          "enum": ["tone", "chord", "sample", "silence"]
+        },
+        "params": { "type": "object", "additionalProperties": true, "default": {} },
+        "volume": { "type": "number", "minimum": 0, "default": 1.0 },
+        "azimuth": { "type": "number", "minimum": -180, "maximum": 180, "default": 0 },
+        "elevation": { "type": "number", "minimum": -90, "maximum": 90, "default": 0 }
+      },
+      "additionalProperties": false
+    },
+    "binding": {
+      "type": "object",
+      "required": ["id", "event_type"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "event_type": {
+          "type": "string",
+          "description": "Matches an EventType.value (e.g. 'cell.created')."
+        },
+        "voice_id": { "type": ["string", "null"], "default": null },
+        "sound_id": { "type": ["string", "null"], "default": null },
+        "say_template": {
+          "type": "string",
+          "default": "",
+          "description": "Python str.format_map template rendered against the event payload."
+        },
+        "predicate": {
+          "type": "string",
+          "default": "",
+          "description": "Opaque guard expression evaluated by the AudioEngine. Empty string means always match."
+        },
+        "priority": { "type": "integer", "default": 100 },
+        "enabled": { "type": "boolean", "default": true }
+      },
+      "additionalProperties": false,
+      "description": "At least one of voice_id, sound_id, or a non-empty say_template must be set."
+    }
+  }
+}

--- a/tests/test_sound_bank.py
+++ b/tests/test_sound_bank.py
@@ -1,0 +1,256 @@
+"""Unit tests for the SoundBank data model."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from asat.sound_bank import (
+    EventBinding,
+    SCHEMA_VERSION,
+    SOUND_KINDS,
+    SoundBank,
+    SoundBankError,
+    SoundRecipe,
+    Voice,
+)
+
+
+def _sample_bank() -> SoundBank:
+    """Build a small valid bank reused across tests."""
+    voice = Voice(id="narrator", rate=1.1, pitch=0.95, azimuth=-15.0)
+    sound = SoundRecipe(
+        id="ding",
+        kind="tone",
+        params={"frequency": 880.0, "duration": 0.15, "waveform": "sine"},
+        volume=0.6,
+    )
+    binding = EventBinding(
+        id="cell_created",
+        event_type="cell.created",
+        voice_id="narrator",
+        sound_id="ding",
+        say_template="new cell {cell_id}",
+        priority=200,
+    )
+    return SoundBank(voices=(voice,), sounds=(sound,), bindings=(binding,))
+
+
+class VoiceTests(unittest.TestCase):
+
+    def test_voice_defaults_are_neutral(self) -> None:
+        voice = Voice(id="v1")
+        self.assertEqual(voice.engine, "")
+        self.assertEqual(voice.rate, 1.0)
+        self.assertEqual(voice.pitch, 1.0)
+        self.assertEqual(voice.volume, 1.0)
+        self.assertEqual(voice.azimuth, 0.0)
+        self.assertEqual(voice.elevation, 0.0)
+
+    def test_voice_round_trip_through_dict(self) -> None:
+        original = Voice(id="v1", engine="sapi", rate=1.2, azimuth=30.0)
+        restored = Voice.from_dict(original.to_dict())
+        self.assertEqual(restored, original)
+
+    def test_voice_rejects_missing_id(self) -> None:
+        with self.assertRaises(SoundBankError):
+            Voice.from_dict({"rate": 1.0})
+
+    def test_voice_rejects_zero_rate(self) -> None:
+        with self.assertRaises(SoundBankError):
+            Voice.from_dict({"id": "v1", "rate": 0})
+
+    def test_voice_rejects_out_of_range_azimuth(self) -> None:
+        with self.assertRaises(SoundBankError):
+            Voice.from_dict({"id": "v1", "azimuth": 200})
+
+
+class SoundRecipeTests(unittest.TestCase):
+
+    def test_all_documented_kinds_are_accepted(self) -> None:
+        for kind in SOUND_KINDS:
+            recipe = SoundRecipe.from_dict({"id": f"s_{kind}", "kind": kind})
+            self.assertEqual(recipe.kind, kind)
+
+    def test_unknown_kind_rejected(self) -> None:
+        with self.assertRaises(SoundBankError):
+            SoundRecipe.from_dict({"id": "s1", "kind": "banana"})
+
+    def test_params_must_be_mapping(self) -> None:
+        with self.assertRaises(SoundBankError):
+            SoundRecipe.from_dict({"id": "s1", "kind": "tone", "params": [1, 2]})
+
+    def test_recipe_round_trip_preserves_params(self) -> None:
+        recipe = SoundRecipe(
+            id="chord1", kind="chord", params={"frequencies": [440.0, 660.0]}
+        )
+        restored = SoundRecipe.from_dict(recipe.to_dict())
+        self.assertEqual(restored, recipe)
+
+
+class EventBindingTests(unittest.TestCase):
+
+    def test_binding_requires_some_effect(self) -> None:
+        with self.assertRaises(SoundBankError):
+            EventBinding.from_dict({"id": "b1", "event_type": "cell.created"})
+
+    def test_binding_accepts_template_only(self) -> None:
+        binding = EventBinding.from_dict(
+            {
+                "id": "b1",
+                "event_type": "cell.created",
+                "say_template": "hello",
+            }
+        )
+        self.assertEqual(binding.say_template, "hello")
+        self.assertIsNone(binding.voice_id)
+        self.assertIsNone(binding.sound_id)
+
+    def test_binding_null_voice_id_round_trips(self) -> None:
+        binding = EventBinding.from_dict(
+            {
+                "id": "b1",
+                "event_type": "cell.created",
+                "voice_id": None,
+                "sound_id": "ding",
+            }
+        )
+        self.assertIsNone(binding.voice_id)
+        self.assertEqual(binding.sound_id, "ding")
+
+    def test_binding_priority_defaults_to_100(self) -> None:
+        binding = EventBinding.from_dict(
+            {"id": "b1", "event_type": "cell.created", "sound_id": "ding"}
+        )
+        self.assertEqual(binding.priority, 100)
+        self.assertTrue(binding.enabled)
+
+
+class SoundBankStructureTests(unittest.TestCase):
+
+    def test_empty_bank_is_valid(self) -> None:
+        bank = SoundBank()
+        bank.validate()
+        self.assertEqual(bank.voices, ())
+        self.assertEqual(bank.version, SCHEMA_VERSION)
+
+    def test_lookup_helpers_return_records(self) -> None:
+        bank = _sample_bank()
+        self.assertEqual(bank.voice_for("narrator").rate, 1.1)
+        self.assertEqual(bank.sound_for("ding").kind, "tone")
+        bindings = bank.bindings_for("cell.created")
+        self.assertEqual(len(bindings), 1)
+
+    def test_lookup_helpers_return_none_for_missing_ids(self) -> None:
+        bank = _sample_bank()
+        self.assertIsNone(bank.voice_for("ghost"))
+        self.assertIsNone(bank.sound_for("ghost"))
+        self.assertEqual(bank.bindings_for("unused.event"), ())
+
+    def test_bindings_sorted_by_priority_desc(self) -> None:
+        voice = Voice(id="v1")
+        bindings = (
+            EventBinding(id="b_low", event_type="cell.created", voice_id="v1", priority=10),
+            EventBinding(id="b_hi", event_type="cell.created", voice_id="v1", priority=500),
+            EventBinding(id="b_mid", event_type="cell.created", voice_id="v1", priority=100),
+        )
+        bank = SoundBank(voices=(voice,), bindings=bindings)
+        ordered = bank.bindings_for("cell.created")
+        self.assertEqual([b.id for b in ordered], ["b_hi", "b_mid", "b_low"])
+
+    def test_disabled_bindings_hidden_by_default(self) -> None:
+        voice = Voice(id="v1")
+        bindings = (
+            EventBinding(id="on", event_type="cell.created", voice_id="v1"),
+            EventBinding(id="off", event_type="cell.created", voice_id="v1", enabled=False),
+        )
+        bank = SoundBank(voices=(voice,), bindings=bindings)
+        self.assertEqual([b.id for b in bank.bindings_for("cell.created")], ["on"])
+        full = bank.bindings_for("cell.created", include_disabled=True)
+        self.assertEqual({b.id for b in full}, {"on", "off"})
+
+
+class SoundBankValidationTests(unittest.TestCase):
+
+    def test_duplicate_voice_ids_rejected(self) -> None:
+        bank = SoundBank(voices=(Voice(id="v"), Voice(id="v")))
+        with self.assertRaises(SoundBankError):
+            bank.validate()
+
+    def test_binding_pointing_at_missing_voice_rejected(self) -> None:
+        bank = SoundBank(
+            bindings=(
+                EventBinding(id="b", event_type="cell.created", voice_id="ghost"),
+            )
+        )
+        with self.assertRaises(SoundBankError):
+            bank.validate()
+
+    def test_binding_pointing_at_missing_sound_rejected(self) -> None:
+        bank = SoundBank(
+            bindings=(
+                EventBinding(id="b", event_type="cell.created", sound_id="ghost"),
+            )
+        )
+        with self.assertRaises(SoundBankError):
+            bank.validate()
+
+
+class SoundBankSerializationTests(unittest.TestCase):
+
+    def test_dict_round_trip_is_equal(self) -> None:
+        bank = _sample_bank()
+        restored = SoundBank.from_dict(bank.to_dict())
+        self.assertEqual(restored, bank)
+
+    def test_load_from_path_returns_equal_bank(self) -> None:
+        bank = _sample_bank()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bank.json"
+            bank.save(path)
+            restored = SoundBank.load(path)
+        self.assertEqual(restored, bank)
+
+    def test_save_creates_parent_directories(self) -> None:
+        bank = _sample_bank()
+        with tempfile.TemporaryDirectory() as tmp:
+            nested = Path(tmp) / "a" / "b" / "bank.json"
+            bank.save(nested)
+            self.assertTrue(nested.exists())
+
+    def test_loader_rejects_wrong_version(self) -> None:
+        bank = _sample_bank().to_dict()
+        bank["version"] = 999
+        with self.assertRaises(SoundBankError):
+            SoundBank.from_dict(bank)
+
+    def test_loader_rejects_malformed_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bad.json"
+            path.write_text("{not valid json")
+            with self.assertRaises(SoundBankError):
+                SoundBank.load(path)
+
+    def test_with_replaced_swaps_lists(self) -> None:
+        bank = _sample_bank()
+        new_voice = Voice(id="alt")
+        updated = bank.with_replaced(voices=(new_voice,))
+        self.assertEqual(updated.voices, (new_voice,))
+        self.assertEqual(updated.sounds, bank.sounds)
+        self.assertEqual(updated.bindings, bank.bindings)
+
+
+class JsonSchemaFileTests(unittest.TestCase):
+
+    def test_schema_file_is_valid_json(self) -> None:
+        schema_path = Path(__file__).resolve().parents[1] / "asat" / "sound_bank_schema.json"
+        data = json.loads(schema_path.read_text(encoding="utf-8"))
+        self.assertEqual(data["properties"]["version"]["const"], SCHEMA_VERSION)
+        kinds = data["$defs"]["sound"]["properties"]["kind"]["enum"]
+        self.assertEqual(tuple(kinds), SOUND_KINDS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

First PR of the audio customization framework: the data layer. No runtime wiring yet; the bank is just parsed, validated, and served to lookups. Pure additive change — 299 tests pass (+28 new).

### What lands

- `asat/sound_bank.py` — frozen dataclasses for the whole model:
  - `Voice` — parametric TTS config (engine, rate, pitch, volume, azimuth, elevation, metadata).
  - `SoundRecipe` — parametric non-speech cue keyed by `kind` (`tone`, `chord`, `sample`, `silence`) with kind-specific params; shares volume/azimuth/elevation with voices.
  - `EventBinding` — glues an `EventType` value to an optional voice, sound, and `say_template`, plus a predicate, priority, and enabled flag.
  - `SoundBank` — the container. Provides `voice_for`, `sound_for`, `bindings_for` lookups, cross-record `validate()`, `to_dict` / `from_dict`, `load` / `save`, and a blunt `with_replaced` helper.
- `asat/sound_bank_schema.json` — JSON Schema draft-2020-12 describing the persisted form. Cross-linked from the Python loader.
- `tests/test_sound_bank.py` — 28 unit tests covering defaults, serialization, validation, lookups, and schema integrity.

### Design choices worth calling out

- **Stdlib-only**: uses `json` + `dataclasses`; no new dependencies.
- **Predicates and templates are opaque strings in A1.** Interpretation lives in A3 (`AudioEngine`). This keeps the data layer free of runtime concerns and safe to share with editors and linters.
- **Everything is frozen.** Edits produce new banks via `with_replaced` (A1) or via richer helpers the `:settings` editor will add in A5.
- **Schema version pinned at 1.** Mismatched versions fail fast so future migrations are explicit.

### Why

The user's request was "a framework of adding and customizing the sounds, generated audio, or speech output with full parametric customization [...] a huge JSON with simple editor [...] thousands of iterations". Landing the data model first means the generator (A2), engine (A3), default bank (A4), and editor (A5) can each plug into a stable shape instead of reshaping each other.

## Test plan

- [x] `python -m unittest discover -s tests -t .` — 299 passed (+28 new)
- [x] Schema file validated as JSON and cross-checked against the Python constants
- [x] Round-trip tests confirm save → load produces the identical bank