### PR TITLE
app+router: F14 ActionMenu keystroke binding

### DIFF
--- a/asat/app.py
+++ b/asat/app.py
@@ -24,6 +24,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, TextIO
 
+from asat.actions import (
+    ActionCatalog,
+    ActionMenu,
+    Clipboard,
+    MemoryClipboard,
+    default_actions,
+)
 from asat.audio_sink import AudioSink, MemorySink
 from asat.default_bank import default_sound_bank
 from asat.event_bus import EventBus, publish_event
@@ -62,6 +69,9 @@ class Application:
     sound_engine: SoundEngine
     sink: AudioSink
     settings_controller: SettingsController
+    clipboard: Clipboard
+    action_catalog: ActionCatalog
+    action_menu: ActionMenu
     session_path: Optional[Path] = None
     running: bool = True
 
@@ -112,12 +122,22 @@ class Application:
             resolved_bank,
             save_path=bank_path,
         )
+        clipboard: Clipboard = MemoryClipboard()
+        action_catalog = default_actions(
+            cursor=cursor,
+            recorder=recorder,
+            output_cursor=output_cursor,
+            clipboard=clipboard,
+            bus=bus,
+        )
+        action_menu = ActionMenu(bus, action_catalog)
         router = InputRouter(
             cursor,
             bus,
             bindings=default_bindings(),
             output_cursor=output_cursor,
             settings_controller=settings_controller,
+            action_menu=action_menu,
         )
         resolved_sink: AudioSink = sink if sink is not None else MemorySink()
         sound_engine = SoundEngine(bus, resolved_bank, resolved_sink)
@@ -134,6 +154,9 @@ class Application:
             sound_engine=sound_engine,
             sink=resolved_sink,
             settings_controller=settings_controller,
+            clipboard=clipboard,
+            action_catalog=action_catalog,
+            action_menu=action_menu,
             session_path=Path(session_path) if session_path is not None else None,
         )
         # Everything below fires AFTER sound_engine and (if requested)

--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 from typing import Callable, Optional
 
 from asat import keys as kc
+from asat.actions import ActionContext, ActionMenu
 from asat.event_bus import EventBus, publish_event
 from asat.events import EventType
 from asat.keys import Key, Modifier
@@ -66,7 +67,8 @@ def default_bindings() -> BindingMap:
         Enter enters input mode on the focused cell,
         Ctrl+N appends a fresh cell and enters input mode,
         Ctrl+O opens the captured output of the focused cell,
-        Ctrl+, (comma) opens the settings editor.
+        Ctrl+, (comma) opens the settings editor,
+        F2 (or Ctrl+.) opens the contextual actions menu.
 
     INPUT mode:
         Backspace deletes the character before the caret,
@@ -85,6 +87,7 @@ def default_bindings() -> BindingMap:
         Up/Down walk one line at a time,
         PageUp/PageDown jump a page,
         Home/End jump to the first or last captured line,
+        F2 (or Ctrl+.) opens the contextual actions menu,
         Escape returns to notebook mode.
 
     SETTINGS mode:
