### PR TITLE
notebook: F11 auto-advance after submit

### DIFF
--- a/asat/notebook.py
+++ b/asat/notebook.py
@@ -278,20 +278,46 @@ class NotebookCursor:
     def submit(self) -> Optional[Cell]:
         """Commit the input buffer and return the cell ready for execution.
 
-        The cursor transitions back to NOTEBOOK mode. Returns the cell
-        so that a controller layer can hand it to the execution kernel.
-        Returns None if called outside INPUT mode or with no focused cell.
+        The cursor auto-advances to a fresh empty INPUT cell after a
+        non-empty submit from the last cell in the session, so the
+        user can immediately type their next command (the REPL-like
+        behaviour documented in FEATURE_REQUESTS.md F11). Submitting
+        an empty buffer, or re-running an already-executed middle
+        cell, still lands in NOTEBOOK on the submitted cell — the
+        user was specifically editing that cell and shouldn't have a
+        new empty cell wedged in after it.
+
+        Returns the cell that was submitted so a controller layer can
+        hand it to the execution kernel. Returns None if called
+        outside INPUT mode or with no focused cell.
         """
         if self._state.mode != FocusMode.INPUT or self._state.cell_id is None:
             return None
         cell = self._commit_buffer_to_cell()
-        self._transition(
-            FocusState(
-                mode=FocusMode.NOTEBOOK,
-                cell_id=cell.cell_id,
-                input_buffer="",
-            )
+        should_autoadvance = (
+            bool(cell.command.strip())
+            and self._session.cells
+            and self._session.cells[-1].cell_id == cell.cell_id
         )
+        if should_autoadvance:
+            new_cell = Cell.new("")
+            self._session.add_cell(new_cell)
+            self._session.set_active(new_cell.cell_id)
+            self._transition(
+                FocusState(
+                    mode=FocusMode.INPUT,
+                    cell_id=new_cell.cell_id,
+                    input_buffer="",
+                )
+            )
+        else:
+            self._transition(
+                FocusState(
+                    mode=FocusMode.NOTEBOOK,
+                    cell_id=cell.cell_id,
+                    input_buffer="",
+                )
+            )
         return cell
 
     def _move(self, delta: int) -> Optional[Cell]:

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -95,9 +95,12 @@ file.
 4. **Press Enter**. You'll hear a triangle-wave "submit" cue on the
    left, then the narrator reads output lines as they stream, then a
    major-chord "success" chime on Enter's exit code, or a low minor
-   "failure" chord on the right if the command failed.
+   "failure" chord on the right if the command failed. ASAT
+   auto-advances to a fresh empty cell in INPUT mode, so you can
+   immediately type your next command without pressing anything else.
 5. **Press Escape**. You're now in NOTEBOOK mode. Up / Down walks
-   between cells.
+   between cells. (You only need this when you want to navigate
+   history; running a new command just means typing and Enter.)
 6. **Press Ctrl+O**. You're now in OUTPUT mode, stepping line-by-line
    through the selected cell's captured output. Escape leaves.
 7. **Press Ctrl+,** (or type `:settings` then Enter in INPUT mode).

--- a/tests/test_input_router.py
+++ b/tests/test_input_router.py
@@ -128,15 +128,21 @@ class InputModeDispatchTests(unittest.TestCase):
         self.assertEqual(cursor.focus.mode, FocusMode.NOTEBOOK)
         self.assertEqual(cells[0].command, "echox")
 
-    def test_enter_submits_and_returns_to_notebook(self) -> None:
-        bus, _, cursor, router, cells = _build(["echo"])
+    def test_enter_submits_and_autoadvances_to_new_input_cell(self) -> None:
+        """F11: after Enter submits a non-empty command from the last
+        cell, the user lands in INPUT mode on a fresh empty cell so
+        they can immediately type the next command."""
+        bus, session, cursor, router, cells = _build(["echo"])
         recorder = _Recorder(bus)
         router.handle_key(ENTER)
         router.handle_key(Key.printable(" "))
         router.handle_key(Key.printable("z"))
         router.handle_key(ENTER)
-        self.assertEqual(cursor.focus.mode, FocusMode.NOTEBOOK)
+        self.assertEqual(cursor.focus.mode, FocusMode.INPUT)
         self.assertEqual(cells[0].command, "echo z")
+        self.assertEqual(len(session), 2)
+        self.assertNotEqual(cursor.focus.cell_id, cells[0].cell_id)
+        self.assertEqual(cursor.focus.input_buffer, "")
         submit_events = [
             e for e in recorder.types_of(EventType.ACTION_INVOKED)
             if e.payload.get("action") == "submit"

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -173,7 +173,13 @@ class CursorInputModeTests(unittest.TestCase):
         cell = self.cursor.submit()
         assert cell is not None
         self.assertEqual(cell.command, "echo az")
-        self.assertEqual(self.cursor.focus.mode, FocusMode.NOTEBOOK)
+        # F11: submitting a non-empty command from the last cell
+        # auto-advances to a fresh empty INPUT cell so the user can
+        # keep typing without pressing Ctrl+N.
+        self.assertEqual(self.cursor.focus.mode, FocusMode.INPUT)
+        self.assertEqual(len(self.session), 2)
+        self.assertNotEqual(self.cursor.focus.cell_id, cell.cell_id)
+        self.assertEqual(self.cursor.focus.input_buffer, "")
 
     def test_submit_outside_input_mode_returns_none(self) -> None:
         self.assertIsNone(self.cursor.submit())
@@ -183,6 +189,57 @@ class CursorInputModeTests(unittest.TestCase):
         self.assertEqual(self.cursor.focus.mode, FocusMode.INPUT)
         self.assertEqual(self.cursor.focus.cell_id, fresh.cell_id)
         self.assertEqual(len(self.session), 2)
+
+    def test_submit_empty_buffer_does_not_autoadvance(self) -> None:
+        """Pressing Enter on an empty buffer should not spam the
+        session with empty cells. Stays in NOTEBOOK on the same cell
+        — effectively a silent no-op you can back out of."""
+        # Start from an empty cell so the commit produces no content.
+        bus = EventBus()
+        session, cells = _session_with([""])
+        cursor = NotebookCursor(session, bus)
+        cursor.enter_input_mode()
+        cell = cursor.submit()
+        self.assertEqual(cursor.focus.mode, FocusMode.NOTEBOOK)
+        self.assertEqual(len(session), 1)
+        assert cell is not None
+        self.assertEqual(cell.cell_id, cells[0].cell_id)
+
+    def test_submit_from_middle_cell_does_not_autoadvance(self) -> None:
+        """Re-running an already-executed middle cell (user edited it
+        and wants to re-run in place) should NOT wedge a new empty
+        cell into the middle of the notebook."""
+        bus = EventBus()
+        session, cells = _session_with(["first", "second", "third"])
+        cursor = NotebookCursor(session, bus)
+        # Focus the middle cell and enter input mode.
+        cursor.focus_cell(cells[1].cell_id)
+        cursor.enter_input_mode()
+        cursor.insert_character("x")
+        cell = cursor.submit()
+        assert cell is not None
+        self.assertEqual(cell.command, "secondx")
+        self.assertEqual(cursor.focus.mode, FocusMode.NOTEBOOK)
+        self.assertEqual(cursor.focus.cell_id, cells[1].cell_id)
+        # Session is still three cells, not four.
+        self.assertEqual(len(session), 3)
+
+    def test_submit_from_last_cell_with_content_autoadvances(self) -> None:
+        """The documented happy path: type, Enter, keep typing."""
+        bus = EventBus()
+        session, cells = _session_with(["first"])
+        cursor = NotebookCursor(session, bus)
+        cursor.enter_input_mode()
+        cursor.insert_character("!")
+        cell = cursor.submit()
+        assert cell is not None
+        self.assertEqual(cell.command, "first!")
+        self.assertEqual(cursor.focus.mode, FocusMode.INPUT)
+        self.assertEqual(len(session), 2)
+        # The new cell is the last cell.
+        self.assertEqual(session.cells[-1].cell_id, cursor.focus.cell_id)
+        # And it's empty, ready for the next command.
+        self.assertEqual(cursor.focus.input_buffer, "")
 
 
 class CursorOutputModeTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- `NotebookCursor.submit` now appends a fresh empty cell and lands in INPUT mode when the user submits a non-empty command from the last cell in the session — no more Ctrl+N between every command.
- Empty submits and submits from middle cells still land in NOTEBOOK on the submitted cell, so re-running history or hitting Enter on an empty buffer does not spam empty cells.
- USER_MANUAL's five-minute tour documents the new REPL-like behavior.

## Why
First-run walkthrough (see docs/FEATURE_REQUESTS.md F11) showed new users typed `echo hello`, `ls *.py`, `pwd` back-to-back and produced a single concatenated cell because Enter committed but never advanced. Auto-advance was the highest-impact fix.

## Test plan
- [x] `python -m unittest discover -s tests -t .` — **493 / 493** green (added 3 new F11 tests, updated 2 existing that asserted the old post-submit state).
- [x] Happy-path simulation: submit three distinct commands in a row, confirm each lands in its own cell with the cursor sitting in a fresh empty INPUT cell.
- [x] Regression: re-run a middle-of-history cell and confirm no new cell is appended.
- [x] Regression: press Enter on an empty buffer and confirm no new cell is appended.
