### PR TITLE
First-launch polish: text trace, Windows live audio, session lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,46 @@ optional accelerator for measured HRTFs only).
 git clone https://github.com/KyleKeane/space-time-termonal
 cd space-time-termonal
 python -m unittest discover -s tests -t .
-python -m asat                       # launch an interactive session
-python -m asat --wav-dir /tmp/asat   # also write every rendered buffer to WAV
 ```
 
-A live-speaker audio sink is still on the feature list
-([F6](docs/FEATURE_REQUESTS.md)); until it lands, `--wav-dir` is how
-you actually hear the narration — open the WAVs in a screen-reader
-friendly player.
+### Launching a session
+
+```
+python -m asat                      # interactive session, text trace on stdout
+python -m asat --live               # also play audio on the speaker (Windows today)
+python -m asat --wav-dir /tmp/asat  # also write every rendered buffer to WAV
+python -m asat --quiet              # suppress the text trace, audio only
+```
+
+The CLI prints a short text trace as you work — a startup banner, your
+keystrokes as you type, the `$ command` you submit, the captured
+output, and a `[done exit=0]` line when each command finishes. That
+trace exists so sighted viewers and anyone debugging can follow along;
+the audio pipeline is the primary UI.
+
+**Audio today.** `--live` uses `winsound` on Windows (stdlib, no
+dependencies) and plays each rendered buffer through the speaker. On
+macOS and Linux the live sink is not yet available — `--live` falls
+back to the in-memory sink with a message, and `--wav-dir DIR`
+captures every buffer as a numbered WAV you can review. Live POSIX
+playback is tracked as [F6](docs/FEATURE_REQUESTS.md#f6--live-speaker-audio-sink).
+
+### Five-minute tour
+
+1. `python -m asat --live` (on Windows) or `python -m asat --wav-dir /tmp/asat`
+   (elsewhere). The session-start chime plays; the trace prints
+   `[asat] session <id> ready. :quit to exit.`
+2. Type a command — `echo hi`, `python --version`, `git status`. Each
+   keystroke narrates (audio) and echoes (text).
+3. Press **Enter**. The trace prints `$ <command>`, the command runs,
+   output streams, and `[done exit=0]` closes it out.
+4. Press **Ctrl+N** for a new cell, **Up/Down** to walk between cells,
+   **Ctrl+O** to enter OUTPUT mode and step through captured lines,
+   **Ctrl+,** to open the live settings editor.
+5. Type `:quit` + Enter (or Ctrl+D on POSIX / Ctrl+Z-Enter on Windows)
+   to exit.
+
+Full keystroke cheat sheet: [docs/USER_MANUAL.md](docs/USER_MANUAL.md).
 
 ## Documentation map
 

--- a/asat/__init__.py
+++ b/asat/__init__.py
@@ -53,7 +53,16 @@ from asat.audio import (
     VoicePreset,
     VoiceProfile,
 )
-from asat.audio_sink import AudioSink, MemorySink, WavFileSink, write_wav
+from asat.audio_sink import (
+    AudioSink,
+    LiveAudioUnavailable,
+    MemorySink,
+    WavFileSink,
+    WindowsLiveAudioSink,
+    buffer_to_wav_bytes,
+    pick_live_sink,
+    write_wav,
+)
 from asat.cell import Cell, CellStatus
 from asat.default_bank import COVERED_EVENT_TYPES, default_sound_bank
 from asat.event_bus import EventBus
@@ -77,6 +86,7 @@ from asat.output_cursor import OutputCursor
 from asat.runner import ProcessRunner
 from asat.screen import Cell as ScreenCell, ScreenSnapshot, VirtualScreen
 from asat.session import Session
+from asat.terminal import TerminalRenderer
 from asat.settings_controller import SettingsController
 from asat.settings_editor import SettingsEditor
 from asat.sound_bank import EventBinding, SoundBank, SoundRecipe, Voice
@@ -117,6 +127,7 @@ __all__ = [
     "InputRouter",
     "InteractiveMenu",
     "Key",
+    "LiveAudioUnavailable",
     "KeyboardReader",
     "MemoryClipboard",
     "MemorySink",
@@ -144,6 +155,7 @@ __all__ = [
     "SpatialPosition",
     "Spatializer",
     "TTSEngine",
+    "TerminalRenderer",
     "TextToken",
     "Token",
     "ToneTTSEngine",
@@ -154,6 +166,8 @@ __all__ = [
     "VoiceProfile",
     "WavFileSink",
     "WindowsKeyboard",
+    "WindowsLiveAudioSink",
+    "buffer_to_wav_bytes",
     "convolve",
     "default_actions",
     "default_bindings",
@@ -161,6 +175,7 @@ __all__ = [
     "detect",
     "generate_sound",
     "pick_default_keyboard",
+    "pick_live_sink",
     "write_wav",
 ]
 

--- a/asat/__main__.py
+++ b/asat/__main__.py
@@ -1,16 +1,22 @@
 """Launch the Accessible Spatial Audio Terminal from the command line.
 
 `python -m asat` assembles an Application with sensible defaults and
-drives it from real keystrokes. Press Enter to submit a command,
-Ctrl+N to open a fresh cell, Ctrl+, to edit settings, and type
-`:quit` (then Enter) or send EOF (Ctrl+D) to exit. The default
-keystroke cheat sheet lives in docs/USER_MANUAL.md.
+drives it from real keystrokes. By default the session narrates to an
+in-memory sink (so every platform starts cleanly) and prints a small
+text trace to stdout (so sighted viewers and anyone debugging can
+follow along). The flags below switch the two knobs:
 
-Audio sinks today: `MemorySink` by default (accumulates in RAM),
-`WavFileSink` when `--wav-dir` is given. A live-speaker sink is
-still on the feature list (see docs/FEATURE_REQUESTS.md, F6);
-until it lands, `--wav-dir DIR` is how a user actually hears the
-narration — open the WAVs in a screen-reader-friendly player.
+    --live          play audio through the platform live-speaker sink
+                    (Windows today; POSIX falls back to MemorySink
+                    with an explanation).
+    --wav-dir DIR   additionally write every rendered buffer to a
+                    numbered WAV file under DIR.
+    --quiet         suppress the text trace on stdout (audio only).
+
+Exit with the `:quit` meta-command (type `:quit` in INPUT mode then
+press Enter) or by sending EOF (Ctrl+D on POSIX, Ctrl+Z then Enter on
+Windows). The full keystroke cheat sheet lives in
+docs/USER_MANUAL.md.
 """
 
 from __future__ import annotations
@@ -21,16 +27,23 @@ from pathlib import Path
 from typing import Optional, Sequence
 
 from asat.app import Application
-from asat.audio_sink import AudioSink, MemorySink, WavFileSink
+from asat.audio_sink import (
+    AudioSink,
+    LiveAudioUnavailable,
+    MemorySink,
+    WavFileSink,
+    pick_live_sink,
+)
 from asat.keyboard import KeyboardReader, pick_default
 from asat.session import Session
 from asat.sound_bank import SoundBank
+from asat.terminal import TerminalRenderer
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
     """Parse args, build the Application, and drive the read-dispatch loop."""
     args = _parse_args(argv)
-    sink = _make_sink(args.wav_dir)
+    sink = _make_sink(args.wav_dir, args.live)
     bank = SoundBank.load(args.bank) if args.bank is not None else None
     session = Session.load(args.session) if args.session is not None else None
     app = Application.build(
@@ -40,10 +53,16 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         session=session,
         session_path=args.session,
     )
+    if not args.quiet:
+        # Attach AFTER Application.build so the renderer does not
+        # double-print the startup banner into its own buffer.
+        TerminalRenderer(app.bus)
     keyboard: KeyboardReader = pick_default()
     try:
         _run(app, keyboard)
     except KeyboardInterrupt:
+        # Clean exit on Ctrl+C during a blocking read. A real cancel
+        # keystroke is tracked as F10 in docs/FEATURE_REQUESTS.md.
         pass
     finally:
         keyboard.close()
@@ -69,10 +88,28 @@ def _parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
         description="Launch the Accessible Spatial Audio Terminal.",
     )
     parser.add_argument(
+        "--live",
+        action="store_true",
+        help=(
+            "Play audio on the platform live-speaker sink. Today this "
+            "means winsound on Windows; POSIX hosts fall back to the "
+            "in-memory sink with an explanation."
+        ),
+    )
+    parser.add_argument(
         "--wav-dir",
         type=Path,
         default=None,
-        help="Write each rendered buffer to a numbered WAV file in this directory.",
+        help=(
+            "Also write each rendered buffer to a numbered WAV file in "
+            "this directory. Useful for off-device review or when "
+            "--live is not available."
+        ),
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress the text trace on stdout. Audio output is unaffected.",
     )
     parser.add_argument(
         "--bank",
@@ -89,12 +126,52 @@ def _parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def _make_sink(wav_dir: Optional[Path]) -> AudioSink:
-    """Return a WAV-writing sink when a directory is given, else a MemorySink."""
+def _make_sink(wav_dir: Optional[Path], live: bool) -> AudioSink:
+    """Compose the sink chain based on the requested flags.
+
+    Priority: `--live` drives the primary sink when available.
+    `--wav-dir DIR` can be layered on either the live sink or the
+    default MemorySink. When `--live` is requested on a platform
+    without a live backend, we print a short explanation and continue
+    with MemorySink so the session still starts.
+    """
+    primary: AudioSink
+    if live:
+        try:
+            primary = pick_live_sink()
+        except LiveAudioUnavailable as exc:
+            print(f"[asat] --live unavailable: {exc}", file=sys.stderr)
+            primary = MemorySink()
+    else:
+        primary = MemorySink()
     if wav_dir is None:
-        return MemorySink()
+        return primary
     wav_dir.mkdir(parents=True, exist_ok=True)
-    return WavFileSink(wav_dir)
+    wav_sink = WavFileSink(wav_dir)
+    return _TeeSink(primary, wav_sink)
+
+
+class _TeeSink:
+    """Dispatch each buffer to two underlying sinks.
+
+    Private to the CLI because no other layer needs it today. If
+    multi-sink composition grows into a real feature, promote this to
+    `asat/audio_sink.py`.
+    """
+
+    def __init__(self, first: AudioSink, second: AudioSink) -> None:
+        self._first = first
+        self._second = second
+
+    def play(self, buffer) -> None:
+        self._first.play(buffer)
+        self._second.play(buffer)
+
+    def close(self) -> None:
+        try:
+            self._first.close()
+        finally:
+            self._second.close()
 
 
 if __name__ == "__main__":

--- a/asat/app.py
+++ b/asat/app.py
@@ -26,7 +26,7 @@ from typing import Optional
 
 from asat.audio_sink import AudioSink, MemorySink
 from asat.default_bank import default_sound_bank
-from asat.event_bus import EventBus
+from asat.event_bus import EventBus, publish_event
 from asat.events import Event, EventType
 from asat.input_router import InputRouter, default_bindings
 from asat.kernel import ExecutionKernel
@@ -95,8 +95,6 @@ class Application:
         seeded = session is None
         resolved_session = session if session is not None else Session.new()
         cursor = NotebookCursor(resolved_session, bus)
-        if seeded:
-            cursor.new_cell()
         kernel = ExecutionKernel(bus)
         recorder = OutputRecorder(bus)
         output_cursor = OutputCursor(bus)
@@ -115,7 +113,7 @@ class Application:
         )
         resolved_sink: AudioSink = sink if sink is not None else MemorySink()
         sound_engine = SoundEngine(bus, resolved_bank, resolved_sink)
-        return cls(
+        app = cls(
             bus=bus,
             session=resolved_session,
             cursor=cursor,
@@ -128,6 +126,27 @@ class Application:
             settings_controller=settings_controller,
             session_path=Path(session_path) if session_path is not None else None,
         )
+        # Everything below fires AFTER sound_engine has subscribed, so
+        # the launch narration actually plays through the sink.
+        publish_event(
+            bus,
+            EventType.SESSION_CREATED,
+            {"session_id": resolved_session.session_id},
+            source="app",
+        )
+        if not seeded and session_path is not None:
+            publish_event(
+                bus,
+                EventType.SESSION_LOADED,
+                {
+                    "session_id": resolved_session.session_id,
+                    "path": str(session_path),
+                },
+                source="app",
+            )
+        if seeded:
+            cursor.new_cell()
+        return app
 
     def handle_key(self, key: Key) -> Optional[str]:
         """Dispatch a keystroke and return the action name, if any.
@@ -152,6 +171,15 @@ class Application:
         """Flush the sink and persist the session if a path was given."""
         if self.session_path is not None:
             self.session.save(self.session_path)
+            publish_event(
+                self.bus,
+                EventType.SESSION_SAVED,
+                {
+                    "session_id": self.session.session_id,
+                    "path": str(self.session_path),
+                },
+                source="app",
+            )
         self.sink.close()
 
     def _on_action_invoked(self, event: Event) -> None:

--- a/asat/audio_sink.py
+++ b/asat/audio_sink.py
@@ -7,21 +7,30 @@ without spinning up audio hardware, and future playback backends
 (sounddevice, an ALSA wrapper, a Windows WASAPI wrapper) plug in the
 same way.
 
-Phase 3 ships two sinks:
+The shipping sinks are:
 
 - MemorySink accumulates every buffer it receives. Tests use it to
-  verify the pipeline's output directly.
+  verify the pipeline's output directly, and it is the CLI default so
+  `python -m asat` always starts cleanly on any OS.
 - WavFileSink writes each buffer to disk as 16-bit PCM. Useful for
   debugging and for listening to the output when no audio device is
-  available in the current environment.
+  available.
+- WindowsLiveAudioSink plays buffers through `winsound.PlaySound` on
+  Windows. It is the first sink that produces actual audio on real
+  speakers; call `pick_live_sink()` from the CLI to select it on the
+  target platform.
 
-A live speaker sink will be added in a later phase when the audio
-hardware dependency is in scope.
+POSIX live playback is still on the roadmap (see
+docs/FEATURE_REQUESTS.md, F6). `pick_live_sink()` raises
+`LiveAudioUnavailable` on non-Windows hosts so the CLI can fall back
+to `MemorySink` with a clear message.
 """
 
 from __future__ import annotations
 
+import io
 import struct
+import sys
 import wave
 from pathlib import Path
 from typing import Protocol
@@ -101,14 +110,37 @@ class WavFileSink:
 def write_wav(path: Path | str, buffer: AudioBuffer) -> None:
     """Write the given buffer to a 16-bit PCM WAV file at path."""
     channels = 2 if buffer.layout == ChannelLayout.STEREO else 1
-    clamped = [_clamp(value) for value in buffer.samples]
-    int_samples = [int(value * 32767) for value in clamped]
-    packed = struct.pack("<" + "h" * len(int_samples), *int_samples)
+    packed = _pcm16_bytes(buffer)
     with wave.open(str(path), "wb") as writer:
         writer.setnchannels(channels)
         writer.setsampwidth(2)
         writer.setframerate(buffer.sample_rate)
         writer.writeframes(packed)
+
+
+def buffer_to_wav_bytes(buffer: AudioBuffer) -> bytes:
+    """Return a full in-memory WAV file (header + PCM) for the given buffer.
+
+    Live sinks that accept a complete WAV blob — notably Windows'
+    `winsound.PlaySound` with `SND_MEMORY` — use this helper so the
+    file layout matches what `write_wav` produces on disk.
+    """
+    channels = 2 if buffer.layout == ChannelLayout.STEREO else 1
+    packed = _pcm16_bytes(buffer)
+    with io.BytesIO() as memory:
+        with wave.open(memory, "wb") as writer:
+            writer.setnchannels(channels)
+            writer.setsampwidth(2)
+            writer.setframerate(buffer.sample_rate)
+            writer.writeframes(packed)
+        return memory.getvalue()
+
+
+def _pcm16_bytes(buffer: AudioBuffer) -> bytes:
+    """Quantise `buffer.samples` to little-endian signed 16-bit PCM."""
+    clamped = [_clamp(value) for value in buffer.samples]
+    int_samples = [int(value * 32767) for value in clamped]
+    return struct.pack("<" + "h" * len(int_samples), *int_samples)
 
 
 def _clamp(value: float) -> float:
@@ -118,3 +150,65 @@ def _clamp(value: float) -> float:
     if value < -1.0:
         return -1.0
     return value
+
+
+class LiveAudioUnavailable(RuntimeError):
+    """Raised when a live speaker sink cannot be constructed on this host.
+
+    The CLI catches this, prints a friendly explanation, and falls back
+    to `MemorySink` so the session still starts instead of crashing.
+    """
+
+
+class WindowsLiveAudioSink:
+    """Play each buffer through `winsound.PlaySound`.
+
+    Each `play()` builds a tiny in-memory WAV and calls `PlaySound`
+    with `SND_MEMORY | SND_ASYNC`. The flags mean:
+
+    - `SND_MEMORY`: data is the WAV bytes themselves, not a filename.
+    - `SND_ASYNC`: return immediately; the OS mixes playback on its
+      own thread. The next `play()` will interrupt any previous
+      asynchronous clip that is still going, which matches the
+      "latest event wins" behaviour we want for keystroke feedback.
+
+    The sink imports `winsound` lazily so this module still loads on
+    POSIX hosts (where the rest of the repo continues to work against
+    `MemorySink` / `WavFileSink`).
+    """
+
+    def __init__(self) -> None:
+        """Import winsound or raise `LiveAudioUnavailable`."""
+        try:
+            import winsound  # noqa: F401  # imported for availability check
+        except ImportError as exc:
+            raise LiveAudioUnavailable(
+                "winsound is only available on Windows",
+            ) from exc
+        self._winsound = __import__("winsound")
+
+    def play(self, buffer: AudioBuffer) -> None:
+        """Render the buffer to a WAV blob and hand it to PlaySound."""
+        data = buffer_to_wav_bytes(buffer)
+        flags = self._winsound.SND_MEMORY | self._winsound.SND_ASYNC
+        self._winsound.PlaySound(data, flags)
+
+    def close(self) -> None:
+        """Stop any in-flight playback so the process exits quietly."""
+        self._winsound.PlaySound(None, self._winsound.SND_PURGE)
+
+
+def pick_live_sink() -> AudioSink:
+    """Return the live sink that fits this host, or raise.
+
+    Today only Windows has a live implementation. POSIX hosts get a
+    clear `LiveAudioUnavailable` so the CLI can tell the user what to
+    do (use `--wav-dir DIR` today; live POSIX is F6).
+    """
+    if sys.platform.startswith("win"):
+        return WindowsLiveAudioSink()
+    raise LiveAudioUnavailable(
+        "no live audio sink is available on this platform yet — "
+        "use --wav-dir DIR to capture the output as WAV files "
+        "(tracked as FEATURE_REQUESTS.md F6)",
+    )

--- a/asat/terminal.py
+++ b/asat/terminal.py
@@ -1,0 +1,124 @@
+"""TerminalRenderer: a minimal text view of the event stream.
+
+The audio pipeline is the primary UI; this renderer exists so sighted
+developers can see what ASAT is doing, and so `python -m asat` feels
+like a terminal rather than a silent black hole. Every line it writes
+is derived from one event on the bus.
+
+What gets printed:
+
+- `SESSION_CREATED`: one-line banner naming the session.
+- `FOCUS_CHANGED`: a one-line status like `[input #1]` whenever the
+  mode or focused cell changes.
+- `ACTION_INVOKED` with action == `insert_character`: the literal
+  character (so the user sees their typing, because cbreak disabled
+  echo).
+- `ACTION_INVOKED` with action == `backspace` in INPUT mode: `\\b \\b`
+  to visually erase the last echoed character.
+- `OUTPUT_CHUNK`: the captured stdout line.
+- `ERROR_CHUNK`: the captured stderr line, prefixed with `! ` so the
+  sighted viewer can tell them apart.
+- `COMMAND_COMPLETED` / `COMMAND_FAILED`: one-line summary with the
+  exit code.
+- `SESSION_SAVED`: one-line confirmation.
+
+The renderer intentionally does NOT render spatial hints or timing;
+that's the audio engine's job. The point is "enough text so the user
+is not flying blind." A `--quiet` switch in the CLI disables it.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TextIO
+
+from asat.event_bus import EventBus
+from asat.events import Event, EventType
+
+
+class TerminalRenderer:
+    """Subscribe to the bus and write a minimal visible trace to a stream."""
+
+    def __init__(self, bus: EventBus, stream: TextIO | None = None) -> None:
+        """Attach to the bus and remember where to write (defaults to stdout)."""
+        self._bus = bus
+        self._stream = stream if stream is not None else sys.stdout
+        self._at_line_start = True
+        bus.subscribe(EventType.SESSION_CREATED, self._on_session_created)
+        bus.subscribe(EventType.SESSION_LOADED, self._on_session_loaded)
+        bus.subscribe(EventType.SESSION_SAVED, self._on_session_saved)
+        bus.subscribe(EventType.FOCUS_CHANGED, self._on_focus_changed)
+        bus.subscribe(EventType.ACTION_INVOKED, self._on_action_invoked)
+        bus.subscribe(EventType.OUTPUT_CHUNK, self._on_output_chunk)
+        bus.subscribe(EventType.ERROR_CHUNK, self._on_error_chunk)
+        bus.subscribe(EventType.COMMAND_COMPLETED, self._on_command_completed)
+        bus.subscribe(EventType.COMMAND_FAILED, self._on_command_failed)
+
+    def _write_line(self, text: str) -> None:
+        """Print a full line, ending any in-flight keystroke echo first."""
+        if not self._at_line_start:
+            self._stream.write("\n")
+        self._stream.write(text)
+        self._stream.write("\n")
+        self._stream.flush()
+        self._at_line_start = True
+
+    def _write_inline(self, text: str) -> None:
+        """Echo raw characters without a trailing newline (for typing feedback)."""
+        self._stream.write(text)
+        self._stream.flush()
+        self._at_line_start = False
+
+    def _on_session_created(self, event: Event) -> None:
+        session_id = event.payload.get("session_id", "?")
+        self._write_line(f"[asat] session {session_id} ready. :quit to exit.")
+
+    def _on_session_loaded(self, event: Event) -> None:
+        path = event.payload.get("path", "?")
+        self._write_line(f"[asat] loaded session from {path}.")
+
+    def _on_session_saved(self, event: Event) -> None:
+        path = event.payload.get("path", "?")
+        self._write_line(f"[asat] saved session to {path}.")
+
+    def _on_focus_changed(self, event: Event) -> None:
+        mode = event.payload.get("new_mode", "?")
+        cell_id = event.payload.get("new_cell_id")
+        suffix = f" #{cell_id[:6]}" if isinstance(cell_id, str) else ""
+        self._write_line(f"[{mode}{suffix}]")
+
+    def _on_action_invoked(self, event: Event) -> None:
+        action = event.payload.get("action")
+        if action == "insert_character":
+            char = event.payload.get("char", "")
+            if isinstance(char, str) and char:
+                self._write_inline(char)
+        elif action == "backspace":
+            # Visually undo the last echoed character; harmless if the
+            # cell already had no echoed content (the terminal just
+            # beeps or clamps).
+            self._write_inline("\b \b")
+        elif action == "submit":
+            if event.payload.get("meta_command") is None:
+                command = event.payload.get("command", "")
+                self._write_line(f"$ {command}")
+
+    def _on_output_chunk(self, event: Event) -> None:
+        line = event.payload.get("line", "")
+        self._write_line(str(line))
+
+    def _on_error_chunk(self, event: Event) -> None:
+        line = event.payload.get("line", "")
+        self._write_line(f"! {line}")
+
+    def _on_command_completed(self, event: Event) -> None:
+        exit_code = event.payload.get("exit_code", 0)
+        self._write_line(f"[done exit={exit_code}]")
+
+    def _on_command_failed(self, event: Event) -> None:
+        payload = event.payload
+        if "error" in payload:
+            self._write_line(f"[failed: {payload['error']}]")
+        else:
+            exit_code = payload.get("exit_code", "?")
+            self._write_line(f"[failed exit={exit_code}]")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,7 +32,7 @@ it; the event bus is the sole backchannel.
            +-----------------------------+
            |  Entry point                |
            |  __main__.py  app.py        |
-           |  keyboard.py                |
+           |  keyboard.py  terminal.py   |
            +---------------+-------------+
                            |
            +---------------v-------------+
@@ -187,6 +187,7 @@ layer and left the one below it unchanged:
 | T     | Follow-up polish: TUI wiring, ANSI-level events + per-binding overrides, docs |
 | H     | HRTF sparse-impulse fast path (synthetic profiles bypass full convolution) |
 | E     | End-to-end entry point: Application wiring, keyboard adapter, `python -m asat` |
+| E2    | First-launch polish: TerminalRenderer, SESSION_* publishes, WindowsLiveAudioSink, `--live` / `--quiet` |
 
 ## Entry point
 
@@ -200,6 +201,25 @@ submitted and hand each to `Application.execute(cell_id)`.
 `asat/keyboard.py` hosts the `PosixKeyboard` and `WindowsKeyboard`
 adapters (plus a `ScriptedKeyboard` for tests); the rest of ASAT
 never touches terminal input APIs directly.
+
+Three supporting modules round the entry point out:
+
+* `asat/terminal.py` — `TerminalRenderer` subscribes to the bus and
+  prints a minimal text trace (startup banner, keystroke echo,
+  submitted `$ command` line, output chunks, `[done exit=...]`). The
+  audio pipeline is the primary UI; the renderer exists so sighted
+  viewers and anyone debugging have a readable mirror of the event
+  stream. `--quiet` switches it off.
+* `asat/audio_sink.py::WindowsLiveAudioSink` — the first sink that
+  produces actual audio on real speakers, via `winsound.PlaySound`
+  with `SND_MEMORY | SND_ASYNC`. Selected by `--live`.
+  `pick_live_sink()` is the one place the CLI asks "what live backend
+  does this host offer?"; POSIX raises `LiveAudioUnavailable` today
+  (tracked as FEATURE_REQUESTS.md F6).
+* `asat/app.py::Application.build` publishes `SESSION_CREATED` after
+  the SoundEngine has subscribed so the startup chime actually plays
+  through the sink, and emits `SESSION_LOADED` / `SESSION_SAVED` at
+  the matching boundaries.
 
 Open feature requests for the next generation live in
 [FEATURE_REQUESTS.md](FEATURE_REQUESTS.md); the short version is

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -95,21 +95,37 @@ deterministic fallback for headless tests.
 
 ---
 
-## F6 — Live-speaker audio sink
+## F6 — Live-speaker audio sink (POSIX)
 
-**Gap.** `AudioSink` ships with `MemorySink` (accumulates buffers for
-tests) and `WavFileSink` (writes to disk). Neither plays audio on
-actual speakers, so the `python -m asat` entry point is silent
-end-to-end until a real sink exists — `--wav-dir DIR` is the current
-workaround, but it only lets the user hear each buffer after the
-fact.
+**Status.** Windows live playback shipped (`WindowsLiveAudioSink` in
+`asat/audio_sink.py`, selected by `python -m asat --live`). The
+remaining gap is POSIX.
 
-**Where it surfaces.** Anyone launching ASAT today without
-`--wav-dir` gets a self-voicing terminal whose voice goes to `/dev/null`.
+**Gap.** On macOS and Linux, `pick_live_sink()` raises
+`LiveAudioUnavailable` and the CLI falls back to `MemorySink` with a
+message. There is no stdlib-only live audio backend on POSIX — every
+candidate (`winsound`) is Windows-only, and `subprocess`-ing `aplay`
+/ `afplay` has latency and availability problems.
 
-**Sketch.** Wrap `winsound` (stdlib) or `sounddevice` for low-latency
-playback; implement the `AudioSink` protocol. Buffer management and
-sample-rate coercion already live in `AudioBuffer`.
+**Where it surfaces.** `python -m asat --live` on Linux or macOS
+prints `[asat] --live unavailable: ...` and continues silently. Users
+today have to pair `--wav-dir DIR` with a WAV player, which is
+asynchronous and awkward.
+
+**Sketch.** Two reasonable paths:
+
+1. **Stdlib `subprocess` dispatch.** Write each buffer to a temp WAV
+   and invoke `/usr/bin/afplay` (macOS) or `aplay`/`paplay` (Linux).
+   Simple, no deps, but latency is ~50-150 ms per buffer — noticeable
+   for keystroke feedback.
+2. **Small C extension via `ctypes`.** Bind to CoreAudio (macOS) or
+   ALSA (Linux) directly. Better latency, no new Python deps, but
+   non-trivial to build and test.
+
+Either way the implementation goes in `asat/audio_sink.py` behind
+the same `AudioSink` protocol, and `pick_live_sink()` learns new
+branches. A queueing strategy (drop in-flight keystroke cues when a
+narration voice starts) should be designed together with this.
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -16,17 +16,46 @@ need to trigger is a key.
 ## Launching a session
 
 ```
-python -m asat                       # interactive session, MemorySink
-python -m asat --wav-dir /tmp/asat   # also write every buffer to WAV
-python -m asat --bank mybank.json    # start from a saved SoundBank
-python -m asat --session s.json      # resume an existing session
+python -m asat                      # interactive session, text trace on stdout
+python -m asat --live               # play audio on the speaker (Windows today)
+python -m asat --wav-dir /tmp/asat  # also write every rendered buffer to WAV
+python -m asat --quiet              # suppress the text trace, audio only
+python -m asat --bank mybank.json   # start from a saved SoundBank
+python -m asat --session s.json     # resume an existing session; saved on exit
 ```
 
-Every flag is optional. Without `--wav-dir`, audio is rendered into
-an in-memory sink; that is useful for tests and for debugging the
-event stream, but a blind user who wants real sound today needs
-`--wav-dir DIR` and a WAV-capable player. A live-speaker sink is
-tracked as [FEATURE_REQUESTS F6](FEATURE_REQUESTS.md#f6--live-speaker-audio-sink).
+Every flag is optional and they compose. The common launch recipes:
+
+- **On Windows:** `python -m asat --live`. You hear the session-start
+  chime and every subsequent narration on the speaker. The text trace
+  on stdout is secondary; most users will want `--quiet` once they
+  are comfortable driving by ear alone.
+- **On macOS/Linux today:** `python -m asat --wav-dir /tmp/asat`.
+  Each rendered buffer is written to a numbered WAV under
+  `/tmp/asat`. Live playback is being worked on
+  (FEATURE_REQUESTS.md F6); until then, WAV capture plus a
+  screen-reader-friendly player is the recommended path.
+- **Resume a session:** `python -m asat --session work.json`. The
+  session loads, you hear a "loaded" narration, and the same file is
+  rewritten on exit with whatever cells you ran this time.
+
+### What you should hear and see on launch
+
+The moment the binary starts:
+
+1. **Audio.** A short rising chime (the SESSION_CREATED binding in
+   the default SoundBank) plays from directly overhead, followed by
+   the `focus_shift` cue as the cursor drops into INPUT mode on the
+   first empty cell. If you hear neither, your sink is silent —
+   re-launch with `--live` (Windows) or `--wav-dir DIR` (elsewhere)
+   and check the `[asat]` line that `--wav-dir` produces.
+2. **Text trace (unless `--quiet`).** One line reading
+   `[asat] session <id> ready. :quit to exit.`, then
+   `[input #<short-id>]` to confirm you are in INPUT mode.
+
+If neither the chime nor the banner appear, the session did not
+start cleanly — see the troubleshooting table at the end of this
+file.
 
 ---
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -129,5 +129,45 @@ class ApplicationPersistenceTests(unittest.TestCase):
             self.assertTrue(path.exists())
 
 
+class ApplicationSessionEventTests(unittest.TestCase):
+    """Verify the session lifecycle events fire at the right boundaries.
+
+    SESSION_CREATED fires inside `build()`, before any caller can
+    subscribe directly on the Application's bus, so we witness it
+    through a `RecordingSink` that passively receives every narration
+    the SoundEngine produces for the SESSION_CREATED binding in the
+    default bank. SESSION_SAVED is easier: it fires inside `close()`,
+    which callers can hook before invoking.
+    """
+
+    def test_build_records_a_narration_for_session_created(self) -> None:
+        # The default bank binds SESSION_CREATED to a system-voice
+        # cue, so the sink receives at least one buffer during build.
+        sink = MemorySink()
+        Application.build(sink=sink)
+        self.assertGreater(
+            len(sink.buffers),
+            0,
+            "SoundEngine produced no buffer for SESSION_CREATED; the "
+            "startup narration has probably gone silent.",
+        )
+
+    def test_close_publishes_session_saved_when_path_is_set(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "s.json"
+            app = Application.build(session_path=path)
+            seen: list[dict] = []
+            app.bus.subscribe(
+                EventType.SESSION_SAVED,
+                lambda e: seen.append(dict(e.payload)),
+            )
+            app.close()
+            self.assertEqual(len(seen), 1)
+            self.assertEqual(seen[0]["path"], str(path))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_audio_sink.py
+++ b/tests/test_audio_sink.py
@@ -2,14 +2,24 @@
 
 from __future__ import annotations
 
+import io
 import struct
+import sys
 import tempfile
 import unittest
 import wave
 from pathlib import Path
+from unittest import mock
 
 from asat.audio import AudioBuffer
-from asat.audio_sink import MemorySink, WavFileSink, write_wav
+from asat.audio_sink import (
+    LiveAudioUnavailable,
+    MemorySink,
+    WavFileSink,
+    buffer_to_wav_bytes,
+    pick_live_sink,
+    write_wav,
+)
 
 
 class MemorySinkTests(unittest.TestCase):
@@ -83,6 +93,51 @@ class WriteWavTests(unittest.TestCase):
         values = struct.unpack("<hh", raw)
         self.assertEqual(values[0], 32767)
         self.assertEqual(values[1], -32767)
+
+
+class BufferToWavBytesTests(unittest.TestCase):
+
+    def test_produces_a_wav_blob_the_wave_module_can_reread(self) -> None:
+        buffer = AudioBuffer.stereo([0.25, -0.25], [0.5, -0.5], sample_rate=8000)
+        blob = buffer_to_wav_bytes(buffer)
+        self.assertTrue(blob.startswith(b"RIFF"))
+        self.assertIn(b"WAVE", blob[:12])
+        with wave.open(io.BytesIO(blob), "rb") as reader:
+            self.assertEqual(reader.getnchannels(), 2)
+            self.assertEqual(reader.getframerate(), 8000)
+            self.assertEqual(reader.getsampwidth(), 2)
+            self.assertEqual(reader.getnframes(), 2)
+
+
+class PickLiveSinkTests(unittest.TestCase):
+
+    def test_non_windows_raises_live_audio_unavailable(self) -> None:
+        # pick_live_sink branches on sys.platform; if we're not on
+        # Windows it must fail cleanly so the CLI can fall back.
+        if sys.platform.startswith("win"):
+            self.skipTest("running on Windows; live sink is expected to succeed")
+        with self.assertRaises(LiveAudioUnavailable):
+            pick_live_sink()
+
+    def test_windows_branch_uses_winsound_with_memory_async_flags(self) -> None:
+        # Simulate the Windows branch by injecting a fake `winsound`
+        # module and flipping sys.platform for the duration of the test.
+        fake = mock.MagicMock()
+        fake.SND_MEMORY = 0x0004
+        fake.SND_ASYNC = 0x0001
+        fake.SND_PURGE = 0x0040
+        with mock.patch.dict(sys.modules, {"winsound": fake}):
+            with mock.patch.object(sys, "platform", "win32"):
+                sink = pick_live_sink()
+                sink.play(AudioBuffer.mono([0.1, 0.2], sample_rate=8000))
+                sink.close()
+        call = fake.PlaySound.call_args_list[0]
+        data, flags = call.args
+        self.assertIsInstance(data, (bytes, bytearray))
+        self.assertTrue(data.startswith(b"RIFF"))
+        self.assertEqual(flags, fake.SND_MEMORY | fake.SND_ASYNC)
+        # close() asks PlaySound to flush any in-flight clip.
+        fake.PlaySound.assert_called_with(None, fake.SND_PURGE)
 
 
 if __name__ == "__main__":

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -1,0 +1,91 @@
+"""Unit tests for the TerminalRenderer.
+
+The renderer is deterministic: every line it produces is a function
+of one event. We exercise it by publishing hand-crafted events into a
+bus it is attached to, and asserting the captured stream contents.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+
+from asat.event_bus import EventBus, publish_event
+from asat.events import EventType
+from asat.terminal import TerminalRenderer
+
+
+class TerminalRendererTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.bus = EventBus()
+        self.stream = io.StringIO()
+        self.renderer = TerminalRenderer(self.bus, stream=self.stream)
+
+    def _emit(self, event_type: EventType, payload: dict) -> None:
+        publish_event(self.bus, event_type, payload, source="test")
+
+    def test_session_created_writes_a_banner(self) -> None:
+        self._emit(EventType.SESSION_CREATED, {"session_id": "abc123"})
+        self.assertIn("session abc123 ready", self.stream.getvalue())
+
+    def test_session_saved_writes_the_path(self) -> None:
+        self._emit(EventType.SESSION_SAVED, {"path": "/tmp/s.json"})
+        self.assertIn("/tmp/s.json", self.stream.getvalue())
+
+    def test_focus_changed_renders_mode_and_short_cell_id(self) -> None:
+        self._emit(
+            EventType.FOCUS_CHANGED,
+            {"new_mode": "input", "new_cell_id": "abcdef1234"},
+        )
+        self.assertIn("[input #abcdef]", self.stream.getvalue())
+
+    def test_insert_character_echoes_the_literal_char(self) -> None:
+        self._emit(
+            EventType.ACTION_INVOKED,
+            {"action": "insert_character", "char": "h"},
+        )
+        self._emit(
+            EventType.ACTION_INVOKED,
+            {"action": "insert_character", "char": "i"},
+        )
+        self.assertIn("hi", self.stream.getvalue())
+
+    def test_submit_writes_a_prompt_line_with_the_command(self) -> None:
+        self._emit(
+            EventType.ACTION_INVOKED,
+            {"action": "submit", "command": "echo hi"},
+        )
+        self.assertIn("$ echo hi", self.stream.getvalue())
+
+    def test_meta_submit_is_not_rendered_as_a_command(self) -> None:
+        self._emit(
+            EventType.ACTION_INVOKED,
+            {"action": "submit", "command": ":quit", "meta_command": "quit"},
+        )
+        self.assertNotIn("$ :quit", self.stream.getvalue())
+
+    def test_output_chunk_prints_the_line(self) -> None:
+        self._emit(EventType.OUTPUT_CHUNK, {"line": "hello world"})
+        self.assertIn("hello world", self.stream.getvalue())
+
+    def test_error_chunk_is_prefixed(self) -> None:
+        self._emit(EventType.ERROR_CHUNK, {"line": "boom"})
+        self.assertIn("! boom", self.stream.getvalue())
+
+    def test_command_completed_shows_exit_code(self) -> None:
+        self._emit(
+            EventType.COMMAND_COMPLETED,
+            {"cell_id": "c1", "exit_code": 0, "timed_out": False},
+        )
+        self.assertIn("[done exit=0]", self.stream.getvalue())
+
+    def test_command_failed_with_launch_error_renders_the_error(self) -> None:
+        self._emit(
+            EventType.COMMAND_FAILED,
+            {"cell_id": "c1", "error": "No such file: frobnicate"},
+        )
+        self.assertIn("[failed: No such file: frobnicate]", self.stream.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

An honest walk-through of `python -m asat` after PR #14 exposed three real
gaps for a blind user on first launch:

1. **Silent audio.** `MemorySink` was the default — every cue was
   synthesised and then thrown away.
2. **Invisible debugging.** `cbreak` mode disables echo, and nothing
   else printed. A sighted helper had zero way to follow along.
3. **No launch cue.** `SESSION_CREATED` / `SESSION_LOADED` were never
   published, so even a bound startup chime stayed quiet.

This PR closes all three gaps with care for both the user and a future
contributor:

- **`asat/terminal.py` — `TerminalRenderer`.** Subscribes to
  `SESSION_*`, `FOCUS_CHANGED`, `ACTION_INVOKED`
  (insert_character / backspace / submit), `OUTPUT_CHUNK`,
  `ERROR_CHUNK`, and command completion events. Prints a minimal,
  readable trace — startup banner, echoed keystrokes, `$ command`
  submit line, streamed output, `[done exit=N]`. Meta-commands
  (`:quit`, etc.) deliberately aren't rendered as `$`. `--quiet`
  switches it off.
- **`asat/audio_sink.py` — `WindowsLiveAudioSink` + `pick_live_sink()`.**
  Uses `winsound.PlaySound(..., SND_MEMORY | SND_ASYNC)` with
  `SND_PURGE` on close, so every rendered buffer goes to the speaker
  with latest-wins semantics. Lazy `winsound` import keeps POSIX
  imports clean. `LiveAudioUnavailable` is raised with an F6
  breadcrumb on non-Windows hosts.
- **`asat/app.py` — `Application.build` / `close`.** Publishes
  `SESSION_CREATED` (and `SESSION_LOADED` when an existing session is
  passed) *after* `SoundEngine` subscribes, so the startup chime
  actually reaches the sink. `cursor.new_cell()` moves to the end of
  build for the same reason. `close()` publishes `SESSION_SAVED` when
  `session_path` is set.
- **`asat/__main__.py`.** Adds `--live` and `--quiet`; `--wav-dir`
  composes cleanly with `--live` through a private `_TeeSink` that
  dispatches `play`/`close` to the primary and the WAV-capture sink.
- **Docs.** README gains "Launching a session" recipes and a
  five-minute tour. USER_MANUAL documents what a user should hear
  *and* see on launch plus the Windows vs POSIX matrix.
  FEATURE_REQUESTS F6 is rescoped to POSIX (Windows ships here), with
  two candidate implementation paths written up. ARCHITECTURE gains a
  Phase E2 row and an expanded entry-point section describing the
  three supporting modules.

## Out of scope

- POSIX live-speaker sink — tracked as [F6](docs/FEATURE_REQUESTS.md#f6--live-speaker-audio-sink-posix).
- Non-blocking execution + `Ctrl+C` cancel — tracked as
  [F10](docs/FEATURE_REQUESTS.md#f10--non-blocking-execution--cancel-keystroke).
  That needs a worker-thread rewrite and deserves its own PR.

## Test plan

- [x] `python -m unittest discover -s tests -t .` — **464 / 464 green**
  (449 previously + 15 new across terminal, app, audio_sink).
- [x] `python -m asat --quiet` launches without tracing.
- [x] `python -m asat --wav-dir /tmp/asat` writes numbered WAVs per
  rendered buffer.
- [ ] `python -m asat --live` on Windows: startup chime plays, each
  keystroke and event is audible (manual; no Windows host here).
- [x] `python -m asat --live` on Linux: falls back to `MemorySink`
  with the `[asat] --live unavailable: …` message and continues.

https://claude.ai/code/session_01Bqqw4D3Hx2e9viK7HYavk6