### PR TITLE
input_router: F17 richer meta-commands

### DIFF
--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -25,6 +25,9 @@ care about output navigation.
 
 from __future__ import annotations
 
+import difflib
+import os
+import re
 from typing import Callable, Optional
 
 from asat import keys as kc
@@ -180,15 +183,24 @@ META_COMMANDS: tuple[str, ...] = (
     "help",
     "delete",
     "duplicate",
+    "pwd",
+    "commands",
 )
 
 # "Ambient" meta-commands do their job without taking focus away from
 # INPUT mode. `:help` prints a cheat sheet; `:save` persists the
-# session. In both cases the natural next action is to keep typing, so
+# session; `:pwd` and `:commands` emit an informational HELP_REQUESTED
+# event. In each case the natural next action is to keep typing, so
 # the router clears the in-progress buffer but leaves the user in INPUT
 # mode. Commands NOT in this set (today: `:settings`, `:quit`)
 # inherently require a mode change and go through `abandon_input_mode`.
-AMBIENT_META_COMMANDS: frozenset[str] = frozenset({"help", "save"})
+AMBIENT_META_COMMANDS: frozenset[str] = frozenset(
+    {"help", "save", "pwd", "commands"}
+)
+
+# `:name optional-argument` — case-insensitive in the name, everything
+# after the first whitespace run is the trailing arg (already stripped).
+_META_NAME_RE = re.compile(r"^:([A-Za-z][A-Za-z0-9_-]*)\s*(.*)$")
 
 
 # The cheat-sheet lines a `:help` meta-command should surface. Kept in
@@ -205,7 +217,8 @@ HELP_LINES: tuple[str, ...] = (
     "           / search (type query, Enter commits), n / N next / prev hit, g jump-to-line.",
     "SETTINGS:  Up/Down walk, Right/Enter descend, Left/Escape ascend, e edit, Ctrl+S save, Ctrl+Q close.",
     "Menu:      F2 (or Ctrl+.) opens contextual actions; Up/Down walk, Enter invokes, Escape closes.",
-    "Meta:      :help, :settings, :save, :quit, :delete, :duplicate (INPUT then Enter).",
+    "Meta:      :help, :settings, :save, :quit, :delete, :duplicate, :pwd, :commands.",
+    "           Meta-commands are case-insensitive and accept a trailing argument.",
     "Exit:      :quit, or EOF (Ctrl+D on POSIX, Ctrl+Z Enter on Windows).",
     "Docs:      docs/USER_MANUAL.md for the full keystroke reference.",
 )
@@ -388,31 +401,50 @@ class InputRouter:
         """Commit the current input buffer and return submission extras.
 
         If the buffer begins with `:`, the router treats it as a meta-
-        command (`:settings`, `:save`, `:quit`), consumes it without
-        writing it back into the cell, and reports the command name via
-        the ACTION_INVOKED payload so observers can trace what
-        happened.
+        command, consumes it without writing it back into the cell,
+        and reports the command name via the ACTION_INVOKED payload so
+        observers can trace what happened. Unknown `:xxx` lines are
+        also intercepted: the router emits a HELP_REQUESTED hint (with
+        a difflib-powered typo suggestion when one is plausible) and
+        leaves the user in INPUT mode so they can correct and retry.
         """
         buffer = self._cursor.focus.input_buffer
-        meta = _parse_meta_command(buffer)
-        if meta is not None:
-            if meta in AMBIENT_META_COMMANDS:
+        parsed = _parse_meta_command(buffer)
+        if parsed is not None:
+            command, arg, raw_name = parsed
+            if command is None:
+                self._cursor.reset_input_buffer()
+                self._publish_unknown_meta(raw_name)
+                extras: dict[str, object] = {
+                    "meta_command": None,
+                    "meta_unknown": raw_name,
+                }
+                suggestion = _suggest_meta_command(raw_name)
+                if suggestion is not None:
+                    extras["meta_suggestion"] = suggestion
+                return extras
+            if command in AMBIENT_META_COMMANDS:
                 self._cursor.reset_input_buffer()
             else:
                 self._cursor.abandon_input_mode()
-            self._handle_meta_command(meta)
-            return {"meta_command": meta}
+            self._handle_meta_command(command, arg)
+            extras = {"meta_command": command}
+            if arg:
+                extras["meta_argument"] = arg
+            return extras
         cell = self._cursor.submit()
         if cell is None:
             return None
         return {"cell_id": cell.cell_id, "command": cell.command}
 
