### PR TITLE
notebook+router: F13 in-line buffer editing

### DIFF
--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -69,7 +69,13 @@ def default_bindings() -> BindingMap:
         Ctrl+, (comma) opens the settings editor.
 
     INPUT mode:
-        Backspace deletes the last character,
+        Backspace deletes the character before the caret,
+        Delete removes the character under the caret,
+        Left / Right / Home / End move the caret within the buffer
+        (Ctrl+A / Ctrl+E also jump to start / end),
+        Ctrl+W kills the word before the caret,
+        Ctrl+U kills from the start of the buffer to the caret,
+        Ctrl+K kills from the caret to the end of the buffer,
         Enter submits the current command,
         Escape commits and returns to notebook mode.
         Lines beginning with `:` are treated as meta-commands
@@ -102,6 +108,16 @@ def default_bindings() -> BindingMap:
         },
         FocusMode.INPUT: {
             kc.BACKSPACE: "backspace",
+            kc.DELETE: "delete_forward",
+            kc.LEFT: "cursor_left",
+            kc.RIGHT: "cursor_right",
+            kc.HOME: "cursor_home",
+            kc.END: "cursor_end",
+            Key.combo("a", Modifier.CTRL): "cursor_home",
+            Key.combo("e", Modifier.CTRL): "cursor_end",
+            Key.combo("w", Modifier.CTRL): "delete_word_left",
+            Key.combo("u", Modifier.CTRL): "delete_to_start",
+            Key.combo("k", Modifier.CTRL): "delete_to_end",
             kc.ENTER: "submit",
             kc.ESCAPE: "exit_input",
         },
