### PR TITLE
First-time UX: capture launch banner, make :help/:save ambient

### DIFF
--- a/asat/__main__.py
+++ b/asat/__main__.py
@@ -38,7 +38,6 @@ from asat.audio_sink import (
 from asat.keyboard import KeyboardNotAvailable, KeyboardReader, pick_default
 from asat.session import Session
 from asat.sound_bank import SoundBank
-from asat.terminal import TerminalRenderer
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -69,21 +68,24 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print(f"[asat] {exc}", file=sys.stderr)
         return 2
     session = _load_session(args.session)
+    # `--check` prints its own diagnostic report and must not mix the
+    # TerminalRenderer trace into stdout. Every other invocation wants
+    # the renderer attached BEFORE `Application.build` publishes
+    # `SESSION_CREATED`/`FOCUS_CHANGED`, so the launch banner and the
+    # first `[input #…]` line reach the user.
+    trace_stream = None if args.quiet or args.check else sys.stdout
     app = Application.build(
         sink=sink,
         bank=bank,
         bank_path=args.bank,
         session=session,
         session_path=args.session,
+        text_trace=trace_stream,
     )
     if args.check:
         _print_check_report(app, args)
         app.close()
         return 0
-    if not args.quiet:
-        # Attach AFTER Application.build so the renderer does not
-        # double-print the startup banner into its own buffer.
-        TerminalRenderer(app.bus)
     try:
         keyboard: KeyboardReader = pick_default()
     except KeyboardNotAvailable as exc:

--- a/asat/app.py
+++ b/asat/app.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TextIO
 
 from asat.audio_sink import AudioSink, MemorySink
 from asat.default_bank import default_sound_bank
@@ -38,6 +38,7 @@ from asat.session import Session
 from asat.settings_controller import SettingsController
 from asat.sound_bank import SoundBank
 from asat.sound_engine import SoundEngine
+from asat.terminal import TerminalRenderer
 
 
 @dataclass
@@ -78,6 +79,7 @@ class Application:
         bank_path: Optional[Path | str] = None,
         session: Optional[Session] = None,
         session_path: Optional[Path | str] = None,
+        text_trace: Optional[TextIO] = None,
     ) -> "Application":
         """Wire every collaborator with sensible defaults.
 
@@ -90,6 +92,12 @@ class Application:
         When `session` is None, a new Session with one empty cell is
         created and the cursor lands in INPUT mode on it so the user
         can start typing immediately.
+
+        When `text_trace` is a writable stream (e.g. `sys.stdout`),
+        a `TerminalRenderer` is attached to the bus BEFORE the startup
+        publishes fire, so the `[asat] session … ready.` banner and
+        the initial `[input #…]` line are captured. Pass `None`
+        (default) to suppress the text trace.
         """
         bus = EventBus()
         seeded = session is None
@@ -113,6 +121,8 @@ class Application:
         )
         resolved_sink: AudioSink = sink if sink is not None else MemorySink()
         sound_engine = SoundEngine(bus, resolved_bank, resolved_sink)
+        if text_trace is not None:
+            TerminalRenderer(bus, stream=text_trace)
         app = cls(
             bus=bus,
             session=resolved_session,
@@ -126,8 +136,9 @@ class Application:
             settings_controller=settings_controller,
             session_path=Path(session_path) if session_path is not None else None,
         )
-        # Everything below fires AFTER sound_engine has subscribed, so
-        # the launch narration actually plays through the sink.
+        # Everything below fires AFTER sound_engine and (if requested)
+        # the TerminalRenderer have subscribed, so the launch banner
+        # both narrates through the sink and prints to the text trace.
         publish_event(
             bus,
             EventType.SESSION_CREATED,

--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -134,6 +134,14 @@ def default_bindings() -> BindingMap:
 # back into the cell).
 META_COMMANDS: tuple[str, ...] = ("settings", "save", "quit", "help")
 
+# "Ambient" meta-commands do their job without taking focus away from
+# INPUT mode. `:help` prints a cheat sheet; `:save` persists the
+# session. In both cases the natural next action is to keep typing, so
+# the router clears the in-progress buffer but leaves the user in INPUT
+# mode. Commands NOT in this set (today: `:settings`, `:quit`)
+# inherently require a mode change and go through `abandon_input_mode`.
+AMBIENT_META_COMMANDS: frozenset[str] = frozenset({"help", "save"})
+
 
 # The cheat-sheet lines a `:help` meta-command should surface. Kept in
 # one place so the renderer, the narration, and the docs can all read
@@ -260,7 +268,10 @@ class InputRouter:
         buffer = self._cursor.focus.input_buffer
         meta = _parse_meta_command(buffer)
         if meta is not None:
-            self._cursor.abandon_input_mode()
+            if meta in AMBIENT_META_COMMANDS:
+                self._cursor.reset_input_buffer()
+            else:
+                self._cursor.abandon_input_mode()
             self._handle_meta_command(meta)
             return {"meta_command": meta}
         cell = self._cursor.submit()

--- a/asat/notebook.py
+++ b/asat/notebook.py
@@ -243,6 +243,22 @@ class NotebookCursor:
         )
         return self._state
 