@@ -95,6 +98,7 @@ def default_bindings() -> BindingMap:
         Ctrl+S saves the bank, Ctrl+Q closes the editor,
         Escape ascends or (at the top level) closes.
     """
+    menu_open = Key.combo(".", Modifier.CTRL)
     return {
         FocusMode.NOTEBOOK: {
             kc.UP: "move_up",
@@ -105,6 +109,8 @@ def default_bindings() -> BindingMap:
             Key.combo("n", Modifier.CTRL): "new_cell",
             Key.combo("o", Modifier.CTRL): "view_output",
             Key.combo(",", Modifier.CTRL): "open_settings",
+            kc.F2: "open_action_menu",
+            menu_open: "open_action_menu",
         },
         FocusMode.INPUT: {
             kc.BACKSPACE: "backspace",
@@ -120,6 +126,8 @@ def default_bindings() -> BindingMap:
             Key.combo("k", Modifier.CTRL): "delete_to_end",
             kc.ENTER: "submit",
             kc.ESCAPE: "exit_input",
+            kc.F2: "open_action_menu",
+            menu_open: "open_action_menu",
         },
         FocusMode.OUTPUT: {
             kc.UP: "output_line_up",
@@ -129,6 +137,8 @@ def default_bindings() -> BindingMap:
             kc.HOME: "output_to_start",
             kc.END: "output_to_end",
             kc.ESCAPE: "exit_output",
+            kc.F2: "open_action_menu",
+            menu_open: "open_action_menu",
         },
         FocusMode.SETTINGS: {
             kc.UP: "settings_prev",
@@ -170,6 +180,7 @@ HELP_LINES: tuple[str, ...] = (
     "           Ctrl+W kills word, Ctrl+U kills to start, Ctrl+K kills to end.",
     "OUTPUT:    Up/Down step lines, PageUp/PageDown page, Escape leaves.",
     "SETTINGS:  Up/Down walk, Right/Enter descend, Left/Escape ascend, e edit, Ctrl+S save, Ctrl+Q close.",
+    "Menu:      F2 (or Ctrl+.) opens contextual actions; Up/Down walk, Enter invokes, Escape closes.",
     "Meta:      :help, :settings, :save, :quit (type in INPUT mode then Enter).",
     "Exit:      :quit, or EOF (Ctrl+D on POSIX, Ctrl+Z Enter on Windows).",
     "Docs:      docs/USER_MANUAL.md for the full keystroke reference.",
@@ -188,6 +199,7 @@ class InputRouter:
         bindings: Optional[BindingMap] = None,
         output_cursor: Optional[OutputCursor] = None,
         settings_controller: Optional[SettingsController] = None,
+        action_menu: Optional[ActionMenu] = None,
     ) -> None:
         """Attach the router to a cursor, event bus, and optional cursors.
 
@@ -196,12 +208,20 @@ class InputRouter:
         SETTINGS focus-mode key map, and recognition of `:settings`
         in INPUT mode. When it is absent, those actions silently no-op
         so a test or embedding that ignores audio still works.
+
+        When an `action_menu` is supplied, F2 (and Ctrl+.) open the
+        contextual actions menu from NOTEBOOK / INPUT / OUTPUT mode.
+        While the menu is open, Up/Down cycle items, Enter invokes the
+        focused item, and Escape closes the menu without activating.
+        Without an `action_menu` the `open_action_menu` action is a
+        silent no-op.
         """
         self._cursor = cursor
         self._bus = bus
         self._bindings = bindings if bindings is not None else default_bindings()
         self._output_cursor = output_cursor
         self._settings_controller = settings_controller
+        self._action_menu = action_menu
 
     @property
     def bindings(self) -> BindingMap:
@@ -217,6 +237,8 @@ class InputRouter:
         no binding.
         """
         self._publish_key(key)
+        if self._action_menu is not None and self._action_menu.is_open:
+            return self._dispatch_menu_key(key)
         mode = self._cursor.focus.mode
         if mode == FocusMode.SETTINGS and self._settings_active_editing():
             return self._dispatch_settings_edit_key(key)
@@ -229,6 +251,29 @@ class InputRouter:
             self._cursor.insert_character(key.char)
             self._publish_action("insert_character", key, {"char": key.char})
             return "insert_character"
+        return None
+
+    def _dispatch_menu_key(self, key: Key) -> Optional[str]:
+        """Route keys while the actions menu is open.
+
+        Up / Down cycle the focused item, Enter invokes it (which then
+        closes the menu), and Escape closes without activating. Every
+        other key is swallowed so they do not leak into the underlying
+        focus mode — opening the menu is modal by design.
+        """
+        assert self._action_menu is not None
+        if key == kc.UP:
+            self._invoke("menu_prev", key)
+            return "menu_prev"
+        if key == kc.DOWN:
+            self._invoke("menu_next", key)
+            return "menu_next"
+        if key == kc.ENTER:
+            self._invoke("menu_activate", key)
+            return "menu_activate"
+        if key == kc.ESCAPE:
+            self._invoke("menu_close", key)
+            return "menu_close"
         return None
 
     def _settings_active_editing(self) -> bool:
@@ -387,6 +432,64 @@ class InputRouter:
         if self._settings_controller is not None:
             self._settings_controller.backspace_edit()
 