@@ -149,7 +165,9 @@ AMBIENT_META_COMMANDS: frozenset[str] = frozenset({"help", "save"})
 HELP_LINES: tuple[str, ...] = (
     "ASAT quick reference.",
     "NOTEBOOK:  Up/Down walk cells, Enter type, Ctrl+N new, Ctrl+O output, Ctrl+, settings.",
-    "INPUT:     Enter submits, Backspace deletes, Escape leaves without running.",
+    "INPUT:     Enter submits, Escape leaves without running.",
+    "           Backspace/Delete cut, Left/Right walk, Home/End jump (or Ctrl+A/E).",
+    "           Ctrl+W kills word, Ctrl+U kills to start, Ctrl+K kills to end.",
     "OUTPUT:    Up/Down step lines, PageUp/PageDown page, Escape leaves.",
     "SETTINGS:  Up/Down walk, Right/Enter descend, Left/Escape ascend, e edit, Ctrl+S save, Ctrl+Q close.",
     "Meta:      :help, :settings, :save, :quit (type in INPUT mode then Enter).",
@@ -386,6 +404,14 @@ class InputRouter:
             "exit_input": _void(self._cursor.exit_input_mode),
             "new_cell": _void(self._cursor.new_cell),
             "backspace": _void(self._cursor.backspace),
+            "cursor_left": _void(self._cursor.cursor_left),
+            "cursor_right": _void(self._cursor.cursor_right),
+            "cursor_home": _void(self._cursor.cursor_home),
+            "cursor_end": _void(self._cursor.cursor_end),
+            "delete_forward": _void(self._cursor.delete_forward),
+            "delete_word_left": _void(self._cursor.delete_word_left),
+            "delete_to_start": _void(self._cursor.delete_to_start),
+            "delete_to_end": _void(self._cursor.delete_to_end),
             "view_output": _void(self._cursor.view_output_mode),
             "exit_output": _void(self._cursor.exit_output_mode),
             "submit": self._submit,

--- a/asat/notebook.py
+++ b/asat/notebook.py
@@ -57,11 +57,16 @@ class FocusState:
         is empty and nothing is focused.
     input_buffer: the text currently being typed when in INPUT mode.
         Empty in other modes.
+    cursor_position: the caret offset into input_buffer (0 == before
+        the first character, len(buffer) == after the last). Only
+        meaningful in INPUT mode; kept at 0 in other modes. Always
+        satisfies 0 <= cursor_position <= len(input_buffer).
     """
 
     mode: FocusMode = FocusMode.NOTEBOOK
     cell_id: Optional[str] = None
     input_buffer: str = ""
+    cursor_position: int = 0
 
 
 class NotebookCursor:
@@ -122,6 +127,7 @@ class NotebookCursor:
                 mode=FocusMode.NOTEBOOK,
                 cell_id=cell_id,
                 input_buffer="",
+                cursor_position=0,
             )
         )
         return cell
@@ -136,12 +142,17 @@ class NotebookCursor:
                 mode=FocusMode.INPUT,
                 cell_id=cell.cell_id,
                 input_buffer=command,
+                cursor_position=len(command),
             )
         )
         return cell
 
     def enter_input_mode(self) -> Optional[FocusState]:
-        """Switch from notebook to input mode on the focused cell."""
+        """Switch from notebook to input mode on the focused cell.
+
+        The caret lands at the end of the existing command so typing
+        continues to append the way the user expects.
+        """
         if self._state.cell_id is None:
             return None
         cell = self._session.get_cell(self._state.cell_id)
@@ -150,6 +161,7 @@ class NotebookCursor:
                 mode=FocusMode.INPUT,
                 cell_id=cell.cell_id,
                 input_buffer=cell.command,
+                cursor_position=len(cell.command),
             )
         )
         return self._state
@@ -164,6 +176,7 @@ class NotebookCursor:
                 mode=FocusMode.NOTEBOOK,
                 cell_id=self._state.cell_id,
                 input_buffer="",
+                cursor_position=0,
             )
         )
         return self._state
@@ -183,6 +196,7 @@ class NotebookCursor:
                 mode=FocusMode.OUTPUT,
                 cell_id=self._state.cell_id,
                 input_buffer="",
+                cursor_position=0,
             )
         )
         return self._state
@@ -196,6 +210,7 @@ class NotebookCursor:
                 mode=FocusMode.NOTEBOOK,
                 cell_id=self._state.cell_id,
                 input_buffer="",
+                cursor_position=0,
             )
         )
         return self._state
@@ -207,6 +222,7 @@ class NotebookCursor:
                 mode=FocusMode.SETTINGS,
                 cell_id=self._state.cell_id,
                 input_buffer="",
+                cursor_position=0,
             )
         )
         return self._state
@@ -220,6 +236,7 @@ class NotebookCursor:
                 mode=FocusMode.NOTEBOOK,
                 cell_id=self._state.cell_id,
                 input_buffer="",
+                cursor_position=0,
             )
         )
         return self._state
@@ -239,6 +256,7 @@ class NotebookCursor:
                 mode=FocusMode.NOTEBOOK,
                 cell_id=self._state.cell_id,
                 input_buffer="",
+                cursor_position=0,
             )
         )
         return self._state
@@ -257,23 +275,120 @@ class NotebookCursor:
             return
         if not self._state.input_buffer:
             return
-        self._transition(replace(self._state, input_buffer=""))
+        self._transition(replace(self._state, input_buffer="", cursor_position=0))
 
     def insert_character(self, character: str) -> None:
-        """Append a character to the input buffer while in INPUT mode."""
+        """Insert a character at the current caret position.
+
+        The caret advances by one so subsequent inserts chain naturally.
+        """
         if self._state.mode != FocusMode.INPUT:
             return
         if len(character) != 1:
             raise ValueError("insert_character expects exactly one character")
-        self._transition(replace(self._state, input_buffer=self._state.input_buffer + character))
+        position = self._state.cursor_position
+        buffer = self._state.input_buffer
+        new_buffer = buffer[:position] + character + buffer[position:]
+        self._transition(
+            replace(self._state, input_buffer=new_buffer, cursor_position=position + 1)
+        )
 
     def backspace(self) -> None:
-        """Delete the last character from the input buffer."""
+        """Delete the character immediately before the caret."""
         if self._state.mode != FocusMode.INPUT:
             return
-        if not self._state.input_buffer:
+        position = self._state.cursor_position
+        if position == 0:
             return
-        self._transition(replace(self._state, input_buffer=self._state.input_buffer[:-1]))
+        buffer = self._state.input_buffer
+        new_buffer = buffer[: position - 1] + buffer[position:]
+        self._transition(
+            replace(self._state, input_buffer=new_buffer, cursor_position=position - 1)
+        )
+
+    def cursor_left(self) -> None:
+        """Move the caret one character to the left; clamp at start."""
+        if self._state.mode != FocusMode.INPUT:
+            return
+        if self._state.cursor_position == 0:
+            return
+        self._transition(replace(self._state, cursor_position=self._state.cursor_position - 1))
+
+    def cursor_right(self) -> None:
+        """Move the caret one character to the right; clamp at end."""
+        if self._state.mode != FocusMode.INPUT:
+            return
+        if self._state.cursor_position >= len(self._state.input_buffer):
+            return
+        self._transition(replace(self._state, cursor_position=self._state.cursor_position + 1))
+
+    def cursor_home(self) -> None:
+        """Jump the caret to the start of the input buffer."""
+        if self._state.mode != FocusMode.INPUT:
+            return
+        if self._state.cursor_position == 0:
+            return
+        self._transition(replace(self._state, cursor_position=0))
+
+    def cursor_end(self) -> None:
+        """Jump the caret to the end of the input buffer."""
+        if self._state.mode != FocusMode.INPUT:
+            return
+        end = len(self._state.input_buffer)
+        if self._state.cursor_position == end:
+            return
+        self._transition(replace(self._state, cursor_position=end))
+
+    def delete_forward(self) -> None:
+        """Delete the character at the caret (Delete key)."""
+        if self._state.mode != FocusMode.INPUT:
+            return
+        position = self._state.cursor_position
+        buffer = self._state.input_buffer
+        if position >= len(buffer):
+            return
+        new_buffer = buffer[:position] + buffer[position + 1 :]
+        self._transition(replace(self._state, input_buffer=new_buffer))
+
+    def delete_word_left(self) -> None:
+        """Delete the whitespace-delimited word preceding the caret."""
+        if self._state.mode != FocusMode.INPUT:
+            return
+        position = self._state.cursor_position
+        if position == 0:
+            return
+        buffer = self._state.input_buffer
+        # Skip trailing whitespace, then skip the word itself.
+        i = position
+        while i > 0 and buffer[i - 1].isspace():
+            i -= 1
+        while i > 0 and not buffer[i - 1].isspace():
+            i -= 1
+        if i == position:
+            return
+        new_buffer = buffer[:i] + buffer[position:]
+        self._transition(replace(self._state, input_buffer=new_buffer, cursor_position=i))
+
+    def delete_to_start(self) -> None:
+        """Delete everything from the start of the buffer up to the caret."""
+        if self._state.mode != FocusMode.INPUT:
+            return
+        position = self._state.cursor_position
+        if position == 0:
+            return
+        new_buffer = self._state.input_buffer[position:]
+        self._transition(replace(self._state, input_buffer=new_buffer, cursor_position=0))
+
+    def delete_to_end(self) -> None:
+        """Delete everything from the caret to the end of the buffer."""
+        if self._state.mode != FocusMode.INPUT:
+            return
+        position = self._state.cursor_position
+        buffer = self._state.input_buffer
+        if position >= len(buffer):
+            return
+        new_buffer = buffer[:position]
+        self._transition(replace(self._state, input_buffer=new_buffer))
 
     def submit(self) -> Optional[Cell]:
         """Commit the input buffer and return the cell ready for execution.
@@ -308,6 +423,7 @@ class NotebookCursor:
                     mode=FocusMode.INPUT,
                     cell_id=new_cell.cell_id,
                     input_buffer="",
+                    cursor_position=0,
                 )
             )
         else:
@@ -316,6 +432,7 @@ class NotebookCursor:
                     mode=FocusMode.NOTEBOOK,
                     cell_id=cell.cell_id,
                     input_buffer="",
+                    cursor_position=0,
                 )
             )
         return cell
@@ -346,12 +463,14 @@ class NotebookCursor:
     def _transition(self, new_state: FocusState) -> None:
         """Replace the focus state and publish an event if it changed.
 
-        Buffer-only deltas (the user typing into the input buffer) are
-        intentionally silent: they would otherwise fire FOCUS_CHANGED
-        per keystroke and drown the sound bank's `focus_shift` cue and
-        the terminal trace's `[input #…]` banner in noise. Consumers
-        that care about the typed text subscribe to ACTION_INVOKED
-        with `action == "insert_character"` instead.
+        Buffer-and-caret-only deltas (typing, deleting, and moving the
+        caret within the input buffer) are intentionally silent. They
+        would otherwise fire FOCUS_CHANGED per keystroke and drown the
+        sound bank's `focus_shift` cue and the terminal trace's
+        `[input #…]` banner in noise. Consumers that care about text
+        or caret edits subscribe to ACTION_INVOKED instead (actions
+        `insert_character`, `backspace`, `cursor_left`, `cursor_right`,
+        etc., or the richer shortcuts like `delete_word_left`).
         """
         if new_state == self._state:
             return

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -189,24 +189,28 @@ subprocess and publishes `COMMAND_CANCELLED`; bind Ctrl+C to it.
 
 ## F11 — Auto-advance after submit
 