+    def reset_input_buffer(self) -> None:
+        """Clear the input buffer while staying in INPUT mode.
+
+        Used by "ambient" meta-commands like `:help` and `:save` that
+        consume the typed buffer (so the literal `:help` text does not
+        linger) but leave the user exactly where they were, ready to
+        keep typing. No FOCUS_CHANGED is published — this matches the
+        contract for every other buffer-only mutation (typing a key,
+        Backspace).
+        """
+        if self._state.mode != FocusMode.INPUT:
+            return
+        if not self._state.input_buffer:
+            return
+        self._transition(replace(self._state, input_buffer=""))
+
     def insert_character(self, character: str) -> None:
         """Append a character to the input buffer while in INPUT mode."""
         if self._state.mode != FocusMode.INPUT:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -200,5 +200,29 @@ class ApplicationSessionEventTests(unittest.TestCase):
             self.assertEqual(seen[0]["path"], str(path))
 
 
+class ApplicationTextTraceTests(unittest.TestCase):
+    """The `text_trace` parameter attaches a TerminalRenderer BEFORE
+    the startup publishes fire, so the launch banner and the initial
+    `[input #…]` line reach the user on first run."""
+
+    def test_text_trace_captures_launch_banner_and_first_input_line(self) -> None:
+        import io
+
+        stream = io.StringIO()
+        Application.build(text_trace=stream)
+        trace = stream.getvalue()
+        self.assertIn("ready", trace)
+        self.assertIn("[input", trace)
+
+    def test_text_trace_none_produces_no_output(self) -> None:
+        # Default behaviour is silent; tests and embedders that want to
+        # observe the stream opt in explicitly.
+        import io
+
+        stream = io.StringIO()
+        Application.build()
+        self.assertEqual(stream.getvalue(), "")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_input_router.py
+++ b/tests/test_input_router.py
@@ -450,6 +450,43 @@ class MetaCommandTests(unittest.TestCase):
         ]
         self.assertEqual(submits[-1].payload["meta_command"], "help")
 
+    def test_colon_help_is_ambient_leaves_user_in_input_mode(self) -> None:
+        """`:help` consumes the buffer but keeps INPUT focus so the
+        user can immediately continue typing their real command."""
+        _, cursor, router, _controller = _build_with_settings([""])
+        router.handle_key(ENTER)
+        for ch in ":help":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+        self.assertEqual(cursor.focus.mode, FocusMode.INPUT)
+        self.assertEqual(cursor.focus.input_buffer, "")
+        # Typing after :help lands in the (now empty) buffer.
+        for ch in "echo hi":
+            router.handle_key(Key.printable(ch))
+        self.assertEqual(cursor.focus.input_buffer, "echo hi")
+
+    def test_colon_save_is_ambient_leaves_user_in_input_mode(self) -> None:
+        """Same ambient semantics for `:save` — session gets saved by
+        the Application via the ACTION_INVOKED payload, and the user
+        stays exactly where they were."""
+        _, cursor, router, _controller = _build_with_settings([""])
+        router.handle_key(ENTER)
+        for ch in ":save":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+        self.assertEqual(cursor.focus.mode, FocusMode.INPUT)
+        self.assertEqual(cursor.focus.input_buffer, "")
+
+    def test_colon_quit_still_ejects_to_notebook(self) -> None:
+        """Non-ambient meta-commands (`:quit`, `:settings`) keep the
+        existing behaviour: leave INPUT mode."""
+        _, cursor, router, _controller = _build_with_settings([""])
+        router.handle_key(ENTER)
+        for ch in ":quit":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+        self.assertEqual(cursor.focus.mode, FocusMode.NOTEBOOK)
+
 
 class CustomBindingTests(unittest.TestCase):
 

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -219,5 +219,46 @@ class CursorOutputModeTests(unittest.TestCase):
         self.assertEqual(self.cursor.focus.mode, FocusMode.NOTEBOOK)
 
 