-    def _handle_meta_command(self, command: str) -> None:
+    def _handle_meta_command(self, command: str, argument: str) -> None:
         """Dispatch a parsed meta-command (without its leading `:`).
 
         `save` and `quit` are handled by the Application via the
         ACTION_INVOKED payload's `meta_command` key, so the router
-        itself intentionally does nothing for them here.
+        itself intentionally does nothing for them here. The trailing
+        `argument` is forwarded only where it has a defined meaning;
+        commands that do not read it simply ignore it.
         """
         if command == "settings":
             self._open_settings()
@@ -422,6 +454,51 @@ class InputRouter:
             self._cursor.delete_focused_cell()
         elif command == "duplicate":
             self._cursor.duplicate_focused_cell()
+        elif command == "pwd":
+            self._publish_pwd()
+        elif command == "commands":
+            self._publish_commands()
+
+    def _publish_pwd(self) -> None:
+        """Announce the current working directory via HELP_REQUESTED."""
+        publish_event(
+            self._bus,
+            EventType.HELP_REQUESTED,
+            {"lines": [f"Working directory: {os.getcwd()}"]},
+            source=self.SOURCE,
+        )
+
+    def _publish_commands(self) -> None:
+        """List every recognised meta-command via HELP_REQUESTED."""
+        lines = ["Meta-commands (type `:name` in INPUT mode, then Enter):"]
+        lines.extend(f"  :{name}" for name in META_COMMANDS)
+        publish_event(
+            self._bus,
+            EventType.HELP_REQUESTED,
+            {"lines": lines},
+            source=self.SOURCE,
+        )
+
+    def _publish_unknown_meta(self, raw_name: str) -> None:
+        """Surface a typo-suggest hint for an unrecognised `:xxx` line."""
+        suggestion = _suggest_meta_command(raw_name)
+        if suggestion is not None:
+            lines = [
+                f"Unknown meta-command `:{raw_name}` — "
+                f"did you mean `:{suggestion}`?",
+                "Line ignored. Type `:commands` to list every meta-command.",
+            ]
+        else:
+            lines = [
+                f"Unknown meta-command `:{raw_name}`. Line ignored.",
+                "Type `:commands` to list every meta-command.",
+            ]
+        publish_event(
+            self._bus,
+            EventType.HELP_REQUESTED,
+            {"lines": lines},
+            source=self.SOURCE,
+        )
 
     def _publish_help(self) -> None:
         """Emit HELP_REQUESTED so the renderer and audio bank can react."""
@@ -738,12 +815,37 @@ class InputRouter:
         )
 
 
-def _parse_meta_command(buffer: str) -> Optional[str]:
-    """Return a meta-command name when buffer is `:<name>` (trimmed), else None."""
+def _parse_meta_command(
+    buffer: str,
+) -> Optional[tuple[Optional[str], str, str]]:
+    """Parse `:<name> [argument]` into `(canonical, argument, raw_name)`.
+
+    Returns `None` when the buffer is not a meta-command line at all
+    (empty, not starting with `:`, or syntactically unparseable). When
+    a `:` prefix is present but the name is not in `META_COMMANDS`,
+    returns `(None, argument, raw_name)` so the caller can emit a
+    typo-suggest hint instead of falling through to the kernel.
+
+    Matching is case-insensitive; `:Help`, `:HELP`, and `:help` all
+    resolve to the canonical `"help"`.
+    """
     stripped = buffer.strip()
     if not stripped.startswith(":"):
         return None
-    name = stripped[1:].strip()
-    if name in META_COMMANDS:
-        return name
-    return None
+    match = _META_NAME_RE.match(stripped)
+    if match is None:
+        return None
+    raw_name = match.group(1)
+    argument = match.group(2).strip()
+    canonical = raw_name.lower()
+    if canonical in META_COMMANDS:
+        return canonical, argument, raw_name
+    return None, argument, raw_name
+
+
+def _suggest_meta_command(name: str) -> Optional[str]:
+    """Return the closest known meta-command to `name`, or None."""
+    matches = difflib.get_close_matches(
+        name.lower(), META_COMMANDS, n=1, cutoff=0.6
+    )
+    return matches[0] if matches else None

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -345,6 +345,8 @@ they don't silently dismiss the overlay.
 
 ## F17 — Richer meta-commands
 
+**Status.** Done (first pass).
+
 **Gap.** Meta-commands are case-sensitive, take no arguments, and
 the set is small. `:Help`, `:HELP`, `:help settings`, `:save-as
 foo.json`, `:cd /tmp`, `:new`, `:load`, `:pwd`, `:clear` are all
@@ -363,6 +365,20 @@ a `:xxx` doesn't match any known command ("`:setings` — did you
 mean `:settings`? Line ignored."). Add `:pwd`, `:commands`,
 `:clear` (reset session), `:new` (start a fresh session without
 touching disk).