-**Gap.** `NotebookCursor.submit()` drops to NOTEBOOK mode on the
-just-run cell. To run another command the user must press Ctrl+N
+**Status.** Done — `NotebookCursor.submit()` now appends a fresh
+empty cell and enters INPUT on it when the user submits a non-empty
+command from the last cell. Empty submits and submits from middle
+cells still stay on the submitted cell.
+
+**Gap.** `NotebookCursor.submit()` dropped to NOTEBOOK mode on the
+just-run cell. To run another command the user had to press Ctrl+N
 (create a fresh cell + enter INPUT). First-time users expect
 REPL-like "prompt again after Enter" behaviour instead.
 
-**Where it surfaces.** A user typing `echo first`, Enter, then
-`echo second` finds that letters are silently swallowed in NOTEBOOK
-mode; pressing Enter re-enters INPUT on the previous cell with its
-old command pre-loaded and appends to it. Running three commands in
-a row currently produces `echo firstecho secondecho third` in one
-cell. The manual's five-minute tour does not mention Ctrl+N.
+**Where it surfaced.** A user typing `echo first`, Enter, then
+`echo second` found that letters were silently swallowed in
+NOTEBOOK mode; pressing Enter re-entered INPUT on the previous cell
+with its old command pre-loaded and appended to it. Running three
+commands in a row produced `echo firstecho secondecho third` in one
+cell. The manual's five-minute tour did not mention Ctrl+N.
 
-**Sketch.** Either change `NotebookCursor.submit()` to create an
-empty trailing cell and transition to INPUT on it, or have
-`Application._on_action_invoked` append a fresh cell after every
-non-meta submit action. Audit the `FOCUS_CHANGED` / narration flow
-so the transition produces exactly one `[input #…]` banner rather
-than a flicker through NOTEBOOK.
+**Sketch (shipped).** `NotebookCursor.submit()` auto-advances when
+(1) the submitted command is non-empty, and (2) the submitted cell
+is the last cell in the session. The transition goes straight
+INPUT → INPUT so observers see exactly one `[input #…]` banner. See
+`asat/notebook.py::NotebookCursor.submit`.
 
 ---
 
@@ -236,23 +240,28 @@ its own review.
 
 ## F13 — In-line buffer editing
 
-**Gap.** INPUT mode only accepts printable characters and
-Backspace. Left / Right / Home / End / Delete / Ctrl+A / Ctrl+U /
-Ctrl+W / Ctrl+K are all unbound. A typo early in a long command
-forces the user to backspace the entire line.
+**Status.** Done — `FocusState` now carries `cursor_position`, and
+the NotebookCursor exposes `cursor_left` / `cursor_right` /
+`cursor_home` / `cursor_end` / `delete_forward` / `delete_word_left`
+/ `delete_to_start` / `delete_to_end`. INPUT-mode bindings cover
+Left / Right / Home / End / Delete plus the readline shortcuts
+Ctrl+A / Ctrl+E / Ctrl+W / Ctrl+U / Ctrl+K. Motion is published via
+`ACTION_INVOKED`; no new event type was needed.
 
