### PR TITLE
Onboarding polish: TTY guard, signpost, :help, --version / --check

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,21 @@ python -m unittest discover -s tests -t .
 
 ### Launching a session
 
+Pick the recipe that matches your platform and go. Every flag is
+optional and they compose.
+
 ```
-python -m asat                      # interactive session, text trace on stdout
-python -m asat --live               # also play audio on the speaker (Windows today)
-python -m asat --wav-dir /tmp/asat  # also write every rendered buffer to WAV
+python -m asat --live               # play audio on the speaker (Windows today)
+python -m asat --wav-dir /tmp/asat  # write each rendered buffer to WAV (any platform)
+python -m asat --live --wav-dir DIR # Windows: speaker + capture in one run
 python -m asat --quiet              # suppress the text trace, audio only
+python -m asat --check              # build, print a diagnostic summary, exit
+python -m asat --version            # print the version string and exit
 ```
+
+If you just run `python -m asat` with no flags the session starts
+silently (audio goes to the in-memory sink) — the CLI prints a one-
+line hint on stderr telling you which flag to pass next.
 
 The CLI prints a short text trace as you work — a startup banner, your
 keystrokes as you type, the `$ command` you submit, the captured
@@ -37,21 +46,29 @@ dependencies) and plays each rendered buffer through the speaker. On
 macOS and Linux the live sink is not yet available — `--live` falls
 back to the in-memory sink with a message, and `--wav-dir DIR`
 captures every buffer as a numbered WAV you can review. Live POSIX