+    def _open_action_menu(self) -> Optional[dict[str, object]]:
+        """Open the contextual actions menu against the current focus.
+
+        Snapshots the current focus (mode + cell) plus, in OUTPUT mode,
+        the focused line number / stream / text so OUTPUT providers can
+        offer `Copy focused line`. A no-op when no `action_menu` was
+        supplied or when the SETTINGS editor is open (the settings UI
+        is modal and its keys would collide with the menu's).
+        """
+        if self._action_menu is None:
+            return None
+        mode = self._cursor.focus.mode
+        if mode == FocusMode.SETTINGS:
+            return None
+        context = self._build_action_context(mode)
+        self._action_menu.open(context)
+        return {"item_count": len(self._action_menu.items)}
+
+    def _build_action_context(self, mode: FocusMode) -> ActionContext:
+        """Assemble the ActionContext consumed by ActionCatalog providers."""
+        cell_id = self._cursor.focus.cell_id
+        line_number: Optional[int] = None
+        line_stream: Optional[str] = None
+        line_text: Optional[str] = None
+        if mode == FocusMode.OUTPUT and self._output_cursor is not None:
+            current = self._output_cursor.current_line()
+            if current is not None:
+                line_number = current.line_number
+                line_stream = current.stream
+                line_text = current.text
+        return ActionContext(
+            focus_mode=mode,
+            cell_id=cell_id,
+            line_number=line_number,
+            line_stream=line_stream,
+            line_text=line_text,
+        )
+
+    def _menu_prev(self) -> None:
+        """Move the menu focus to the previous item (no-op when closed)."""
+        if self._action_menu is not None:
+            self._action_menu.focus_prev()
+
+    def _menu_next(self) -> None:
+        """Move the menu focus to the next item (no-op when closed)."""
+        if self._action_menu is not None:
+            self._action_menu.focus_next()
+
+    def _menu_activate(self) -> None:
+        """Invoke the focused menu item; the menu closes itself."""
+        if self._action_menu is not None:
+            self._action_menu.activate()
+
+    def _menu_close(self) -> None:
+        """Close the menu without invoking anything."""
+        if self._action_menu is not None:
+            self._action_menu.close()
+
     def _action_handler(self, action: str) -> ActionHandler:
         """Map an action name to a zero-argument callable.
 
@@ -444,6 +547,11 @@ class InputRouter:
             "settings_edit_commit": self._settings_edit_commit,
             "settings_edit_cancel": _void(self._settings_edit_cancel),
             "settings_edit_backspace": _void(self._settings_edit_backspace),
+            "open_action_menu": self._open_action_menu,
+            "menu_prev": _void(self._menu_prev),
+            "menu_next": _void(self._menu_next),
+            "menu_activate": _void(self._menu_activate),
+            "menu_close": _void(self._menu_close),
         }
         if action not in handlers:
             raise KeyError(f"Unknown action: {action}")

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -267,25 +267,30 @@ etc. action names when ready.
 
 ## F14 — ActionMenu keystroke binding
 
-**Gap.** `asat/actions.py` builds a fully-functional `ActionMenu`
-with default providers that contribute "copy focused line", "copy
-all output", "copy stderr only", "edit command", "explore output",
-etc. No default keystroke opens the menu, so the whole module is
-unreachable from a real user's keyboard today. As a direct
-consequence, clipboard functionality is also unreachable.
+**Status.** Done — `Application.build()` now wires a `MemoryClipboard`,
+an `ActionCatalog` via `default_actions(...)`, and an `ActionMenu`.
+F2 (and Ctrl+. as a fallback) opens the menu from NOTEBOOK, INPUT,
+and OUTPUT modes. While the menu is open, Up/Down cycle items,
+Enter invokes, and Escape closes. SETTINGS mode is excluded so the
+modal editor's keys do not collide.
 
-**Where it surfaces.** A user who wants to copy a single output
-line has no way to do it. Tests drive `ActionMenu.activate(...)`
-programmatically but no key triggers `ACTION_MENU_OPENED`.
+**Gap.** `asat/actions.py` built a fully-functional `ActionMenu`
+with default providers ("copy focused line", "copy all output",
+"copy stderr only", "edit command", "explore output", etc.) but
+no default keystroke opened the menu, so the whole module was
+unreachable from a real user's keyboard. As a direct consequence,
+clipboard functionality was also unreachable.
 
-**Sketch.** `Application.build()` constructs an `ActionCatalog` via
-`default_actions(...)` and an `ActionMenu` wired to the bus. Add
-an `open_action_menu` action in `InputRouter`, bound to a mode-
-agnostic key (F2 or `Menu` key; Ctrl+. as fallback on keyboards
-without F-row). When the menu is open the router routes keys to a
-menu dispatch (Up/Down cycle, Enter activate, Escape close).
-`default_bindings()` gains the one new entry; every other mode
-keeps its current keymap unchanged.
+**Where it surfaced.** A user who wanted to copy a single output
+line had no way to do it. Tests drove `ActionMenu.activate(...)`
+programmatically but no key triggered `ACTION_MENU_OPENED`.
+
+**Sketch (shipped).** `Application.build()` constructs the catalog,
+menu, and clipboard; `InputRouter` gains an `action_menu` parameter
+and an `open_action_menu` action that snapshots the focused cell
+(plus line context in OUTPUT mode) into an `ActionContext` before
+calling `menu.open(...)`. See `asat/input_router.py::_open_action_menu`
+and `_dispatch_menu_key`.
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -227,6 +227,34 @@ to say "stderr:" every time.
 
 ---
 
+## Actions menu — context-sensitive affordances
+
+The actions menu is the keyboard-driven equivalent of a right-click
+menu. Press **F2** (or **Ctrl+.** as a fallback on keyboards without
+an F-row) from NOTEBOOK, INPUT, or OUTPUT mode and a short list of
+items appears based on where you're focused:
+
+* **NOTEBOOK** — edit the focused command, or explore its output.
+* **INPUT** — submit the command, or cancel editing.
+* **OUTPUT** — copy the focused line, copy the whole buffer, copy
+  just stderr, or return to the notebook.
+
+While the menu is open the keymap is modal:
+
+| Key       | What it does                                      |
+|-----------|---------------------------------------------------|
+| Up / Down | Previous / next item (clamped at the ends).       |
+| Enter     | Invoke the focused item; the menu closes.         |
+| Escape    | Close the menu without invoking anything.         |
+
+Every transition narrates. Opening the menu reads the item labels,
+Up/Down reads the newly-focused label, Enter announces the invocation
+and fires the `menu_activate` cue, and Escape fires `menu_close`.
+Copy items route through the clipboard (in-memory by default;
+platform adapters can plug in an OS backend).
+
+---
+
 ## SETTINGS mode — reshaping audio without restarting
 
 The settings editor is the live control surface for every voice,
@@ -318,6 +346,7 @@ Every key you need, one table.
 | NOTEBOOK   | Ctrl+N            | New empty cell                        |
 | NOTEBOOK   | Ctrl+O            | Enter OUTPUT mode                     |
 | NOTEBOOK   | Ctrl+,            | Open settings editor                  |
+| NOTEBOOK   | F2 / Ctrl+.       | Open actions menu                     |
 | INPUT      | Enter             | Submit command                        |
 | INPUT      | Backspace         | Delete char before caret              |
 | INPUT      | Delete            | Delete char under caret               |
@@ -328,6 +357,7 @@ Every key you need, one table.
 | INPUT      | Ctrl+U            | Delete from start of line to caret    |
 | INPUT      | Ctrl+K            | Delete from caret to end of line      |
 | INPUT      | Escape            | Leave INPUT without running           |
+| INPUT      | F2 / Ctrl+.       | Open actions menu                     |
 | INPUT      | `:help`⏎          | Narrate + print the cheat sheet       |
 | INPUT      | `:settings`⏎      | Open settings editor                  |
 | INPUT      | `:save`⏎          | Save session                          |
@@ -336,6 +366,10 @@ Every key you need, one table.
 | OUTPUT     | PageUp / PageDown | Jump a page                           |
 | OUTPUT     | Home / End        | First / last line                     |
 | OUTPUT     | Escape            | Back to NOTEBOOK                      |
+| OUTPUT     | F2 / Ctrl+.       | Open actions menu                     |
+| MENU       | Up / Down         | Prev / next item                      |
+| MENU       | Enter             | Invoke focused item                   |
+| MENU       | Escape            | Close without invoking                |
 | SETTINGS   | Up / Down         | Prev / next item                      |
 | SETTINGS   | Right / Enter     | Descend                               |
 | SETTINGS   | Left / Escape     | Ascend / close                        |

--- a/tests/test_input_router.py
+++ b/tests/test_input_router.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import unittest
 
+from asat.actions import ActionMenu, MemoryClipboard, default_actions
 from asat.cell import Cell
 from asat.event_bus import EventBus
 from asat.events import Event, EventType
@@ -15,6 +16,7 @@ from asat.keys import (
     END,
     ENTER,
     ESCAPE,
+    F2,
     HOME,
     Key,
     LEFT,
@@ -25,7 +27,7 @@ from asat.keys import (
     UP,
 )
 from asat.notebook import FocusMode, NotebookCursor
-from asat.output_buffer import OutputBuffer, STDOUT
+from asat.output_buffer import OutputBuffer, OutputRecorder, STDOUT
 from asat.output_cursor import OutputCursor
 from asat.session import Session
 from asat.settings_controller import SettingsController
@@ -587,6 +589,132 @@ class CustomBindingTests(unittest.TestCase):
         router = InputRouter(cursor, bus, bindings=custom)
         self.assertEqual(router.handle_key(Key.printable("j")), "move_down")
         self.assertIsNone(router.handle_key(UP))
+
+
+def _build_with_menu(
+    commands: list[str],
+) -> tuple[EventBus, NotebookCursor, InputRouter, ActionMenu, OutputCursor, OutputRecorder, MemoryClipboard]:
+    """Build a router wired to a real ActionMenu + default providers.
+
+    Mirrors what `Application.build` assembles but keeps the audio and
+    kernel sides out of the way so menu dispatch is the only thing
+    under test.
+    """
+    bus = EventBus()
+    session = Session.new()
+    for command in commands:
+        session.add_cell(Cell.new(command))
+    cursor = NotebookCursor(session, bus)
+    recorder = OutputRecorder(bus)
+    output_cursor = OutputCursor(bus)
+    clipboard = MemoryClipboard()
+    catalog = default_actions(
+        cursor=cursor,
+        recorder=recorder,
+        output_cursor=output_cursor,
+        clipboard=clipboard,
+        bus=bus,
+    )
+    menu = ActionMenu(bus, catalog)
+    router = InputRouter(
+        cursor,
+        bus,
+        output_cursor=output_cursor,
+        action_menu=menu,
+    )
+    return bus, cursor, router, menu, output_cursor, recorder, clipboard
+
+
+class ActionMenuBindingTests(unittest.TestCase):
+    """F14: F2 (and Ctrl+.) open the contextual menu, and while the
+    menu is open Up / Down / Enter / Escape drive it instead of the
+    current focus mode."""
+
+    def test_f2_opens_menu_from_notebook(self) -> None:
+        _, _, router, menu, _, _, _ = _build_with_menu(["echo"])
+        self.assertFalse(menu.is_open)
+        self.assertEqual(router.handle_key(F2), "open_action_menu")
+        self.assertTrue(menu.is_open)
+        # NOTEBOOK providers contribute "enter_input" + "view_output".
+        self.assertEqual([item.id for item in menu.items], ["enter_input", "view_output"])
+
+    def test_ctrl_dot_is_alternate_opener(self) -> None:
+        _, _, router, menu, _, _, _ = _build_with_menu(["echo"])
+        self.assertEqual(
+            router.handle_key(Key.combo(".", Modifier.CTRL)),
+            "open_action_menu",
+        )
+        self.assertTrue(menu.is_open)
+
+    def test_f2_opens_menu_from_input_mode(self) -> None:
+        _, _, router, menu, _, _, _ = _build_with_menu(["echo"])
+        router.handle_key(ENTER)  # enter INPUT
+        router.handle_key(F2)
+        self.assertTrue(menu.is_open)
+        # INPUT providers contribute "submit" + "exit_input".
+        self.assertEqual([item.id for item in menu.items], ["submit", "exit_input"])
+
+    def test_menu_up_and_down_cycle_items(self) -> None:
+        _, _, router, menu, _, _, _ = _build_with_menu(["echo"])
+        router.handle_key(F2)
+        self.assertEqual(menu.current_item().id, "enter_input")
+        self.assertEqual(router.handle_key(DOWN), "menu_next")
+        self.assertEqual(menu.current_item().id, "view_output")
+        self.assertEqual(router.handle_key(UP), "menu_prev")
+        self.assertEqual(menu.current_item().id, "enter_input")
+
+    def test_enter_activates_and_closes(self) -> None:
+        _, cursor, router, menu, _, _, _ = _build_with_menu(["echo"])
+        router.handle_key(F2)
+        # "enter_input" is first; activating it enters INPUT mode.
+        result = router.handle_key(ENTER)
+        self.assertEqual(result, "menu_activate")
+        self.assertFalse(menu.is_open)
+        self.assertEqual(cursor.focus.mode, FocusMode.INPUT)
+
+    def test_escape_closes_without_activating(self) -> None:
+        _, cursor, router, menu, _, _, _ = _build_with_menu(["echo"])
+        router.handle_key(F2)
+        result = router.handle_key(ESCAPE)
+        self.assertEqual(result, "menu_close")
+        self.assertFalse(menu.is_open)
+        # NOT in input mode because we cancelled.
+        self.assertEqual(cursor.focus.mode, FocusMode.NOTEBOOK)
+
+    def test_output_mode_menu_carries_line_context(self) -> None:
+        bus, cursor, router, menu, output_cursor, recorder, clipboard = _build_with_menu(["echo"])
+        cell_id = cursor.focus.cell_id
+        buffer = recorder.buffer_for(cell_id)
+        buffer.append("first", stream=STDOUT)
+        buffer.append("second", stream=STDOUT)
+        output_cursor.attach(buffer)
+        cursor.view_output_mode()
+        output_cursor.move_to_end()
+        router.handle_key(F2)
+        # "copy_line" only appears when line_text was captured.
+        self.assertIn("copy_line", [item.id for item in menu.items])
+        # Focus the "copy_line" item and invoke it.
+        while menu.current_item().id != "copy_line":
+            router.handle_key(DOWN)
+        router.handle_key(ENTER)
+        self.assertEqual(clipboard.text, "second")
+
+    def test_unbound_menu_key_is_swallowed(self) -> None:
+        _, _, router, menu, _, _, _ = _build_with_menu(["echo"])
+        router.handle_key(F2)
+        before_index = menu.items.index(menu.current_item())
+        # A printable key while menu is open should not leak into INPUT
+        # insertion or change the menu focus.
+        self.assertIsNone(router.handle_key(Key.printable("x")))
+        self.assertTrue(menu.is_open)
+        self.assertEqual(menu.items.index(menu.current_item()), before_index)
+
+    def test_menu_no_op_without_action_menu(self) -> None:
+        _, _, _, router, _ = _build(["echo"])
+        # Without an action_menu wired in, F2 maps to "open_action_menu"
+        # but the handler silently no-ops. Router still reports the
+        # matched action so downstream observers see the attempt.
+        self.assertEqual(router.handle_key(F2), "open_action_menu")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `Application.build()` wires a `MemoryClipboard`, an `ActionCatalog` (via `default_actions(...)`), and an `ActionMenu`; all three are exposed as public fields.
- `InputRouter` gains an `action_menu` parameter, an `open_action_menu` action that snapshots the current focus (plus line context in OUTPUT mode) into an `ActionContext`, and a modal menu-dispatch path that intercepts Up / Down / Enter / Escape while the menu is open.
- `default_bindings()` binds F2 (and Ctrl+. as a fallback) in NOTEBOOK, INPUT, and OUTPUT modes. SETTINGS is intentionally excluded so the modal editor's keys do not collide.
- USER_MANUAL picks up a new "Actions menu" section plus MENU rows in the cheat sheet; `HELP_LINES` gains a single-line reminder so `:help` in-app surfaces the new key.

## Why
Prior UX audit (docs/FEATURE_REQUESTS.md F14) found the whole `actions.py` subsystem — copy focused line, copy all output, copy stderr, "Explore output", "Edit command" — was unreachable because no keystroke opened the menu. That also made the clipboard path dead code. This PR exposes the menu without changing a single action or provider.

## Test plan
- [x] `python -m unittest discover -s tests -t .` — **530 / 530** green (added 9 new F14 tests covering open from every mode, Up/Down cycling, Enter-activates-and-closes, Escape-closes-without-activating, OUTPUT-mode line capture + clipboard routing, stray-key swallowing, and no-op behavior without a menu wired).
- [x] End-to-end: `python -c "from asat.app import Application; ... "` confirms F2 opens the seeded INPUT-mode menu (items = submit, exit_input) and Escape closes cleanly.