-**Where it surfaces.** Every command of non-trivial length. Blind
+**Gap.** INPUT mode only accepted printable characters and
+Backspace. Left / Right / Home / End / Delete / Ctrl+A / Ctrl+U /
+Ctrl+W / Ctrl+K were all unbound. A typo early in a long command
+forced the user to backspace the entire line.
+
+**Where it surfaced.** Every command of non-trivial length. Blind
 users rely on left/right navigation and word-kill shortcuts to
 correct text without re-typing.
 
-**Sketch.** Add `cursor_position: int` to `FocusState`. Extend
-`NotebookCursor` with `cursor_left`, `cursor_right`, `cursor_home`,
-`cursor_end`, `delete_forward`, `delete_word_left`, `delete_to_start`,
-`delete_to_end`, and teach `insert_character` and `backspace` to
-respect the cursor position. Publish a new `INPUT_CURSOR_MOVED`
-event (or extend `FOCUS_CHANGED`) so the audio engine can cue the
-move without speaking every character. Bind the keys in
-`default_bindings()` and add a default cue to the SoundBank.
+**Not shipped (follow-up).** A dedicated SoundBank cue for caret
+motion is still pending — observers currently hear the existing
+`insert_character` / `backspace` cues but no cue for pure motion.
+Audio designers can wire a new binding against the `cursor_left`
+etc. action names when ready.
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -160,8 +160,15 @@ or when you press Enter from NOTEBOOK mode.
 
 | Key       | What it does                                      |
 |-----------|---------------------------------------------------|
-| Any char  | Appended to the input buffer.                     |
-| Backspace | Removes the last character.                       |
+| Any char  | Inserted at the caret.                            |
+| Backspace | Deletes the character before the caret.           |
+| Delete    | Deletes the character under the caret.            |
+| Left / Right | Move the caret one character.                  |
+| Home / End | Jump the caret to the start / end of the line.   |
+| Ctrl+A / Ctrl+E | Alias for Home / End (readline-style).       |
+| Ctrl+W    | Delete the word immediately before the caret.     |
+| Ctrl+U    | Delete from the start of the line up to the caret. |
+| Ctrl+K    | Delete from the caret to the end of the line.    |
 | Enter     | Submits the command to the execution kernel.      |
 | Escape    | Commits the buffer into the cell and returns to NOTEBOOK (does not run). |
 
@@ -312,7 +319,14 @@ Every key you need, one table.
 | NOTEBOOK   | Ctrl+O            | Enter OUTPUT mode                     |
 | NOTEBOOK   | Ctrl+,            | Open settings editor                  |
 | INPUT      | Enter             | Submit command                        |
-| INPUT      | Backspace         | Delete last char                      |
+| INPUT      | Backspace         | Delete char before caret              |
+| INPUT      | Delete            | Delete char under caret               |
+| INPUT      | Left / Right      | Move caret one character              |
+| INPUT      | Home / End        | Caret to start / end                  |
+| INPUT      | Ctrl+A / Ctrl+E   | Caret to start / end (readline)       |
+| INPUT      | Ctrl+W            | Delete word before caret              |
+| INPUT      | Ctrl+U            | Delete from start of line to caret    |
+| INPUT      | Ctrl+K            | Delete from caret to end of line      |
 | INPUT      | Escape            | Leave INPUT without running           |
 | INPUT      | `:help`⏎          | Narrate + print the cheat sheet       |
 | INPUT      | `:settings`⏎      | Open settings editor                  |

--- a/tests/test_input_router.py
+++ b/tests/test_input_router.py
@@ -10,15 +10,18 @@ from asat.events import Event, EventType
 from asat.input_router import InputRouter, default_bindings
 from asat.keys import (
     BACKSPACE,
+    DELETE,
     DOWN,
     END,
     ENTER,
     ESCAPE,
     HOME,
     Key,
+    LEFT,
     Modifier,
     PAGE_DOWN,
     PAGE_UP,
+    RIGHT,
     UP,
 )
 from asat.notebook import FocusMode, NotebookCursor
@@ -158,6 +161,81 @@ class InputModeDispatchTests(unittest.TestCase):
         self.assertIsNone(router.handle_key(Key.combo("n", Modifier.CTRL)))
         self.assertEqual(len(session), before)
         self.assertEqual(cursor.focus.mode, FocusMode.INPUT)