+class ResetInputBufferTests(unittest.TestCase):
+    """`reset_input_buffer` is the ambient-meta-command helper: it
+    clears the in-progress buffer while leaving the user in INPUT
+    mode, and is silent on the event bus (buffer-only mutation)."""
+
+    def test_reset_clears_buffer_without_leaving_input_mode(self) -> None:
+        bus = EventBus()
+        session, cells = _session_with([""])
+        cursor = NotebookCursor(session, bus)
+        cursor.enter_input_mode()
+        for ch in ":help":
+            cursor.insert_character(ch)
+        self.assertEqual(cursor.focus.input_buffer, ":help")
+        recorder = _Recorder(bus)
+        cursor.reset_input_buffer()
+        self.assertEqual(cursor.focus.mode, FocusMode.INPUT)
+        self.assertEqual(cursor.focus.cell_id, cells[0].cell_id)
+        self.assertEqual(cursor.focus.input_buffer, "")
+        # Buffer-only mutations must NOT publish FOCUS_CHANGED (matches
+        # the contract for insert_character and backspace).
+        self.assertEqual(recorder.events, [])
+
+    def test_reset_outside_input_mode_is_noop(self) -> None:
+        bus = EventBus()
+        session, _ = _session_with(["echo"])
+        cursor = NotebookCursor(session, bus)
+        self.assertEqual(cursor.focus.mode, FocusMode.NOTEBOOK)
+        cursor.reset_input_buffer()
+        self.assertEqual(cursor.focus.mode, FocusMode.NOTEBOOK)
+
+    def test_reset_with_empty_buffer_is_noop(self) -> None:
+        bus = EventBus()
+        session, _ = _session_with([""])
+        cursor = NotebookCursor(session, bus)
+        cursor.enter_input_mode()
+        recorder = _Recorder(bus)
+        cursor.reset_input_buffer()
+        self.assertEqual(cursor.focus.input_buffer, "")
+        self.assertEqual(recorder.events, [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fresh cold-read walkthrough of the documented first-run flow (`python -m asat`, read the banner, type `:help`, start working) surfaced three gaps:

- **Launch banner never prints.** `TerminalRenderer` was attached AFTER `Application.build()`, so `SESSION_CREATED` and the first `[input #…]` line — the cues that tell a sighted user the app is alive — were published into a bus with no renderer subscribed.
- **`:help` ejects you from INPUT.** A first-time user reads the manual, types `:help`, presses Enter, and wonders why their next keystroke doesn't enter the buffer: they silently got flipped to NOTEBOOK mode.
- **`:save` has the same problem.** Saving mid-typing throws you out of INPUT mode, forcing an extra Enter before you can continue.

## Changes

- `Application.build()` gains a `text_trace: Optional[TextIO]` parameter that attaches the `TerminalRenderer` BEFORE startup publishes fire. CLI passes `sys.stdout` when neither `--quiet` nor `--check` is set.
- `NotebookCursor.reset_input_buffer()` — new helper that clears the buffer while staying in INPUT mode. Silent on the event bus (matches the existing contract for buffer-only mutations like `insert_character` / `backspace`).
- `InputRouter._submit()` routes "ambient" meta-commands (`:help`, `:save`) through `reset_input_buffer()`. `:settings`/`:quit` keep `abandon_input_mode()` since those inherently require a mode change.

## Test plan

- [x] `python -m unittest discover -s tests -t .` — 490 passing (+8 over baseline)
- [x] Hand-simulated first-run flow: banner prints, `:help` leaves user in INPUT with empty buffer, subsequent typing enters the buffer cleanly
- [x] New coverage in `test_app.py` (text_trace on/off), `test_input_router.py` (ambient help/save, non-ambient quit), `test_notebook.py` (reset_input_buffer semantics)

https://claude.ai/code/session_01Bqqw4D3Hx2e9viK7HYavk6