### PR TITLE
cli+docs: graceful missing-file handling and doc drift fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ rather than a raw traceback.
 2. Type `:help` + Enter any time to re-hear the cheat sheet (audio)
    and see it printed (text trace).
 3. Type a command — `echo hi`, `python --version`, `git status`. Each
-   keystroke narrates (audio) and echoes (text).
+   keystroke echoes to the text trace; typing itself is silent in
+   audio by design so long commands don't drown you in cues.
 4. Press **Enter**. The trace prints `$ <command>`, the command runs,
    output streams, and `[done exit=0]` closes it out.
 5. Press **Ctrl+N** for a new cell, **Up/Down** to walk between cells,

--- a/asat/__main__.py
+++ b/asat/__main__.py
@@ -63,8 +63,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             "(Windows) or --wav-dir DIR to hear or capture it.",
             file=sys.stderr,
         )
-    bank = SoundBank.load(args.bank) if args.bank is not None else None
-    session = Session.load(args.session) if args.session is not None else None
+    try:
+        bank = _load_bank(args.bank)
+    except _FriendlyExit as exc:
+        print(f"[asat] {exc}", file=sys.stderr)
+        return 2
+    session = _load_session(args.session)
     app = Application.build(
         sink=sink,
         bank=bank,
@@ -183,6 +187,41 @@ def _parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
         ),
     )
     return parser.parse_args(argv)