+
+
+class InLineBufferEditingBindingTests(unittest.TestCase):
+    """F13: the INPUT-mode binding map wires caret motion + kill keys
+    through to the NotebookCursor."""
+
+    def _enter_with_buffer(self, command: str) -> tuple[NotebookCursor, InputRouter]:
+        _, _, cursor, router, _ = _build([command])
+        router.handle_key(ENTER)
+        return cursor, router
+
+    def test_left_and_right_move_caret(self) -> None:
+        cursor, router = self._enter_with_buffer("echo hi")
+        router.handle_key(LEFT)
+        router.handle_key(LEFT)
+        self.assertEqual(cursor.focus.cursor_position, len("echo hi") - 2)
+        router.handle_key(RIGHT)
+        self.assertEqual(cursor.focus.cursor_position, len("echo hi") - 1)
+
+    def test_home_and_end_jump_caret(self) -> None:
+        cursor, router = self._enter_with_buffer("echo hi")
+        router.handle_key(HOME)
+        self.assertEqual(cursor.focus.cursor_position, 0)
+        router.handle_key(END)
+        self.assertEqual(cursor.focus.cursor_position, len("echo hi"))
+
+    def test_ctrl_a_and_ctrl_e_mirror_home_and_end(self) -> None:
+        cursor, router = self._enter_with_buffer("echo hi")
+        router.handle_key(Key.combo("a", Modifier.CTRL))
+        self.assertEqual(cursor.focus.cursor_position, 0)
+        router.handle_key(Key.combo("e", Modifier.CTRL))
+        self.assertEqual(cursor.focus.cursor_position, len("echo hi"))
+
+    def test_delete_removes_character_under_caret(self) -> None:
+        cursor, router = self._enter_with_buffer("echo hi")
+        router.handle_key(HOME)
+        router.handle_key(DELETE)
+        self.assertEqual(cursor.focus.input_buffer, "cho hi")
+
+    def test_insert_respects_caret_position(self) -> None:
+        cursor, router = self._enter_with_buffer("echo hi")
+        router.handle_key(HOME)
+        router.handle_key(Key.printable("X"))
+        self.assertEqual(cursor.focus.input_buffer, "Xecho hi")
+
+    def test_ctrl_w_kills_word_left(self) -> None:
+        cursor, router = self._enter_with_buffer("echo hello")
+        router.handle_key(Key.combo("w", Modifier.CTRL))
+        self.assertEqual(cursor.focus.input_buffer, "echo ")
+
+    def test_ctrl_u_kills_to_start(self) -> None:
+        cursor, router = self._enter_with_buffer("echo hello")
+        # Park the caret between "echo" and " hello", then kill the prefix.
+        for _ in range(len(" hello")):
+            router.handle_key(LEFT)
+        router.handle_key(Key.combo("u", Modifier.CTRL))
+        self.assertEqual(cursor.focus.input_buffer, " hello")
+
+    def test_ctrl_k_kills_to_end(self) -> None:
+        cursor, router = self._enter_with_buffer("echo hello")
+        for _ in range(len(" hello")):
+            router.handle_key(LEFT)
+        router.handle_key(Key.combo("k", Modifier.CTRL))
+        self.assertEqual(cursor.focus.input_buffer, "echo")
+
+    def test_motion_publishes_action_invoked(self) -> None:
+        bus, _, _, router, _ = _build(["echo hi"])
+        router.handle_key(ENTER)
+        recorder = _Recorder(bus)
+        router.handle_key(LEFT)
+        actions = [
+            e.payload["action"]
+            for e in recorder.types_of(EventType.ACTION_INVOKED)
+        ]
+        self.assertIn("cursor_left", actions)
 
 
 class ActionEventPayloadTests(unittest.TestCase):

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -317,5 +317,147 @@ class ResetInputBufferTests(unittest.TestCase):
         self.assertEqual(recorder.events, [])
 
 