+
+**Sketch (shipped).** `_parse_meta_command` now returns a
+`(canonical, argument, raw_name)` triple and matches the name
+case-insensitively via a regex (`:([A-Za-z][A-Za-z0-9_-]*)\s*(.*)$`).
+The submit path intercepts every `:xxx` line — known commands
+dispatch as before (with the trailing `argument` surfaced on the
+ACTION_INVOKED payload), and unknown commands trigger a
+HELP_REQUESTED hint with a `difflib.get_close_matches` suggestion
+("did you mean `:settings`?"). Two new ambient meta-commands are
+now recognised: `:pwd` (announces `os.getcwd()`) and `:commands`
+(lists every known meta-command). Session-mutating candidates
+(`:cd`, `:load`, `:save-as`, `:clear`, `:new`) are deferred to a
+follow-up pass because they need new session-cursor primitives and
+cross-cutting file-system handling.
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -189,10 +189,18 @@ discarded and the cell is not modified.
 | `:quit`      | Exit ASAT.                                           |
 | `:delete`    | Delete the focused cell (same as `d` in NOTEBOOK).   |
 | `:duplicate` | Duplicate the focused cell (same as `y` in NOTEBOOK).|
+| `:pwd`       | Announce the current working directory.              |
+| `:commands`  | List every available meta-command.                   |
 
-Type the meta-command exactly as shown, then press Enter. If you
-mistype (e.g. `:setings`), the line is treated as a normal command
-and handed to the shell — you'll hear the failure chord back.
+Meta-command names are **case-insensitive** — `:HELP`, `:Help`, and
+`:help` all do the same thing. A single trailing argument is
+allowed (`:help settings`) and is surfaced on the submit event for
+observers that care.
+
+If you mistype (e.g. `:setings`), the router keeps the line out of
+the shell, clears the buffer, and narrates a hint like *"unknown
+meta-command `:setings` — did you mean `:settings`?"*. Type
+`:commands` any time to hear the full list.
 
 ### Running a command
 
@@ -375,6 +383,8 @@ Every key you need, one table.
 | INPUT      | `:quit`⏎          | Exit ASAT                             |
 | INPUT      | `:delete`⏎        | Delete focused cell                   |
 | INPUT      | `:duplicate`⏎     | Duplicate focused cell                |
+| INPUT      | `:pwd`⏎           | Announce working directory            |
+| INPUT      | `:commands`⏎      | List every meta-command               |
 | OUTPUT     | Up / Down         | Prev / next line                      |
 | OUTPUT     | PageUp / PageDown | Jump a page                           |
 | OUTPUT     | Home / End        | First / last line                     |

--- a/tests/test_input_router.py
+++ b/tests/test_input_router.py
@@ -505,8 +505,10 @@ class MetaCommandTests(unittest.TestCase):
         self.assertEqual(submits[0].payload["meta_command"], "settings")
         self.assertNotIn("command", submits[0].payload)
 
-    def test_non_meta_colon_command_falls_through_as_regular_submit(self) -> None:
-        bus, _, router, _controller = _build_with_settings([""])
+    def test_unknown_meta_command_is_intercepted_with_help_hint(self) -> None:
+        """F17: `:unknown` no longer falls through to the shell; the
+        router consumes the line and emits a HELP_REQUESTED hint."""
+        bus, cursor, router, _controller = _build_with_settings([""])
         recorder = _Recorder(bus)
         router.handle_key(ENTER)
         for ch in ":unknown":
@@ -516,7 +518,97 @@ class MetaCommandTests(unittest.TestCase):
             e for e in recorder.types_of(EventType.ACTION_INVOKED)
             if e.payload.get("action") == "submit"
         ]