+
+
+class _FriendlyExit(Exception):
+    """Raised when the CLI should abort with a one-line stderr message."""
+
+
+def _load_bank(path: Optional[Path]) -> Optional[SoundBank]:
+    """Load a SoundBank from disk, or return None for the built-in default.
+
+    A missing file aborts with a friendly message rather than a raw
+    FileNotFoundError traceback, because the most common cause is a
+    typo and the user deserves to see it before anything else happens.
+    """
+    if path is None:
+        return None
+    if not path.exists():
+        raise _FriendlyExit(
+            f"--bank {path}: file not found. Check the path or omit "
+            "the flag to use the built-in default bank."
+        )
+    return SoundBank.load(path)
+
+
+def _load_session(path: Optional[Path]) -> Optional[Session]:
+    """Load a Session from disk, or return None for a fresh session.
+
+    A missing `--session` path is NOT an error: the semantics are
+    "resume from this file if it exists, else create a fresh session
+    and save to this path on exit". This matches the natural
+    expectation of `python -m asat --session work.json` on a blank
+    workspace and keeps first-run onboarding from crashing.
+    """
+    if path is None or not path.exists():
+        return None
+    return Session.load(path)
 
 
 def _make_sink(

--- a/docs/AUDIO.md
+++ b/docs/AUDIO.md
@@ -120,7 +120,13 @@ exit_code == 0
 stream == "stderr"
 action in ["copy_line", "copy_all"]
 timed_out != False
+transition == mode        # FOCUS_CHANGED: only when the focus mode changed
+transition == cell        # FOCUS_CHANGED: only when the focused cell changed
 ```
+
+String RHS values may be quoted (`"stderr"`) or bare (`mode`) — both
+are accepted because `_parse_literal` falls back to the raw string
+when `ast.literal_eval` can't parse it.
 
 Plug in a different evaluator by passing `predicate=...` to
 `SoundEngine(...)`; the `PredicateEvaluator` protocol is tiny

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -77,9 +77,20 @@ and `asat.notebook.NotebookCursor` (`source="notebook"`).
 
 | EventType        | Payload keys                                                                   | Source          |
 |------------------|--------------------------------------------------------------------------------|-----------------|
-| `FOCUS_CHANGED`  | `old_mode`, `new_mode`, `old_cell_id`, `new_cell_id`, `input_buffer`           | `notebook`      |
+| `FOCUS_CHANGED`  | `old_mode`, `new_mode`, `old_cell_id`, `new_cell_id`, `input_buffer`, `transition`, `command` | `notebook`      |
 | `KEY_PRESSED`    | `name`, `char`, `modifiers`                                                    | `input_router`  |
 | `ACTION_INVOKED` | `action`, `focus_mode`, `cell_id`, `key_name`, plus action-specific extras     | `input_router`  |
+
+`FOCUS_CHANGED` extras:
+
+* `transition` is `"mode"` when the focus mode changed, `"cell"` when
+  only the focused cell changed within NOTEBOOK. Buffer-only deltas
+  (characters typed into the input buffer) do NOT publish
+  `FOCUS_CHANGED`; subscribe to `ACTION_INVOKED` with
+  `action == "insert_character"` instead.
+* `command` is the focused cell's current command text at transition
+  time, or `""` when no cell is focused. Bindings can narrate it with
+  a `{command}` template.
 
 `ACTION_INVOKED` extras:
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -37,9 +37,11 @@ Every flag is optional and they compose. The common launch recipes:
   `/tmp/asat`. Live playback is being worked on
   (FEATURE_REQUESTS.md F6); until then, WAV capture plus a
   screen-reader-friendly player is the recommended path.
-- **Resume a session:** `python -m asat --session work.json`. The
-  session loads, you hear a "loaded" narration, and the same file is
-  rewritten on exit with whatever cells you ran this time.
+- **Resume or start a session:** `python -m asat --session work.json`.
+  If the file exists the session loads and you hear a "loaded"
+  narration; if it does not exist a fresh session starts and the file
+  is created on exit. Either way the same path is rewritten on exit
+  with whatever cells you ran. `:save` (INPUT mode) persists mid-run.
 - **Sanity-check your install:** `python -m asat --check`. Builds the
   Application, prints the picked sink, bank, session, and TTY state,
   and exits without starting the read loop. Useful when you launched

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,5 +90,42 @@ class NonTTYTests(unittest.TestCase):
         self.assertIn("needs a TTY", err.getvalue())
 
 
+class MissingSessionPathTests(unittest.TestCase):
+    """`--session /path/that/doesnt/exist.json` bootstraps a fresh session."""
+
+    def test_missing_session_starts_fresh_and_saves_on_exit(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        fake_keyboard = mock.MagicMock()
+        fake_keyboard.read_key.return_value = None
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "fresh.json"
+            self.assertFalse(path.exists())
+            err = io.StringIO()
+            out = io.StringIO()
+            with mock.patch("asat.__main__.pick_default", return_value=fake_keyboard), \
+                 mock.patch("sys.stderr", err), \
+                 mock.patch("sys.stdout", out):
+                rc = cli.main(["--live", "--session", str(path)])
+            self.assertEqual(rc, 0)
+            # File was created on exit (Application.close() path).
+            self.assertTrue(path.exists())
+
+
+class MissingBankPathTests(unittest.TestCase):
+    """`--bank /path/that/doesnt/exist.json` exits with a friendly error."""
+
+    def test_missing_bank_exits_with_code_2_and_hint(self) -> None:
+        err = io.StringIO()
+        out = io.StringIO()
+        with mock.patch("sys.stderr", err), \
+             mock.patch("sys.stdout", out):
+            rc = cli.main(["--bank", "/tmp/asat-no-such-bank.json"])
+        self.assertEqual(rc, 2)
+        self.assertIn("--bank", err.getvalue())
+        self.assertIn("file not found", err.getvalue())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

A third cold-read pass of the onboarding surface surfaced five more gaps between the code and the docs. Two were real crashes for a first-time user; three were doc drift from PR #17.

### Gaps fixed

1. **`python -m asat --session /fresh.json` crashed** with a raw `FileNotFoundError` when the file didn't exist, before any friendly message could be printed. The natural expectation is "resume from here if present, else create fresh and save on exit" — that's what it does now.
2. **`python -m asat --bank /missing.json` crashed identically.** A typo should not produce a traceback — it now prints `[asat] --bank /missing.json: file not found. Check the path or omit the flag to use the built-in default bank.` and exits 2.
3. **EVENTS.md was stale.** The `FOCUS_CHANGED` row still listed only the five original payload keys; it now lists `transition` and `command` too and explains the buffer-only-silence rule.
4. **README tour lied.** "Each keystroke narrates (audio)" hasn't been true since PR #17 suppressed per-keystroke FOCUS_CHANGED. The step now says typing is text-echo only, silent in audio by design.
5. **AUDIO.md predicate examples were thin.** Added `transition == mode` / `transition == cell` (the patterns the default bank actually relies on) and noted bare-string RHS values are accepted.

### Changes

- `asat/__main__.py`: new `_load_session` (missing path → fresh session, save on exit) and `_load_bank` (missing path → `_FriendlyExit`, exit 2 with stderr hint).
- `docs/EVENTS.md`: FOCUS_CHANGED row + an "`FOCUS_CHANGED` extras" explanatory block.
- `docs/AUDIO.md`: two new predicate examples + one-liner about bare-string RHS.
- `docs/USER_MANUAL.md`: `--session` recipe updated with resume-or-start semantics.
- `README.md`: five-minute-tour keystroke step corrected.

## Test plan

- [x] `python -m unittest discover -s tests -t .` — **482 tests pass** (+2 new)
- [x] New `MissingSessionPathTests` verifies `--session /nonexistent.json` starts fresh and writes the file on exit.
- [x] New `MissingBankPathTests` verifies `--bank /nonexistent.json` exits 2 with the hint on stderr.
- [x] Existing CLI / app / router / notebook / default-bank suites unchanged and green.