-playback is tracked as [F6](docs/FEATURE_REQUESTS.md#f6--live-speaker-audio-sink).
+playback is tracked as [F6](docs/FEATURE_REQUESTS.md#f6--live-speaker-audio-sink-posix).
+
+**ASAT needs an interactive terminal.** If stdin is not a TTY (you
+piped input, or you're inside a sandbox without a real console) the
+CLI exits with `[asat] cannot start: …` and returns exit code 2
+rather than a raw traceback.
 
 ### Five-minute tour
 
-1. `python -m asat --live` (on Windows) or `python -m asat --wav-dir /tmp/asat`
-   (elsewhere). The session-start chime plays; the trace prints
-   `[asat] session <id> ready. :quit to exit.`
-2. Type a command — `echo hi`, `python --version`, `git status`. Each
+1. Launch with the recipe for your platform above. On Windows use
+   `--live`; on macOS/Linux use `--wav-dir /tmp/asat`. The session-
+   start chime plays; the trace prints `[asat] session <id> ready.
+   Type :help for the keystroke cheat sheet, :quit to exit.`
+2. Type `:help` + Enter any time to re-hear the cheat sheet (audio)
+   and see it printed (text trace).
+3. Type a command — `echo hi`, `python --version`, `git status`. Each
    keystroke narrates (audio) and echoes (text).
-3. Press **Enter**. The trace prints `$ <command>`, the command runs,
+4. Press **Enter**. The trace prints `$ <command>`, the command runs,
    output streams, and `[done exit=0]` closes it out.
-4. Press **Ctrl+N** for a new cell, **Up/Down** to walk between cells,
+5. Press **Ctrl+N** for a new cell, **Up/Down** to walk between cells,
    **Ctrl+O** to enter OUTPUT mode and step through captured lines,
    **Ctrl+,** to open the live settings editor.
-5. Type `:quit` + Enter (or Ctrl+D on POSIX / Ctrl+Z-Enter on Windows)
+6. Type `:quit` + Enter (or Ctrl+D on POSIX / Ctrl+Z-Enter on Windows)
    to exit.
 
 Full keystroke cheat sheet: [docs/USER_MANUAL.md](docs/USER_MANUAL.md).

--- a/asat/__init__.py
+++ b/asat/__init__.py
@@ -73,6 +73,7 @@ from asat.input_router import BindingMap, InputRouter, default_bindings
 from asat.interactive import InteractiveMenu, MenuItemView, detect
 from asat.kernel import ExecutionKernel
 from asat.keyboard import (
+    KeyboardNotAvailable,
     KeyboardReader,
     PosixKeyboard,
     ScriptedKeyboard,
@@ -127,8 +128,9 @@ __all__ = [
     "InputRouter",
     "InteractiveMenu",
     "Key",
-    "LiveAudioUnavailable",
+    "KeyboardNotAvailable",
     "KeyboardReader",
+    "LiveAudioUnavailable",
     "MemoryClipboard",
     "MemorySink",
     "MenuItem",

--- a/asat/__main__.py
+++ b/asat/__main__.py
@@ -26,6 +26,7 @@ import sys
 from pathlib import Path
 from typing import Optional, Sequence
 
+from asat import __version__
 from asat.app import Application
 from asat.audio_sink import (
     AudioSink,
@@ -34,7 +35,7 @@ from asat.audio_sink import (
     WavFileSink,
     pick_live_sink,
 )
-from asat.keyboard import KeyboardReader, pick_default
+from asat.keyboard import KeyboardNotAvailable, KeyboardReader, pick_default
 from asat.session import Session
 from asat.sound_bank import SoundBank
 from asat.terminal import TerminalRenderer
@@ -43,7 +44,25 @@ from asat.terminal import TerminalRenderer
 def main(argv: Optional[Sequence[str]] = None) -> int:
     """Parse args, build the Application, and drive the read-dispatch loop."""
     args = _parse_args(argv)
-    sink = _make_sink(args.wav_dir, args.live)
+    if args.version:
+        print(f"asat {__version__}")
+        return 0
+    sink = _make_sink(args.wav_dir, args.live, quiet=args.quiet)
+    if (
+        not args.quiet
+        and not args.check
+        and not args.live
+        and args.wav_dir is None
+    ):
+        # Tell first-time users why they are hearing silence without
+        # forcing them to read the docs. Suppressed once any audio
+        # destination is requested explicitly, and when --check is
+        # printing its own diagnostic report.
+        print(
+            "[asat] audio is going to the in-memory sink. Pass --live "
+            "(Windows) or --wav-dir DIR to hear or capture it.",
+            file=sys.stderr,
+        )
     bank = SoundBank.load(args.bank) if args.bank is not None else None
     session = Session.load(args.session) if args.session is not None else None
     app = Application.build(
@@ -53,11 +72,20 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         session=session,
         session_path=args.session,
     )
+    if args.check:
+        _print_check_report(app, args)
+        app.close()
+        return 0
     if not args.quiet:
         # Attach AFTER Application.build so the renderer does not
         # double-print the startup banner into its own buffer.
         TerminalRenderer(app.bus)
-    keyboard: KeyboardReader = pick_default()
+    try:
+        keyboard: KeyboardReader = pick_default()
+    except KeyboardNotAvailable as exc:
+        print(f"[asat] cannot start: {exc}", file=sys.stderr)
+        app.close()
+        return 2
     try:
         _run(app, keyboard)
     except KeyboardInterrupt:
@@ -68,6 +96,22 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         keyboard.close()
         app.close()
     return 0
+
+
+def _print_check_report(app: Application, args: argparse.Namespace) -> None:
+    """Write a diagnostic summary and return without starting the loop."""
+    lines = [
+        f"asat {__version__}",
+        f"platform       {sys.platform}",
+        f"stdin tty      {sys.stdin.isatty()}",
+        f"sink           {type(app.sink).__name__}",
+        f"bank path      {args.bank if args.bank is not None else '(built-in default)'}",
+        f"session path   {args.session if args.session is not None else '(fresh)'}",
+        f"session id     {app.session.session_id}",
+        f"bindings       {sum(len(m) for m in app.router.bindings.values())}",
+    ]
+    for line in lines:
+        print(line)
 
 
 def _run(app: Application, keyboard: KeyboardReader) -> None:
@@ -123,10 +167,30 @@ def _parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
         default=None,
         help="Load an existing Session from this JSON file; saved on exit.",
     )
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Print the asat version string and exit.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "Build the Application, print a diagnostic summary "
+            "(sink, bank, session, TTY state), and exit without "
+            "entering the key-read loop. Useful for smoke-testing "
+            "a fresh install."
+        ),
+    )
     return parser.parse_args(argv)
 
 
-def _make_sink(wav_dir: Optional[Path], live: bool) -> AudioSink:
+def _make_sink(
+    wav_dir: Optional[Path],
+    live: bool,
+    *,
+    quiet: bool = False,
+) -> AudioSink:
     """Compose the sink chain based on the requested flags.
 
     Priority: `--live` drives the primary sink when available.
@@ -140,7 +204,16 @@ def _make_sink(wav_dir: Optional[Path], live: bool) -> AudioSink:
         try:
             primary = pick_live_sink()
         except LiveAudioUnavailable as exc:
-            print(f"[asat] --live unavailable: {exc}", file=sys.stderr)
+            if not quiet:
+                print(f"[asat] --live unavailable: {exc}", file=sys.stderr)
+                if wav_dir is None:
+                    print(
+                        "[asat] falling back to the in-memory sink. "
+                        "Pair with --wav-dir DIR to capture audio as WAVs "
+                        "you can play back (tracked as F6 in "
+                        "docs/FEATURE_REQUESTS.md).",
+                        file=sys.stderr,
+                    )
             primary = MemorySink()
     else:
         primary = MemorySink()

--- a/asat/default_bank.py
+++ b/asat/default_bank.py
@@ -77,6 +77,7 @@ COVERED_EVENT_TYPES: frozenset[EventType] = frozenset({
     EventType.SETTINGS_FOCUSED,
     EventType.SETTINGS_VALUE_EDITED,
     EventType.SETTINGS_SAVED,
+    EventType.HELP_REQUESTED,
 })
 
 
@@ -478,6 +479,21 @@ def _default_bindings() -> tuple[EventBinding, ...]:
             voice_id="system",
             sound_id="settings_save",
             say_template="settings saved",
+            priority=220,
+        ),
+
+        # Help: speak a short summary so :help is useful without a
+        # visible terminal trace. The TerminalRenderer prints the full
+        # cheat sheet on the same event.
+        EventBinding(
+            id="help_requested",
+            event_type=EventType.HELP_REQUESTED.value,
+            voice_id="system",
+            sound_id="settings_chime",
+            say_template=(
+                "help. Escape leaves any mode. Ctrl plus comma opens "
+                "settings. Type colon quit to exit."
+            ),
             priority=220,
         ),
     )

--- a/asat/events.py
+++ b/asat/events.py
@@ -59,6 +59,9 @@ class EventType(str, Enum):
 
     Audio engine:
         AUDIO_SPOKEN, AUDIO_INTERRUPTED
+
+    Help surface:
+        HELP_REQUESTED
     """
 
     SESSION_CREATED = "session.created"
@@ -100,6 +103,8 @@ class EventType(str, Enum):
 
     AUDIO_SPOKEN = "audio.spoken"
     AUDIO_INTERRUPTED = "audio.interrupted"
+
+    HELP_REQUESTED = "help.requested"
 
     SETTINGS_OPENED = "settings.opened"
     SETTINGS_CLOSED = "settings.closed"

--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -132,7 +132,22 @@ def default_bindings() -> BindingMap:
 # A meta-command short-circuits the normal submit path: the cell is not
 # handed to the kernel and the input buffer is discarded (not written
 # back into the cell).
-META_COMMANDS: tuple[str, ...] = ("settings", "save", "quit")
+META_COMMANDS: tuple[str, ...] = ("settings", "save", "quit", "help")
+
+
+# The cheat-sheet lines a `:help` meta-command should surface. Kept in
+# one place so the renderer, the narration, and the docs can all read
+# from the same source of truth.
+HELP_LINES: tuple[str, ...] = (
+    "ASAT quick reference.",
+    "NOTEBOOK:  Up/Down walk cells, Enter type, Ctrl+N new, Ctrl+O output, Ctrl+, settings.",
+    "INPUT:     Enter submits, Backspace deletes, Escape leaves without running.",
+    "OUTPUT:    Up/Down step lines, PageUp/PageDown page, Escape leaves.",
+    "SETTINGS:  Up/Down walk, Right/Enter descend, Left/Escape ascend, e edit, Ctrl+S save, Ctrl+Q close.",
+    "Meta:      :help, :settings, :save, :quit (type in INPUT mode then Enter).",
+    "Exit:      :quit, or EOF (Ctrl+D on POSIX, Ctrl+Z Enter on Windows).",
+    "Docs:      docs/USER_MANUAL.md for the full keystroke reference.",
+)
 
 
 class InputRouter:
@@ -261,6 +276,17 @@ class InputRouter:
             self._save_settings()
         elif command == "quit":
             self._close_settings()
+        elif command == "help":
+            self._publish_help()
+
+    def _publish_help(self) -> None:
+        """Emit HELP_REQUESTED so the renderer and audio bank can react."""
+        publish_event(
+            self._bus,
+            EventType.HELP_REQUESTED,
+            {"lines": list(HELP_LINES)},
+            source=self.SOURCE,
+        )
 
     def _open_settings(self) -> None:
         """Enter SETTINGS mode and open a controller session if available."""

--- a/asat/keyboard.py
+++ b/asat/keyboard.py
@@ -138,6 +138,18 @@ def decode_windows_special(code: int) -> Optional[Key]:
     return _WINDOWS_SPECIAL.get(code)
 
 
+class KeyboardNotAvailable(RuntimeError):
+    """Raised when the process has no usable interactive keyboard.
+
+    The most common trigger is a non-TTY stdin: someone runs
+    `echo :quit | python -m asat`, or launches from a sandbox that
+    pipes stdin, or runs under a CI harness. In those cases the
+    Posix / Windows adapters cannot put the terminal into cbreak
+    mode and would otherwise surface a raw `termios.error` or an
+    IO error as an unexplained traceback.
+    """
+
+
 class PosixKeyboard:
     """Read keystrokes from stdin in cbreak mode and decode them."""
 
@@ -146,6 +158,13 @@ class PosixKeyboard:
         import termios
         import tty
 
+        if not sys.stdin.isatty():
+            raise KeyboardNotAvailable(
+                "ASAT needs an interactive terminal (a TTY). "
+                "stdin is not a TTY, so keystrokes cannot be read. "
+                "Launch from a real terminal, or use ScriptedKeyboard "
+                "in tests."
+            )
         self._termios = termios
         self._fd = sys.stdin.fileno()
         self._original = termios.tcgetattr(self._fd)
@@ -188,6 +207,12 @@ class WindowsKeyboard:
         """Import msvcrt; there is no terminal state to save."""
         import msvcrt
 
+        if not sys.stdin.isatty():
+            raise KeyboardNotAvailable(
+                "ASAT needs an interactive Windows console. "
+                "stdin is not a TTY, so keystrokes cannot be read. "
+                "Launch from cmd, PowerShell, or Windows Terminal."
+            )
         self._msvcrt = msvcrt
 
     def read_key(self) -> Optional[Key]:

--- a/asat/terminal.py
+++ b/asat/terminal.py
@@ -7,7 +7,9 @@ is derived from one event on the bus.
 
 What gets printed:
 
-- `SESSION_CREATED`: one-line banner naming the session.
+- `SESSION_CREATED`: one-line banner naming the session and pointing
+  at `:help`.
+- `HELP_REQUESTED`: the cheat-sheet lines carried on the event.
 - `FOCUS_CHANGED`: a one-line status like `[input #1]` whenever the
   mode or focused cell changes.
 - `ACTION_INVOKED` with action == `insert_character`: the literal
@@ -47,6 +49,7 @@ class TerminalRenderer:
         bus.subscribe(EventType.SESSION_CREATED, self._on_session_created)
         bus.subscribe(EventType.SESSION_LOADED, self._on_session_loaded)
         bus.subscribe(EventType.SESSION_SAVED, self._on_session_saved)
+        bus.subscribe(EventType.HELP_REQUESTED, self._on_help_requested)
         bus.subscribe(EventType.FOCUS_CHANGED, self._on_focus_changed)
         bus.subscribe(EventType.ACTION_INVOKED, self._on_action_invoked)
         bus.subscribe(EventType.OUTPUT_CHUNK, self._on_output_chunk)
@@ -71,7 +74,15 @@ class TerminalRenderer:
 
     def _on_session_created(self, event: Event) -> None:
         session_id = event.payload.get("session_id", "?")
-        self._write_line(f"[asat] session {session_id} ready. :quit to exit.")
+        self._write_line(
+            f"[asat] session {session_id} ready. Type :help for the keystroke "
+            "cheat sheet, :quit to exit."
+        )
+
+    def _on_help_requested(self, event: Event) -> None:
+        lines = event.payload.get("lines", [])
+        for line in lines:
+            self._write_line(str(line))
 
     def _on_session_loaded(self, event: Event) -> None:
         path = event.payload.get("path", "?")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -188,6 +188,7 @@ layer and left the one below it unchanged:
 | H     | HRTF sparse-impulse fast path (synthetic profiles bypass full convolution) |
 | E     | End-to-end entry point: Application wiring, keyboard adapter, `python -m asat` |
 | E2    | First-launch polish: TerminalRenderer, SESSION_* publishes, WindowsLiveAudioSink, `--live` / `--quiet` |
+| E3    | Onboarding polish: non-TTY guard, sink signpost, `:help` meta-command + `HELP_REQUESTED`, `--version` / `--check` |
 
 ## Entry point
 

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -194,6 +194,15 @@ Producer: `asat.settings_editor.SettingsEditor`
 | `SETTINGS_VALUE_EDITED`  | `section`, `record_index`, `field`, `old_value`, `new_value`        |
 | `SETTINGS_SAVED`         | `path`                                                              |
 
+## Help surface
+
+Producer: `asat.input_router.InputRouter` (`source="input_router"`),
+fired when the user submits the `:help` meta-command.
+
+| EventType        | Payload keys                                     |
+|------------------|--------------------------------------------------|
+| `HELP_REQUESTED` | `lines` (list of str: the cheat-sheet lines from `asat.input_router.HELP_LINES`) |
+
 ---
 
 ## Adding a new event

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -22,6 +22,8 @@ python -m asat --wav-dir /tmp/asat  # also write every rendered buffer to WAV
 python -m asat --quiet              # suppress the text trace, audio only
 python -m asat --bank mybank.json   # start from a saved SoundBank
 python -m asat --session s.json     # resume an existing session; saved on exit
+python -m asat --check              # build, print a diagnostic summary, exit
+python -m asat --version            # print the version string and exit
 ```
 
 Every flag is optional and they compose. The common launch recipes:
@@ -38,6 +40,22 @@ Every flag is optional and they compose. The common launch recipes:
 - **Resume a session:** `python -m asat --session work.json`. The
   session loads, you hear a "loaded" narration, and the same file is
   rewritten on exit with whatever cells you ran this time.
+- **Sanity-check your install:** `python -m asat --check`. Builds the
+  Application, prints the picked sink, bank, session, and TTY state,
+  and exits without starting the read loop. Useful when you launched
+  once and heard nothing — `--check` tells you which sink you got.
+
+If you run `python -m asat` with no `--live` / `--wav-dir` flag the
+CLI prints a one-line stderr hint: `[asat] audio is going to the in-
+memory sink. Pass --live (Windows) or --wav-dir DIR to hear or
+capture it.` That is not an error; audio is still being rendered and
+processed, it just isn't going anywhere audible.
+
+**If stdin is not a TTY** (you piped input into ASAT, or you're
+inside a sandbox without a real console) the CLI exits cleanly with
+`[asat] cannot start: ASAT needs an interactive terminal (a TTY). …`
+and returns exit code 2, rather than a raw `termios.error`
+traceback. Launch from a real terminal to fix it.
 
 ### What you should hear and see on launch
 
@@ -50,8 +68,9 @@ The moment the binary starts:
    re-launch with `--live` (Windows) or `--wav-dir DIR` (elsewhere)
    and check the `[asat]` line that `--wav-dir` produces.
 2. **Text trace (unless `--quiet`).** One line reading
-   `[asat] session <id> ready. :quit to exit.`, then
-   `[input #<short-id>]` to confirm you are in INPUT mode.
+   `[asat] session <id> ready. Type :help for the keystroke cheat
+   sheet, :quit to exit.`, then `[input #<short-id>]` to confirm you
+   are in INPUT mode.
 
 If neither the chime nor the banner appear, the session did not
 start cleanly — see the troubleshooting table at the end of this
@@ -61,20 +80,25 @@ file.
 
 ## The five-minute tour
 
-1. **Launch** ASAT. You'll hear a short rising chime (the session
-   start) from directly overhead — that means the session is live.
-2. **Type a command** — e.g. `dir`, `python --version`, `git status`.
+1. **Launch** ASAT with the recipe above for your platform
+   (`--live` on Windows, `--wav-dir DIR` on POSIX). You'll hear a
+   short rising chime (the session start) from directly overhead —
+   that means the session is live.
+2. **Type `:help`** then Enter. You'll hear a short spoken summary
+   of the keys, and the text trace prints the full cheat sheet.
+   You can do this any time you get lost.
+3. **Type a command** — e.g. `dir`, `python --version`, `git status`.
    You are automatically in INPUT mode, so keys go into the current
    cell.
-3. **Press Enter**. You'll hear a triangle-wave "submit" cue on the
+4. **Press Enter**. You'll hear a triangle-wave "submit" cue on the
    left, then the narrator reads output lines as they stream, then a
    major-chord "success" chime on Enter's exit code, or a low minor
    "failure" chord on the right if the command failed.
-4. **Press Escape**. You're now in NOTEBOOK mode. Up / Down walks
+5. **Press Escape**. You're now in NOTEBOOK mode. Up / Down walks
    between cells.
-5. **Press Ctrl+O**. You're now in OUTPUT mode, stepping line-by-line
+6. **Press Ctrl+O**. You're now in OUTPUT mode, stepping line-by-line
    through the selected cell's captured output. Escape leaves.
-6. **Press Ctrl+,** (or type `:settings` then Enter in INPUT mode).
+7. **Press Ctrl+,** (or type `:settings` then Enter in INPUT mode).
    You're in the settings editor. Escape or Ctrl+Q leaves.
 
 That's the whole shape. The rest of this manual is the detail behind
@@ -139,6 +163,7 @@ discarded and the cell is not modified.
 
 | Meta-command | Effect                                               |
 |--------------|------------------------------------------------------|
+| `:help`      | Narrate + print the keystroke cheat sheet.           |
 | `:settings`  | Open the settings editor (same as Ctrl+,).           |
 | `:save`      | Save the current session to disk.                    |
 | `:quit`      | Exit ASAT.                                           |
@@ -279,6 +304,7 @@ Every key you need, one table.
 | INPUT      | Enter             | Submit command                        |
 | INPUT      | Backspace         | Delete last char                      |
 | INPUT      | Escape            | Leave INPUT without running           |
+| INPUT      | `:help`⏎          | Narrate + print the cheat sheet       |
 | INPUT      | `:settings`⏎      | Open settings editor                  |
 | INPUT      | `:save`⏎          | Save session                          |
 | INPUT      | `:quit`⏎          | Exit ASAT                             |
@@ -333,16 +359,28 @@ about the terminal itself rather than about your command.
 
 ## Troubleshooting
 
+**`[asat] cannot start: ASAT needs an interactive terminal (a TTY).`**
+Something is piping your stdin into ASAT — maybe `echo :quit | python
+-m asat`, a CI runner, or a sandbox without a real console. Launch
+from a real terminal instead. Exit code 2.
+
+**I launched and heard nothing.**
+Run `python -m asat --check`. It prints the sink class that was picked,
+the bank path, and whether stdin is a TTY. If the sink is `MemorySink`,
+you forgot `--live` (Windows) or `--wav-dir DIR` (any platform).
+
 **I pressed a key and nothing happened.**
 Check your mode. Most keys are mode-scoped; Ctrl+O in INPUT mode
-just types literally because INPUT mode accepts characters.
+just types literally because INPUT mode accepts characters. When in
+doubt, type `:help` + Enter.
 
 **I lost my command in the middle of typing and now I can't get back
 to the input line.**
 Press Escape from wherever you are (twice if you're in the settings
 editor). You'll be in NOTEBOOK mode. Up / Down to find the cell you
 were typing in, Enter to resume INPUT mode on it — the buffer you
-typed is still there.
+typed is still there. If you are completely unsure where you are,
+drop into INPUT mode and type `:help` + Enter.
 
 **Everything is too chatty.**
 Open `:settings`, navigate to the offending binding, press `e` on

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,94 @@
+"""Unit tests for `python -m asat` (the CLI shim).
+
+These tests exercise the small set of branches that only surface at
+the CLI layer: the signpost stderr hint, `--version`, `--check`, and
+the friendly non-TTY exit. The actual read-dispatch loop is covered
+through Application tests.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from unittest import mock
+
+from asat import __main__ as cli
+from asat import __version__
+
+
+class VersionFlagTests(unittest.TestCase):
+    def test_version_prints_package_version_and_exits_zero(self) -> None:
+        out = io.StringIO()
+        with mock.patch("sys.stdout", out):
+            rc = cli.main(["--version"])
+        self.assertEqual(rc, 0)
+        self.assertIn(__version__, out.getvalue())
+
+
+class SignpostHintTests(unittest.TestCase):
+    """`python -m asat` with no audio flag must nudge the user once."""
+
+    def test_no_flags_prints_sink_hint_to_stderr(self) -> None:
+        err = io.StringIO()
+        out = io.StringIO()
+        fake_keyboard = mock.MagicMock()
+        fake_keyboard.read_key.return_value = None
+        with mock.patch("asat.__main__.pick_default", return_value=fake_keyboard), \
+             mock.patch("sys.stderr", err), \
+             mock.patch("sys.stdout", out):
+            rc = cli.main([])
+        self.assertEqual(rc, 0)
+        self.assertIn("in-memory sink", err.getvalue())
+        self.assertIn("--live", err.getvalue())
+        self.assertIn("--wav-dir", err.getvalue())
+
+    def test_live_flag_suppresses_hint(self) -> None:
+        err = io.StringIO()
+        out = io.StringIO()
+        fake_keyboard = mock.MagicMock()
+        fake_keyboard.read_key.return_value = None
+        with mock.patch("asat.__main__.pick_default", return_value=fake_keyboard), \
+             mock.patch("sys.stderr", err), \
+             mock.patch("sys.stdout", out):
+            rc = cli.main(["--live"])
+        self.assertEqual(rc, 0)
+        self.assertNotIn("in-memory sink. Pass", err.getvalue())
+
+
+class CheckFlagTests(unittest.TestCase):
+    def test_check_prints_summary_and_exits_without_reading_keys(self) -> None:
+        out = io.StringIO()
+        # pick_default must NOT be called; --check short-circuits.
+        with mock.patch("asat.__main__.pick_default", side_effect=AssertionError), \
+             mock.patch("sys.stdout", out):
+            rc = cli.main(["--check"])
+        self.assertEqual(rc, 0)
+        report = out.getvalue()
+        self.assertIn("asat", report)
+        self.assertIn("platform", report)
+        self.assertIn("sink", report)
+        self.assertIn("bindings", report)
+
+
+class NonTTYTests(unittest.TestCase):
+    """A non-interactive stdin produces a clean exit, not a traceback."""
+
+    def test_non_tty_exits_with_code_2_and_friendly_message(self) -> None:
+        from asat.keyboard import KeyboardNotAvailable
+
+        err = io.StringIO()
+        out = io.StringIO()
+        raise_on_pick = mock.MagicMock(
+            side_effect=KeyboardNotAvailable("needs a TTY")
+        )
+        with mock.patch("asat.__main__.pick_default", raise_on_pick), \
+             mock.patch("sys.stderr", err), \
+             mock.patch("sys.stdout", out):
+            rc = cli.main(["--live"])
+        self.assertEqual(rc, 2)
+        self.assertIn("cannot start", err.getvalue())
+        self.assertIn("needs a TTY", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_default_bank.py
+++ b/tests/test_default_bank.py
@@ -90,6 +90,7 @@ SAMPLE_PAYLOADS: dict[EventType, dict[str, object]] = {
         "new_value": 1.1,
     },
     EventType.SETTINGS_SAVED: {"path": "/tmp/bank.json"},
+    EventType.HELP_REQUESTED: {"lines": ["help"]},
 }
 
 

--- a/tests/test_input_router.py
+++ b/tests/test_input_router.py
@@ -432,6 +432,24 @@ class MetaCommandTests(unittest.TestCase):
         ]
         self.assertEqual(submits[0].payload.get("command"), ":unknown")
 
+    def test_colon_help_publishes_help_requested_with_cheat_sheet_lines(self) -> None:
+        from asat.input_router import HELP_LINES
+
+        bus, _, router, _controller = _build_with_settings([""])
+        recorder = _Recorder(bus)
+        router.handle_key(ENTER)
+        for ch in ":help":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+        helps = recorder.types_of(EventType.HELP_REQUESTED)
+        self.assertEqual(len(helps), 1)
+        self.assertEqual(tuple(helps[0].payload["lines"]), HELP_LINES)
+        submits = [
+            e for e in recorder.types_of(EventType.ACTION_INVOKED)
+            if e.payload.get("action") == "submit"
+        ]
+        self.assertEqual(submits[-1].payload["meta_command"], "help")
+
 
 class CustomBindingTests(unittest.TestCase):
 

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -11,9 +11,15 @@ from __future__ import annotations
 
 import unittest
 
+import io
+from unittest import mock
+
 from asat import keys as kc
 from asat.keyboard import (
+    KeyboardNotAvailable,
+    PosixKeyboard,
     ScriptedKeyboard,
+    WindowsKeyboard,
     decode_control_byte,
     decode_windows_special,
     parse_csi,
@@ -82,6 +88,30 @@ class ScriptedKeyboardTests(unittest.TestCase):
         self.assertEqual(reader.read_key(), kc.ENTER)
         self.assertEqual(reader.read_key(), Key.printable("a"))
         self.assertIsNone(reader.read_key())
+
+
+class TTYGuardTests(unittest.TestCase):
+    """Both platform adapters must refuse to construct on a non-TTY."""
+
+    def test_posix_keyboard_raises_keyboard_not_available_when_stdin_is_not_a_tty(
+        self,
+    ) -> None:
+        fake_stdin = io.StringIO("")  # StringIO.isatty() -> False
+        with mock.patch("asat.keyboard.sys.stdin", fake_stdin):
+            with self.assertRaises(KeyboardNotAvailable) as ctx:
+                PosixKeyboard()
+        self.assertIn("interactive terminal", str(ctx.exception))
+
+    def test_windows_keyboard_raises_keyboard_not_available_when_stdin_is_not_a_tty(
+        self,
+    ) -> None:
+        fake_stdin = io.StringIO("")
+        fake_msvcrt = mock.MagicMock()
+        with mock.patch.dict("sys.modules", {"msvcrt": fake_msvcrt}):
+            with mock.patch("asat.keyboard.sys.stdin", fake_stdin):
+                with self.assertRaises(KeyboardNotAvailable) as ctx:
+                    WindowsKeyboard()
+        self.assertIn("interactive Windows console", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -28,6 +28,22 @@ class TerminalRendererTests(unittest.TestCase):
         self._emit(EventType.SESSION_CREATED, {"session_id": "abc123"})
         self.assertIn("session abc123 ready", self.stream.getvalue())
 
+    def test_session_banner_advertises_help_and_quit(self) -> None:
+        self._emit(EventType.SESSION_CREATED, {"session_id": "abc"})
+        out = self.stream.getvalue()
+        self.assertIn(":help", out)
+        self.assertIn(":quit", out)
+
+    def test_help_requested_prints_each_line(self) -> None:
+        self._emit(
+            EventType.HELP_REQUESTED,
+            {"lines": ["line one", "line two", "line three"]},
+        )
+        out = self.stream.getvalue()
+        self.assertIn("line one", out)
+        self.assertIn("line two", out)
+        self.assertIn("line three", out)
+
     def test_session_saved_writes_the_path(self) -> None:
         self._emit(EventType.SESSION_SAVED, {"path": "/tmp/s.json"})
         self.assertIn("/tmp/s.json", self.stream.getvalue())


### PR DESCRIPTION
## Summary

A cold-read walk-through of `python -m asat` after PR #15 — pretending
to be a brand-new blind user opening the box — surfaced six onboarding
gaps. This PR closes every one of them. No architectural churn; every
change is contained and defensive.

### Gaps closed

- **G1 · Non-TTY traceback.** Piping stdin, running from a sandbox
  without a real console, or a CI runner produced a raw
  `termios.error` traceback. Both `PosixKeyboard` and
  `WindowsKeyboard` now check `sys.stdin.isatty()` at construction
  and raise the new `KeyboardNotAvailable` exception with a plain
  message. `__main__` catches it, writes
  `[asat] cannot start: …` to stderr, and exits with code 2.
- **G2 · Silent default launch.** `python -m asat` with no audio flag
  sent every cue to the in-memory sink. The CLI now writes one stderr
  hint pointing at `--live` / `--wav-dir`; suppressed by `--quiet`,
  `--check`, and by passing either audio flag.
- **G3 · No `:help` keystroke.** Added `:help` as a meta-command. It
  publishes a new `HELP_REQUESTED` event carrying a cheat-sheet from
  `asat.input_router.HELP_LINES`. TerminalRenderer prints each line;
  the default SoundBank narrates a short summary so `:help` is
  useful even with `--quiet`.
- **G4 · No version / diagnostic flag.** Added `--version` (prints
  `asat <version>`, exits 0) and `--check` (prints platform, TTY
  state, sink class, bank path, session path/id, and binding count,
  then exits). Both short-circuit before the read loop.
- **G5 · README tour started with the unqualified launch line.** The
  tour now tells the user to pick the recipe for their platform in
  step 1, and has a new step 2 nudging them to run `:help` any time.
- **G6 · `--live` POSIX fallback was also silent.** The fallback now
  nudges users toward `--wav-dir DIR` so they at least get capture.

### What changed

| Area | Files |
|------|-------|
| Guard | `asat/keyboard.py` (KeyboardNotAvailable, isatty check), `asat/__main__.py` (catch + friendly exit) |
| Signpost | `asat/__main__.py` (stderr hint, --live fallback hint) |
| :help | `asat/events.py` (HELP_REQUESTED), `asat/input_router.py` (META + dispatch + HELP_LINES), `asat/terminal.py` (subscriber), `asat/default_bank.py` (narration binding) |
| Diagnostic flags | `asat/__main__.py` (--version, --check + report helper) |
| Docs | `README.md`, `docs/USER_MANUAL.md`, `docs/EVENTS.md`, `docs/ARCHITECTURE.md` (Phase E3) |
| Exports | `asat/__init__.py` (KeyboardNotAvailable) |
| Tests | `tests/test_keyboard.py` (+2), `tests/test_input_router.py` (+1), `tests/test_terminal.py` (+2), `tests/test_default_bank.py` (+1 sample payload), `tests/test_cli.py` (new, 5 tests) |

### Test plan

- [x] `python -m unittest discover -s tests -t .` — **474 / 474 green**
  (464 previously + 10 new).
- [x] `python -m asat --version` prints `asat 0.7.0` and exits 0.
- [x] `python -m asat --check` prints the diagnostic report and exits 0.
- [x] `echo :quit | python -m asat` exits cleanly with code 2 and a
  friendly message, not a traceback.
- [x] `python -m asat` with no flags prints the sink hint to stderr.
- [ ] `python -m asat --live` on Windows still plays the chime and
  `:help` narrates (manual; no Windows host available here).

### Out of scope

- POSIX live-speaker sink — still tracked as [F6](docs/FEATURE_REQUESTS.md#f6--live-speaker-audio-sink-posix).
- Non-blocking execution + `Ctrl+C` cancel — still tracked as
  [F10](docs/FEATURE_REQUESTS.md#f10--non-blocking-execution--cancel-keystroke).

https://claude.ai/code/session_01Bqqw4D3Hx2e9viK7HYavk6