+class InLineBufferEditingTests(unittest.TestCase):
+    """F13: caret tracking, in-place insert, and readline-style kill
+    shortcuts inside the input buffer."""
+
+    def setUp(self) -> None:
+        self.bus = EventBus()
+        self.recorder = _Recorder(self.bus)
+        self.session, self.cells = _session_with(["echo hello"])
+        self.cursor = NotebookCursor(self.session, self.bus)
+        self.cursor.enter_input_mode()
+        # Drop the focus-changed event caused by entering input mode.
+        self.recorder.events.clear()
+
+    def test_enter_input_mode_places_caret_at_end(self) -> None:
+        self.assertEqual(self.cursor.focus.cursor_position, len("echo hello"))
+
+    def test_cursor_left_and_right_move_one_character(self) -> None:
+        self.cursor.cursor_left()
+        self.cursor.cursor_left()
+        self.assertEqual(self.cursor.focus.cursor_position, len("echo hello") - 2)
+        self.cursor.cursor_right()
+        self.assertEqual(self.cursor.focus.cursor_position, len("echo hello") - 1)
+
+    def test_cursor_motion_does_not_publish_focus_changed(self) -> None:
+        self.cursor.cursor_left()
+        self.cursor.cursor_right()
+        self.cursor.cursor_home()
+        self.cursor.cursor_end()
+        self.assertEqual(self.recorder.events, [])
+
+    def test_cursor_left_clamps_at_start(self) -> None:
+        self.cursor.cursor_home()
+        self.cursor.cursor_left()
+        self.assertEqual(self.cursor.focus.cursor_position, 0)
+
+    def test_cursor_right_clamps_at_end(self) -> None:
+        # Already at end from setUp.
+        self.cursor.cursor_right()
+        self.assertEqual(self.cursor.focus.cursor_position, len("echo hello"))
+
+    def test_cursor_home_and_end(self) -> None:
+        self.cursor.cursor_home()
+        self.assertEqual(self.cursor.focus.cursor_position, 0)
+        self.cursor.cursor_end()
+        self.assertEqual(self.cursor.focus.cursor_position, len("echo hello"))
+
+    def test_insert_character_inserts_at_caret(self) -> None:
+        self.cursor.cursor_home()
+        self.cursor.insert_character("X")
+        self.assertEqual(self.cursor.focus.input_buffer, "Xecho hello")
+        self.assertEqual(self.cursor.focus.cursor_position, 1)
+
+    def test_insert_character_in_middle(self) -> None:
+        # Move caret between "echo" and " hello".
+        for _ in range(len(" hello")):
+            self.cursor.cursor_left()
+        self.cursor.insert_character("!")
+        self.assertEqual(self.cursor.focus.input_buffer, "echo! hello")
+        self.assertEqual(self.cursor.focus.cursor_position, len("echo!"))
+
+    def test_backspace_deletes_before_caret(self) -> None:
+        # Move caret to the start of "hello"; backspace should eat the space.
+        for _ in range(len("hello")):
+            self.cursor.cursor_left()
+        self.cursor.backspace()
+        self.assertEqual(self.cursor.focus.input_buffer, "echohello")
+        # Caret now sits where the space used to be (index 4).
+        self.assertEqual(self.cursor.focus.cursor_position, 4)
+
+    def test_backspace_at_start_is_noop(self) -> None:
+        self.cursor.cursor_home()
+        self.cursor.backspace()
+        self.assertEqual(self.cursor.focus.input_buffer, "echo hello")
+        self.assertEqual(self.cursor.focus.cursor_position, 0)
+
+    def test_delete_forward_deletes_under_caret(self) -> None:
+        self.cursor.cursor_home()
+        self.cursor.delete_forward()
+        self.assertEqual(self.cursor.focus.input_buffer, "cho hello")
+        self.assertEqual(self.cursor.focus.cursor_position, 0)
+
+    def test_delete_forward_at_end_is_noop(self) -> None:
+        # Caret is at the end after setUp.
+        self.cursor.delete_forward()
+        self.assertEqual(self.cursor.focus.input_buffer, "echo hello")
+
+    def test_delete_word_left_eats_preceding_word(self) -> None:
+        self.cursor.delete_word_left()
+        self.assertEqual(self.cursor.focus.input_buffer, "echo ")
+        self.assertEqual(self.cursor.focus.cursor_position, len("echo "))
+
+    def test_delete_word_left_eats_trailing_whitespace(self) -> None:
+        # "echo hello   " with trailing whitespace — should kill both.
+        for ch in "   ":
+            self.cursor.insert_character(ch)
+        self.cursor.delete_word_left()
+        self.assertEqual(self.cursor.focus.input_buffer, "echo ")
+        self.assertEqual(self.cursor.focus.cursor_position, len("echo "))
+
+    def test_delete_word_left_at_start_is_noop(self) -> None:
+        self.cursor.cursor_home()
+        self.cursor.delete_word_left()
+        self.assertEqual(self.cursor.focus.input_buffer, "echo hello")
+
+    def test_delete_to_start_clears_prefix(self) -> None:
+        # Move caret to just before "hello".
+        for _ in range(len("hello")):
+            self.cursor.cursor_left()
+        self.cursor.delete_to_start()
+        self.assertEqual(self.cursor.focus.input_buffer, "hello")
+        self.assertEqual(self.cursor.focus.cursor_position, 0)
+
+    def test_delete_to_end_clears_suffix(self) -> None:
+        # Caret between "echo" and " hello".
+        for _ in range(len(" hello")):
+            self.cursor.cursor_left()
+        self.cursor.delete_to_end()
+        self.assertEqual(self.cursor.focus.input_buffer, "echo")
+        # Caret position unchanged.
+        self.assertEqual(self.cursor.focus.cursor_position, len("echo"))
+
+    def test_motion_and_edit_outside_input_mode_are_noops(self) -> None:
+        self.cursor.exit_input_mode()
+        self.assertEqual(self.cursor.focus.mode, FocusMode.NOTEBOOK)
+        self.cursor.cursor_left()
+        self.cursor.cursor_right()
+        self.cursor.cursor_home()
+        self.cursor.cursor_end()
+        self.cursor.delete_forward()
+        self.cursor.delete_word_left()
+        self.cursor.delete_to_start()
+        self.cursor.delete_to_end()
+        # None of these should have altered buffer/caret state.
+        self.assertEqual(self.cursor.focus.input_buffer, "")
+        self.assertEqual(self.cursor.focus.cursor_position, 0)
+
+    def test_exiting_input_mode_resets_caret(self) -> None:
+        self.cursor.cursor_home()
+        self.cursor.exit_input_mode()
+        self.assertEqual(self.cursor.focus.cursor_position, 0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- `FocusState` gains `cursor_position`, and `NotebookCursor` now exposes `cursor_left`, `cursor_right`, `cursor_home`, `cursor_end`, `delete_forward`, `delete_word_left`, `delete_to_start`, `delete_to_end`. `insert_character` and `backspace` respect the caret instead of always editing at the end.
- INPUT-mode default bindings pick up Left / Right / Home / End / Delete plus the readline shortcuts Ctrl+A / Ctrl+E / Ctrl+W / Ctrl+U / Ctrl+K.
- Caret motion stays silent on `FOCUS_CHANGED` (same rule as `insert_character`); observers who need it subscribe to `ACTION_INVOKED` by action name.
- USER_MANUAL's INPUT-mode table and cheat sheet, plus the in-app `:help` lines, document the new keys.

## Why
First-run UX audit (docs/FEATURE_REQUESTS.md F13) found that a single typo early in a long command forced the user to backspace the entire line. Blind users especially rely on Left / Right / Home / End / Ctrl+W to correct text without re-typing.

## Not shipped (follow-up)
A dedicated SoundBank cue for caret motion is still pending — observers hear the existing `insert_character` / `backspace` cues but no distinct cue for pure motion. Audio designers can bind against the new action names (`cursor_left`, `cursor_right`, `cursor_home`, `cursor_end`, `delete_forward`, `delete_word_left`, `delete_to_start`, `delete_to_end`) when ready.

## Test plan
- [x] `python -m unittest discover -s tests -t .` — **521 / 521** green (added 28 new tests covering caret tracking, in-place insert/backspace, kill shortcuts, and router bindings).
- [x] Manual simulation: typed `echo helo world`, walked caret into `helo`, inserted `l`, then used Ctrl+W and Ctrl+U to shrink the buffer back to empty — all with the expected caret positions.
- [x] Regression: existing `test_insert_character_appends_to_buffer` and `test_backspace_removes_last_character` still pass unchanged because the caret lands at end on `enter_input_mode`.