-        self.assertEqual(submits[0].payload.get("command"), ":unknown")
+        self.assertIsNone(submits[0].payload.get("command"))
+        self.assertIsNone(submits[0].payload.get("meta_command"))
+        self.assertEqual(submits[0].payload.get("meta_unknown"), "unknown")
+        helps = recorder.types_of(EventType.HELP_REQUESTED)
+        self.assertEqual(len(helps), 1)
+        text = "\n".join(helps[0].payload["lines"])
+        self.assertIn("unknown", text)
+        self.assertEqual(cursor.focus.mode, FocusMode.INPUT)
+        self.assertEqual(cursor.focus.input_buffer, "")
+
+    def test_unknown_meta_command_suggests_closest_known_name(self) -> None:
+        """F17: difflib suggests `:settings` when the user types
+        `:setings` (single-letter typo)."""
+        bus, _, router, _controller = _build_with_settings([""])
+        recorder = _Recorder(bus)
+        router.handle_key(ENTER)
+        for ch in ":setings":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+        submits = [
+            e for e in recorder.types_of(EventType.ACTION_INVOKED)
+            if e.payload.get("action") == "submit"
+        ]
+        self.assertEqual(submits[0].payload.get("meta_suggestion"), "settings")
+        helps = recorder.types_of(EventType.HELP_REQUESTED)
+        text = "\n".join(helps[0].payload["lines"])
+        self.assertIn(":settings", text)
+
+    def test_meta_command_matching_is_case_insensitive(self) -> None:
+        """F17: `:HELP`, `:Help`, and `:help` all run the same command."""
+        bus, _, router, _controller = _build_with_settings([""])
+        recorder = _Recorder(bus)
+        router.handle_key(ENTER)
+        for ch in ":HELP":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+        helps = recorder.types_of(EventType.HELP_REQUESTED)
+        self.assertEqual(len(helps), 1)
+        submits = [
+            e for e in recorder.types_of(EventType.ACTION_INVOKED)
+            if e.payload.get("action") == "submit"
+        ]
+        self.assertEqual(submits[-1].payload["meta_command"], "help")
+
+    def test_meta_command_trailing_argument_reported_in_payload(self) -> None:
+        """F17: `:help settings` exposes `settings` as meta_argument."""
+        bus, _, router, _controller = _build_with_settings([""])
+        recorder = _Recorder(bus)
+        router.handle_key(ENTER)
+        for ch in ":help settings":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+        submits = [
+            e for e in recorder.types_of(EventType.ACTION_INVOKED)
+            if e.payload.get("action") == "submit"
+        ]
+        self.assertEqual(submits[-1].payload["meta_command"], "help")
+        self.assertEqual(submits[-1].payload["meta_argument"], "settings")
+
+    def test_colon_pwd_reports_working_directory(self) -> None:
+        """F17: `:pwd` emits HELP_REQUESTED with the current CWD."""
+        import os
+
+        bus, cursor, router, _controller = _build_with_settings([""])
+        recorder = _Recorder(bus)
+        router.handle_key(ENTER)
+        for ch in ":pwd":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+        helps = recorder.types_of(EventType.HELP_REQUESTED)
+        self.assertEqual(len(helps), 1)
+        text = "\n".join(helps[0].payload["lines"])
+        self.assertIn(os.getcwd(), text)
+        self.assertEqual(cursor.focus.mode, FocusMode.INPUT)
+        self.assertEqual(cursor.focus.input_buffer, "")
+
+    def test_colon_commands_lists_every_meta_command(self) -> None:
+        """F17: `:commands` enumerates the full meta-command set."""
+        from asat.input_router import META_COMMANDS
+
+        bus, _, router, _controller = _build_with_settings([""])
+        recorder = _Recorder(bus)
+        router.handle_key(ENTER)
+        for ch in ":commands":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+        helps = recorder.types_of(EventType.HELP_REQUESTED)
+        self.assertEqual(len(helps), 1)
+        text = "\n".join(helps[0].payload["lines"])
+        for name in META_COMMANDS:
+            self.assertIn(f":{name}", text)
 
     def test_colon_help_publishes_help_requested_with_cheat_sheet_lines(self) -> None:
         from asat.input_router import HELP_LINES


### PR DESCRIPTION
## Summary

- `_parse_meta_command` now returns `(canonical, argument, raw_name)` and matches the name **case-insensitively** via a regex. `:HELP`, `:Help`, and `:help` all resolve to the same canonical command, and a single trailing argument is accepted (`:help settings`) and surfaced on the `ACTION_INVOKED` payload as `meta_argument`.
- Unknown `:xxx` lines are no longer handed to the shell. The router intercepts them, clears the buffer, and emits a `HELP_REQUESTED` hint — when `difflib.get_close_matches` finds a neighbour, the hint includes a typo suggestion ("did you mean `:settings`?").
- Two new ambient meta-commands:
  - `:pwd` announces `os.getcwd()` via `HELP_REQUESTED`.
  - `:commands` lists every known meta-command.
- Session-mutating candidates (`:cd`, `:load`, `:save-as`, `:clear`, `:new`) are deferred to a follow-up pass — they need new session-cursor primitives and cross-cutting filesystem handling.

Tests: **576 → 581** (5 new F17 tests; the previous `test_non_meta_colon_command_falls_through_as_regular_submit` was replaced by `test_unknown_meta_command_is_intercepted_with_help_hint` to match the new intercept behaviour).

## Test plan

- [x] `python -m unittest tests.test_input_router.MetaCommandTests -v`
- [x] `python -m unittest discover -s tests -t .` → 581 passing
- [ ] Manual: launch session, type `:HELP`, `:help settings`, `:pwd`, `:commands`, `:setings` — confirm narrator surfaces each outcome as expected.

https://claude.ai/code/session_01Bqqw4D3Hx2e9viK7HYavk6