### PR TITLE
docs: refresh developer + user docs, add README and feature-requests log

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# ASAT — Accessible Spatial Audio Terminal
+
+A self-voicing notebook-style terminal for blind developers on Windows.
+Every state change — a keystroke, a command completion, a menu
+highlight, an ANSI event — flows through one synchronous event bus
+and can be bound to a spoken phrase or a spatialised tone. Keyboard
+only, standard-library only, no mouse, no screen coordinates.
+
+## Install and run
+
+Requires Python 3.10 or newer. No runtime dependencies (`numpy` is an
+optional accelerator for measured HRTFs only).
+
+```
+git clone https://github.com/KyleKeane/space-time-termonal
+cd space-time-termonal
+python -m unittest discover -s tests -t .
+```
+
+The test suite is the current entry point; an end-user binary is on
+the roadmap (see `docs/FEATURE_REQUESTS.md`).
+
+## Documentation map
+
+* [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — layered module map,
+  focus model, execution path. Read this first.
+* [docs/USER_MANUAL.md](docs/USER_MANUAL.md) — keystroke cheat sheet,
+  modes, troubleshooting.
+* [docs/EVENTS.md](docs/EVENTS.md) — every event type and its payload.
+* [docs/AUDIO.md](docs/AUDIO.md) — voices, recipes, HRTF, spatialiser.
+* [docs/CLAUDE_CODE_MODES.md](docs/CLAUDE_CODE_MODES.md) — sonification
+  targets for the Claude Code TUI.
+* [docs/FEATURE_REQUESTS.md](docs/FEATURE_REQUESTS.md) — open gaps for
+  the next generation.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,9 +11,12 @@ self-voicing feedback without ever depending on colour or layout.
 * Self-voicing: every state change produces an auditable event.
 * Keyboard-first: no action requires a mouse, a pointer, or screen
   coordinates.
-* Standard library only (Python >= 3.10): zero third-party runtime
-  dependencies. External backends (TTS engines, sound output) plug in
-  behind small `Protocol`-based interfaces.
+* Standard library only (Python >= 3.10): no third-party runtime
+  dependencies. `numpy` is used opportunistically by `asat/hrtf.py`
+  as an optional accelerator for dense (measured) HRTF kernels; the
+  synthetic profiles shipped by default run pure-Python on a
+  sparse-impulse fast path. External backends (TTS engines, sound
+  output) plug in behind small `Protocol`-based interfaces.
 * Hyper-modular: each concern lives in its own file so contributions
   can land independently and each module can be read in one sitting.
 * Deterministic: the `EventBus` runs synchronously and publishes to
@@ -119,8 +122,10 @@ The user is always in exactly one of four focus modes, owned by
 Mode transitions publish `FOCUS_CHANGED`. The `InputRouter`
 (`asat/input_router.py`) looks up a keystroke under the current mode
 to find an action name, runs the matching handler, and publishes
-`KEY_PRESSED` + `ACTION_INVOKED`. See [INPUT.md](INPUT.md) for the
-binding table (to be added alongside the audio framework).
+`KEY_PRESSED` + `ACTION_INVOKED`. The default binding table per mode
+is printed in [USER_MANUAL.md](USER_MANUAL.md#the-keystroke-cheat-sheet);
+the authoritative source is `default_bindings()` in
+`asat/input_router.py`.
 
 ## Execution path
 
@@ -172,7 +177,11 @@ layer and left the one below it unchanged:
 | 4     | Input router + notebook cursor                 |
 | 5     | Output buffering + contextual action menu      |
 | 6     | ANSI parsing + virtual screen + menu detection |
-| A     | Data-driven audio framework and settings editor |
+| A     | Data-driven audio framework (generators, engine, default bank, editor) |
+| T     | Follow-up polish: TUI wiring, ANSI-level events + per-binding overrides, docs |
+| H     | HRTF sparse-impulse fast path (synthetic profiles bypass full convolution) |
 
-Future phases will add Windows-native TTS and sink adapters plus the
-live-speaker playback stack.
+Open feature requests for the next generation live in
+[FEATURE_REQUESTS.md](FEATURE_REQUESTS.md); the short version is
+Windows-native TTS, live-speaker sinks, settings-editor record
+creation, and command history.

--- a/docs/AUDIO.md
+++ b/docs/AUDIO.md
@@ -220,12 +220,36 @@ so a typo fails loudly at load time.
 
 ## Spatialisation: HRTF
 
-`asat/hrtf.py` holds a synthetic head-related transfer function. The
+`asat/hrtf.py` holds the head-related transfer function pipeline. The
 `Spatializer` convolves a mono buffer with a left / right IR pair
 derived from a `SpatialPosition(azimuth, elevation)`. Two sources at
 different azimuths arrive at different inter-aural times and gains,
 which is enough for the ear to hear "left of centre" vs. "right of
 centre" even through cheap headphones.
+
+Two ways to obtain a profile:
+
+* `HRTFProfile.synthetic(position)` — builds a sparse impulse-response
+  pair (one nonzero tap per ear) modelling only the inter-aural time
+  and level difference. This is the shipping default. It is not a
+  substitute for a measured HRTF but is enough for front-vs-side and
+  left-vs-right discrimination on headphones.
+* `HRTFProfile.from_stereo_wav(path)` — loads a stereo WAV whose two
+  channels are the left-ear and right-ear impulse responses. This is
+  the shape most SOFA-derived HRIR datasets land in after conversion.
+
+`convolve(signal, kernel)` branches on kernel shape:
+
+1. Sparse impulse (one nonzero tap) — delay-and-scale in O(n). Every
+   synthetic profile takes this path; no third-party import needed.
+2. All-zero kernel — returns a zero buffer of length `n + m − 1`.
+3. Dense kernel — `numpy.convolve` when `numpy` is importable, else a
+   pure-Python fallback. Measured HRTFs (128–512 taps) benefit from
+   the numpy path by ~1000× on long narration buffers; without numpy
+   the fallback still produces correct audio, only slower.
+
+numpy is therefore an optional accelerator only — `pip install numpy`
+is never a requirement for ASAT to run.
 
 Conventions used by every module:
 

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -25,8 +25,12 @@ over time.
 
 ## Session lifecycle
 
-Producer: `Session` serialization helpers (phase-2-onward caller code;
-no module publishes these automatically yet).
+Producer: caller code that owns a `Session` — today ASAT does not yet
+ship an automatic publisher for these. Embedding code (the eventual
+entry-point binary) is expected to fire them around `Session`
+construction, `Session.load(...)`, and `Session.save(...)`. Bindings
+in the default bank are already wired so narration lights up the
+instant a producer appears.
 
 | EventType         | Payload keys                      |
 |-------------------|-----------------------------------|
@@ -80,7 +84,10 @@ and `asat.notebook.NotebookCursor` (`source="notebook"`).
 `ACTION_INVOKED` extras:
 
 * `submit` → `cell_id` (of the submitted cell), `command`
-* Every other action → no extras today
+* `insert_character` → `char` (the literal character that was inserted)
+* `settings_edit_extend` → `char` (the literal character appended to
+  the in-progress settings edit buffer)
+* Every other action → no extras
 
 ## Output buffering and cursor
 

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -1,0 +1,177 @@
+# Feature requests
+
+Open gaps in ASAT — things the codebase does not yet do but should, in
+roughly the next generation. Each entry explains what is missing, where
+the gap surfaces today, and a sketch of what the fix would look like.
+
+This file is descriptive, not prescriptive: priorities and scheduling
+live in the PR queue.
+
+---
+
+## F1 — Cancel a running command
+
+**Gap.** There is no INPUT-mode keybinding to cancel a command that
+is currently running. The `COMMAND_CANCELLED` event type exists and
+the default bank binds a cue to it, but nothing publishes it today.
+
+**Where it surfaces.**
+[USER_MANUAL.md](USER_MANUAL.md) explicitly notes: "Cancelling a
+running command is a future keyboard binding; for now let commands
+finish or send `:quit` to bail out of the whole session."
+
+**Sketch.** Bind `Ctrl+C` in INPUT mode to a `cancel_command`
+action. `ExecutionKernel` already owns the subprocess; add a
+`cancel(cell_id)` method that terminates it and publishes
+`COMMAND_CANCELLED`.
+
+---
+
+## F2 — Settings editor: create / delete records
+
+**Gap.** `SettingsEditor` can edit fields on existing `Voice`,
+`SoundRecipe`, and `EventBinding` records, but has no "add new" or
+"delete" operations. Users who want a new record today have to edit
+the bank JSON on disk and restart.
+
+**Where it surfaces.**
+[USER_MANUAL.md](USER_MANUAL.md) troubleshooting — "I want a brand-new
+sound" — has to route users out to a file editor.
+
+**Sketch.** Add `create_record(section)` and `delete_record()` to
+`SettingsEditor`, surface them as key actions in `SettingsController`
+(e.g. `a` = add, `d` = delete, with a confirmation step on delete).
+Defaults for a fresh record are obvious (`Voice()` neutral,
+`SoundRecipe(kind="silence")`, `EventBinding()` disabled).
+
+---
+
+## F3 — Reload bank from disk
+
+**Gap.** Ctrl+S writes the in-memory bank to disk; there is no inverse
+that discards uncommitted edits and reloads the last saved bank.
+
+**Where it surfaces.** A user experimenting with settings can only
+undo by remembering every edit they made, or by closing the editor
+and reopening it (which does not reload from disk — the session still
+holds the live bank).
+
+**Sketch.** Add `SettingsEditor.reload(path)` that calls
+`SoundBank.load(path)` and swaps the active bank after a confirmation
+prompt. Bind to a keystroke (Ctrl+R) in SETTINGS mode.
+
+---
+
+## F4 — Command history
+
+**Gap.** Up / Down in INPUT mode do nothing. There is no way to recall
+or search past commands.
+
+**Where it surfaces.** Every real terminal has this; its absence is
+felt the first time a user wants to repeat the previous command.
+
+**Sketch.** Extend `Session` with an ordered list of commands
+submitted this session. Bind Up / Down in INPUT mode to walk it;
+Ctrl+R opens reverse-incremental search (a small overlay state
+machine mirroring the approach `SettingsEditor` already uses).
+
+---
+
+## F5 — Windows-native TTS adapter
+
+**Gap.** The shipping `ToneTTSEngine` is a parametric tone generator
+— useful as a self-contained default but not a real voice. On Windows
+the obvious target is SAPI / OneCore TTS via `pywin32` (or `ctypes`
+to avoid adding a dep).
+
+**Where it surfaces.** [ARCHITECTURE.md](ARCHITECTURE.md) phase
+history lists this as a next-generation item.
+
+**Sketch.** Implement the `TTSEngine` protocol against SAPI,
+expose a `SapiTTSEngine` class, let the user pick it via the `engine`
+field on `Voice`. Add a Voice-level routing step in `SoundEngine`
+that picks the right engine by id. Keep `ToneTTSEngine` as the
+deterministic fallback for headless tests.
+
+---
+
+## F6 — Live-speaker audio sink
+
+**Gap.** `AudioSink` ships with `MemorySink` (accumulates buffers for
+tests) and `WavFileSink` (writes to disk). Neither plays audio on
+actual speakers, so the terminal is silent end-to-end until a real
+sink exists.
+
+**Where it surfaces.** [ARCHITECTURE.md](ARCHITECTURE.md) phase
+history calls this out as future work.
+
+**Sketch.** Wrap `winsound` (stdlib) or `sounddevice` for low-latency
+playback; implement the `AudioSink` protocol. Buffer management and
+sample-rate coercion already live in `AudioBuffer`.
+
+---
+
+## F7 — Default binding for OSC 133 semantic prompt
+
+**Gap.** `ANSI_OSC_RECEIVED` is emitted and
+[CLAUDE_CODE_MODES.md](CLAUDE_CODE_MODES.md) points at OSC 133 as a
+prompt-boundary signal, but the default bank has no OSC 133 binding.
+
+**Where it surfaces.** Users running shells that emit OSC 133 (zsh
+with powerlevel, starship, etc.) get a useful stream of prompt /
+command / output markers but hear nothing unless they add a binding.
+
+**Sketch.** Add a predicate-gated `ANSI_OSC_RECEIVED` binding in
+`asat/default_bank.py` that matches `body` starting with `133;` and
+routes to `system` voice with a short tone on prompt-ready. Test it
+with a recorded fixture.
+
+---
+
+## F8 — Measured HRTF loader for end users
+
+**Gap.** `HRTFProfile.from_stereo_wav` exists and the `convolve`
+fast-path correctly handles dense kernels, but there is no user
+surface for swapping in a measured HRTF. Today it requires editing
+Python code.
+
+**Where it surfaces.** [AUDIO.md](AUDIO.md) mentions the loader but
+does not document a user path to it.
+
+**Sketch.** Add an `hrtf_path` field to the top-level `SoundBank`
+(optional; null → synthetic). `SoundEngine` loads the measured
+profile at `set_bank(...)` and uses it for every spatialised cue.
+Document the SOFA-to-stereo-WAV conversion recipe in AUDIO.md.
+
+---
+
+## F9 — Root README.md
+
+**Gap.** The repo root has no README.md — anyone landing on GitHub
+sees a directory listing with no entry point.
+
+**Where it surfaces.** First-contact experience for contributors and
+users alike.
+
+**Sketch.** Short landing page (~30 lines) with: one-paragraph
+description, install / run snippet, pointer into `docs/`.
+Status: addressed by the same PR that ships this file.
+
+---
+
+## How to add an entry
+
+Append a section using the template:
+
+```
+## F<N> — <short name>
+
+**Gap.** <what the code does not do today>
+
+**Where it surfaces.** <user-visible consequence or doc citation>
+
+**Sketch.** <rough implementation approach>
+```
+
+Keep entries small and user-facing. Cross-cutting infrastructure
+changes (testing, CI) belong in a separate log.

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -303,10 +303,19 @@ Open `:settings`, navigate to the offending binding, press `e` on
 `enabled`, type `false`, Enter, then Ctrl+S. The binding is silenced
 but still in the bank so you can re-enable it later.
 
-**I want a new sound for an event.**
-Open `:settings`, add a new `SoundRecipe` in the `sounds` section
-(id, kind, params, volume, azimuth), then find the binding in
-`bindings` and set `sound_id` to your new recipe's id. Ctrl+S.
+**I want to reuse a different existing sound for an event.**
+Open `:settings`, walk to `bindings`, find the binding you want to
+retune, descend to its `sound_id` field, press `e`, type the id of
+another `SoundRecipe` in the bank, Enter, Ctrl+S.
+
+**I want a brand-new sound that does not yet exist in the bank.**
+The in-terminal editor today can retune existing records but cannot
+create new voices, sounds, or bindings (see
+[FEATURE_REQUESTS.md](FEATURE_REQUESTS.md) F2). To add one now: edit
+the on-disk bank JSON directly, add a `SoundRecipe` object (give it
+an `id`, `kind`, and `params`), update the relevant binding's
+`sound_id` to your new id, then reopen ASAT — the new bank loads on
+start-up.
 
 **Output is too fast to follow.**
 The `narrator` voice's `rate` field is a multiplier. Open


### PR DESCRIPTION
## Summary

End-to-end pass over every doc to match the current codebase, plus
two new entry points so first-contact experience is reasonable.

### New files

- `README.md` (repo root) — one-paragraph description, install/test
  snippet, documentation map. Previously the repo root had no
  landing page.
- `docs/FEATURE_REQUESTS.md` — next-generation gap log (F1-F9)
  capturing things the codebase does not yet do but should: cancel
  running command, editor create/delete records, bank reload,
  command history, SAPI TTS adapter, live-speaker `AudioSink`,
  default OSC 133 binding, measured-HRTF user loader, root README.

### Doc updates (match current code)

- `docs/ARCHITECTURE.md` — goals now describe numpy as an optional
  accelerator for dense HRTFs only; phase history gains rows T
  (TUI wiring + docs) and H (HRTF sparse-impulse fast path);
  points at `FEATURE_REQUESTS.md`.
- `docs/EVENTS.md` — `ACTION_INVOKED` extras table now lists
  `insert_character → char` and `settings_edit_extend → char`
  (previously missing); session-lifecycle producer note rewritten
  to clarify that embedding code is expected to fire these.
- `docs/AUDIO.md` — HRTF section expanded to cover the
  synthetic sparse-impulse vs measured dense-kernel distinction
  and the three-way `convolve` branching introduced in #12.
- `docs/USER_MANUAL.md` — split the "I want a new sound for an
  event" troubleshooting entry into two: retune-existing via the
  editor (supported today), and create-brand-new via on-disk JSON
  (the editor can't add records yet — tracked as F2).

## Test plan

- [x] `python -m unittest discover -s tests -t .` — 428/428 green
- [x] Every `docs/*.md` link resolves to a file in the repo
- [x] No changes to `asat/` or `tests/` — purely doc/README updates
