### PR TITLE
actions+app: F18 SystemClipboard OS-native copy adapter

### DIFF
--- a/asat/__init__.py
+++ b/asat/__init__.py
@@ -33,6 +33,7 @@ from asat.actions import (
     Clipboard,
     MemoryClipboard,
     MenuItem,
+    SystemClipboard,
     default_actions,
 )
 from asat.app import Application
@@ -156,6 +157,7 @@ __all__ = [
     "SoundRecipe",
     "SpatialPosition",
     "Spatializer",
+    "SystemClipboard",
     "TTSEngine",
     "TerminalRenderer",
     "TextToken",

--- a/asat/__main__.py
+++ b/asat/__main__.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Optional, Sequence
 
 from asat import __version__
+from asat.actions import SystemClipboard
 from asat.app import Application
 from asat.audio_sink import (
     AudioSink,
@@ -81,6 +82,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         session=session,
         session_path=args.session,
         text_trace=trace_stream,
+        clipboard_factory=SystemClipboard,
     )
     if args.check:
         _print_check_report(app, args)

--- a/asat/actions.py
+++ b/asat/actions.py
@@ -34,6 +34,8 @@ build their own catalog from the same primitives.
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from dataclasses import dataclass
 from typing import Callable, Optional, Protocol
 
@@ -92,6 +94,153 @@ class MemoryClipboard:
     def set_text(self, text: str) -> None:
         """Replace the stored text."""
         self._text = text
+
+
+# Priority-ordered command runs for each supported platform. `linux`
+# prefers Wayland (`wl-copy`) and falls through to the two classic X11
+# tools (`xclip`, `xsel`); macOS uses the built-in `pbcopy`; Windows
+# uses `clip` which ships with the OS. Match by prefix (sys.platform is
+# `linux`, `linux2`, `darwin`, `win32`, `cygwin`, …).
+_SYSTEM_CLIPBOARD_CANDIDATES: tuple[tuple[str, tuple[tuple[str, ...], ...]], ...] = (
+    ("linux", (
+        ("wl-copy",),
+        ("xclip", "-selection", "clipboard"),
+        ("xsel", "--clipboard", "--input"),
+    )),
+    ("darwin", (("pbcopy",),)),
+    ("win", (("clip",),)),
+    ("cygwin", (("clip",),)),
+)
+
+
+class _ClipboardCommandError(Exception):
+    """Raised by a clipboard runner when a candidate command fails."""
+
+
+ClipboardRunner = Callable[[tuple[str, ...], str], None]
+
+
+def _subprocess_runner(cmd: tuple[str, ...], text: str) -> None:
+    """Default runner: spawn `cmd` and feed `text` to stdin.
+
+    Raises `_ClipboardCommandError` when the binary is missing, the
+    call times out, or the exit status is non-zero. Those failures are
+    how `SystemClipboard` walks the candidate list, so they must not
+    leak out to the caller as ambient subprocess exceptions.
+    """
+    try:
+        result = subprocess.run(
+            cmd,
+            input=text.encode("utf-8"),
+            check=False,
+            capture_output=True,
+            timeout=3.0,
+        )
+    except (FileNotFoundError, OSError) as exc:
+        raise _ClipboardCommandError(f"{cmd[0]}: {exc}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise _ClipboardCommandError(f"{cmd[0]} timed out") from exc
+    if result.returncode != 0:
+        stderr = result.stderr.decode("utf-8", errors="replace").strip()
+        raise _ClipboardCommandError(
+            f"{cmd[0]} exit {result.returncode}: {stderr}"
+        )
+
+
+class SystemClipboard:
+    """Clipboard adapter backed by an OS-native tool when available.
+
+    On each `set_text` call, tries a platform-specific list of
+    command-line tools in priority order (Wayland's `wl-copy`, then
+    X11's `xclip` / `xsel` on Linux; `pbcopy` on macOS; `clip` on
+    Windows). The first tool that succeeds wins. When every candidate
+    fails — or the current platform has no candidates — the text is
+    retained in-process so callers can still read it back via `.text`,
+    and a one-shot `HELP_REQUESTED` event explains the situation.
+
+    Testable: pass `runner` to stub subprocess calls and
+    `platform_name` to exercise a platform other than the host's.
+    """
+
+    SOURCE = "system_clipboard"
+
+    def __init__(
+        self,
+        bus: Optional[EventBus] = None,
+        *,
+        runner: Optional[ClipboardRunner] = None,
+        platform_name: Optional[str] = None,
+    ) -> None:
+        """Wire the adapter to an optional bus and override points."""
+        self._bus = bus
+        self._runner = runner if runner is not None else _subprocess_runner
+        self._platform = (
+            platform_name if platform_name is not None else sys.platform
+        )
+        self._text = ""
+        self._warned = False
+        self._last_backend: Optional[str] = None
+
+    @property
+    def text(self) -> str:
+        """Return the most recently stored text (also what would be pasted)."""
+        return self._text
+
+    @property
+    def last_backend(self) -> Optional[str]:
+        """Return the backend binary that handled the last set_text, or None.
+
+        None means the last call either had no candidates on this
+        platform or every candidate failed and the text only landed
+        in the in-process fallback.
+        """
+        return self._last_backend
+
+    def set_text(self, text: str) -> None:
+        """Publish `text` to the system clipboard, falling back to memory."""
+        self._text = text
+        for cmd in self._candidates():
+            try:
+                self._runner(cmd, text)
+            except _ClipboardCommandError:
+                continue
+            self._last_backend = cmd[0]
+            return
+        self._last_backend = None
+        if not self._warned:
+            self._warn()
+            self._warned = True
+
+    def _candidates(self) -> tuple[tuple[str, ...], ...]:
+        """Return the ordered command list for the current platform."""
+        for prefix, entries in _SYSTEM_CLIPBOARD_CANDIDATES:
+            if self._platform.startswith(prefix):
+                return entries
+        return ()
+
+    def _warn(self) -> None:
+        """Emit a one-shot HELP_REQUESTED event when no backend works.
+
+        Skipped silently when no bus was supplied (typical in tests),
+        so the adapter stays usable as a plain memory fallback.
+        """
+        if self._bus is None:
+            return
+        names = [c[0] for c in self._candidates()]
+        tried = ", ".join(names) if names else "(none for this platform)"
+        publish_event(
+            self._bus,
+            EventType.HELP_REQUESTED,
+            {
+                "lines": [
+                    "Clipboard: no OS clipboard tool found.",
+                    f"Tried: {tried}.",
+                    "Text was copied in-process only. Install one of "
+                    "these tools to enable system-wide paste.",
+                ]
+            },
+            source=self.SOURCE,
+        )
 
 
 class ActionCatalog:

--- a/asat/app.py
+++ b/asat/app.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, TextIO
+from typing import Callable, Optional, TextIO
 
 from asat.actions import (
     ActionCatalog,
@@ -90,6 +90,9 @@ class Application:
         session: Optional[Session] = None,
         session_path: Optional[Path | str] = None,
         text_trace: Optional[TextIO] = None,
+        clipboard_factory: Optional[
+            "Callable[[EventBus], Clipboard]"
+        ] = None,
     ) -> "Application":
         """Wire every collaborator with sensible defaults.
 
@@ -108,6 +111,12 @@ class Application:
         publishes fire, so the `[asat] session … ready.` banner and
         the initial `[input #…]` line are captured. Pass `None`
         (default) to suppress the text trace.
+
+        `clipboard_factory` is the hook the CLI uses to install a
+        `SystemClipboard` (so "copy output line" lands on the real OS
+        clipboard) without forcing the in-process `MemoryClipboard`
+        default on every test. The factory receives the freshly built
+        `EventBus` so adapters can publish warnings.
         """
         bus = EventBus()
         seeded = session is None
@@ -122,7 +131,10 @@ class Application:
             resolved_bank,
             save_path=bank_path,
         )
-        clipboard: Clipboard = MemoryClipboard()
+        if clipboard_factory is None:
+            clipboard: Clipboard = MemoryClipboard()
+        else:
+            clipboard = clipboard_factory(bus)
         action_catalog = default_actions(
             cursor=cursor,
             recorder=recorder,

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -384,6 +384,8 @@ cross-cutting file-system handling.
 
 ## F18 — OS clipboard adapter
 
+**Status.** Done.
+
 **Gap.** `MemoryClipboard` is the only `Clipboard` implementation.
 Even if F14 unlocked the menu, "copy output line" would store text
 in-process and nothing would land on the system clipboard.
@@ -398,6 +400,23 @@ subprocess `pbcopy`; on Linux try `wl-copy` then `xclip`/`xsel`.
 Fall back to `MemoryClipboard` with a one-line warning on first
 copy. `Application.build` picks the best available adapter unless
 tests pass one in explicitly.
+
+**Sketch (shipped).** `SystemClipboard` lives in `asat/actions.py`
+alongside `MemoryClipboard`. It holds a priority-ordered list of
+command runs per platform (Linux: `wl-copy` → `xclip` → `xsel`;
+macOS: `pbcopy`; Windows: `clip`) and invokes them via a
+`subprocess.run(..., input=text.encode("utf-8"))` runner. Windows
+uses the built-in `clip` tool rather than `ctypes` — it ships with
+every supported release and avoids a second code path. The runner
+and `sys.platform` are injectable so tests exercise every
+fallthrough path without spawning real subprocesses. When every
+candidate fails (or the platform has no candidates), the text is
+retained in-process and a one-shot `HELP_REQUESTED` event explains
+the situation. `Application.build` keeps `MemoryClipboard` as the
+in-process default (so tests stay deterministic) and adds a
+`clipboard_factory` kwarg; `python -m asat` passes
+`SystemClipboard` as the factory so the real CLI gets OS-native
+clipboard support automatically.
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -266,8 +266,13 @@ While the menu is open the keymap is modal:
 Every transition narrates. Opening the menu reads the item labels,
 Up/Down reads the newly-focused label, Enter announces the invocation
 and fires the `menu_activate` cue, and Escape fires `menu_close`.
-Copy items route through the clipboard (in-memory by default;
-platform adapters can plug in an OS backend).
+Copy items route through the clipboard. `python -m asat` wires up
+`SystemClipboard`, which tries the native tool for your platform
+(Wayland's `wl-copy`, then `xclip`, then `xsel` on Linux; `pbcopy`
+on macOS; `clip` on Windows) and falls back to in-process storage
+with a spoken warning if none of them is installed. Tests and
+embeddings that build the Application directly still get the
+deterministic `MemoryClipboard` by default.
 
 ---
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import unittest
+from typing import Optional
 
 from asat.actions import (
     ActionCatalog,
@@ -10,6 +11,7 @@ from asat.actions import (
     ActionMenu,
     MemoryClipboard,
     MenuItem,
+    SystemClipboard,
     default_actions,
 )
 from asat.cell import Cell
@@ -260,6 +262,141 @@ class DefaultActionsTests(unittest.TestCase):
         self.assertEqual(len(copied), 1)
         self.assertEqual(copied[0].payload["source"], "line")
         self.assertEqual(copied[0].payload["length"], 3)
+
+
+class _ScriptedRunner:
+    """Records every (cmd, text) call and can raise per-command errors."""
+
+    def __init__(self, failures: Optional[dict[str, Exception]] = None) -> None:
+        self.calls: list[tuple[tuple[str, ...], str]] = []
+        self._failures = failures or {}
+
+    def __call__(self, cmd: tuple[str, ...], text: str) -> None:
+        self.calls.append((cmd, text))
+        if cmd[0] in self._failures:
+            raise self._failures[cmd[0]]
+
+
+class SystemClipboardTests(unittest.TestCase):
+    """F18: OS-native clipboard adapter with platform fallthrough."""
+
+    def test_linux_prefers_wl_copy(self) -> None:
+        runner = _ScriptedRunner()
+        clipboard = SystemClipboard(
+            runner=runner, platform_name="linux"
+        )
+        clipboard.set_text("hello")
+        self.assertEqual(runner.calls, [(("wl-copy",), "hello")])
+        self.assertEqual(clipboard.last_backend, "wl-copy")
+        self.assertEqual(clipboard.text, "hello")
+
+    def test_linux_falls_through_to_xclip_when_wl_copy_missing(self) -> None:
+        from asat.actions import _ClipboardCommandError
+
+        runner = _ScriptedRunner(
+            failures={"wl-copy": _ClipboardCommandError("missing")}
+        )
+        clipboard = SystemClipboard(
+            runner=runner, platform_name="linux"
+        )
+        clipboard.set_text("hi")
+        self.assertEqual(len(runner.calls), 2)
+        self.assertEqual(runner.calls[1][0][0], "xclip")
+        self.assertEqual(clipboard.last_backend, "xclip")
+
+    def test_linux_falls_through_to_xsel_as_last_resort(self) -> None:
+        from asat.actions import _ClipboardCommandError
+
+        runner = _ScriptedRunner(
+            failures={
+                "wl-copy": _ClipboardCommandError("missing"),
+                "xclip": _ClipboardCommandError("missing"),
+            }
+        )
+        clipboard = SystemClipboard(
+            runner=runner, platform_name="linux"
+        )
+        clipboard.set_text("hi")
+        self.assertEqual(clipboard.last_backend, "xsel")
+        self.assertEqual([c[0][0] for c in runner.calls], ["wl-copy", "xclip", "xsel"])
+
+    def test_macos_uses_pbcopy(self) -> None:
+        runner = _ScriptedRunner()
+        clipboard = SystemClipboard(runner=runner, platform_name="darwin")
+        clipboard.set_text("mac text")
+        self.assertEqual(runner.calls, [(("pbcopy",), "mac text")])
+        self.assertEqual(clipboard.last_backend, "pbcopy")
+
+    def test_windows_uses_clip(self) -> None:
+        runner = _ScriptedRunner()
+        clipboard = SystemClipboard(runner=runner, platform_name="win32")
+        clipboard.set_text("win text")
+        self.assertEqual(runner.calls, [(("clip",), "win text")])
+        self.assertEqual(clipboard.last_backend, "clip")
+
+    def test_unsupported_platform_falls_back_to_memory(self) -> None:
+        runner = _ScriptedRunner()
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        clipboard = SystemClipboard(
+            bus=bus, runner=runner, platform_name="plan9"
+        )
+        clipboard.set_text("fallback")
+        self.assertEqual(runner.calls, [])
+        self.assertEqual(clipboard.text, "fallback")
+        self.assertIsNone(clipboard.last_backend)
+        helps = [
+            e for e in recorder.events
+            if e.event_type == EventType.HELP_REQUESTED
+        ]
+        self.assertEqual(len(helps), 1)
+        self.assertIn(
+            "in-process only",
+            "\n".join(helps[0].payload["lines"]),
+        )
+
+    def test_all_candidates_failing_warns_once_and_stores_in_memory(self) -> None:
+        from asat.actions import _ClipboardCommandError
+
+        failures = {
+            "wl-copy": _ClipboardCommandError("missing"),
+            "xclip": _ClipboardCommandError("missing"),
+            "xsel": _ClipboardCommandError("missing"),
+        }
+        runner = _ScriptedRunner(failures=failures)
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        clipboard = SystemClipboard(
+            bus=bus, runner=runner, platform_name="linux"
+        )
+        clipboard.set_text("first")
+        clipboard.set_text("second")
+        # Each call tries every candidate (since nothing ever works),
+        # but the warning event fires exactly once.
+        self.assertEqual(len(runner.calls), 6)
+        self.assertEqual(clipboard.text, "second")
+        helps = [
+            e for e in recorder.events
+            if e.event_type == EventType.HELP_REQUESTED
+        ]
+        self.assertEqual(len(helps), 1)
+
+    def test_warning_suppressed_without_bus(self) -> None:
+        from asat.actions import _ClipboardCommandError
+
+        runner = _ScriptedRunner(
+            failures={
+                "wl-copy": _ClipboardCommandError("missing"),
+                "xclip": _ClipboardCommandError("missing"),
+                "xsel": _ClipboardCommandError("missing"),
+            }
+        )
+        clipboard = SystemClipboard(
+            runner=runner, platform_name="linux"
+        )
+        clipboard.set_text("still works")
+        self.assertEqual(clipboard.text, "still works")
+        self.assertIsNone(clipboard.last_backend)
 
 
 if __name__ == "__main__":

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -71,6 +71,31 @@ class ApplicationBuildTests(unittest.TestCase):
         app = Application.build()
         self.assertIsInstance(app.sink, MemorySink)
 
+    def test_default_clipboard_is_memory(self) -> None:
+        from asat.actions import MemoryClipboard
+
+        app = Application.build()
+        self.assertIsInstance(app.clipboard, MemoryClipboard)
+
+    def test_clipboard_factory_receives_event_bus(self) -> None:
+        """F18: callers can install an OS-aware clipboard adapter via the
+        factory, which gets handed the freshly-built EventBus."""
+        from asat.event_bus import EventBus
+
+        seen_bus: list[EventBus] = []
+
+        class _StubClipboard:
+            def __init__(self, bus: EventBus) -> None:
+                seen_bus.append(bus)
+                self.text = ""
+
+            def set_text(self, text: str) -> None:
+                self.text = text
+
+        app = Application.build(clipboard_factory=_StubClipboard)
+        self.assertIs(seen_bus[0], app.bus)
+        self.assertIsInstance(app.clipboard, _StubClipboard)
+
 
 class ApplicationSubmissionTests(unittest.TestCase):
     def test_typing_and_submit_executes_a_cell(self) -> None:


### PR DESCRIPTION
## Summary

- `SystemClipboard` in `asat/actions.py` is a second `Clipboard` implementation that delegates to OS-native tools via `subprocess.run`. It tries candidates in priority order per platform:
  - **Linux:** `wl-copy` → `xclip -selection clipboard` → `xsel --clipboard --input`
  - **macOS:** `pbcopy`
  - **Windows:** `clip` (built-in on every supported release; avoided `ctypes` to keep one code path)
- Failures fall through; when every candidate fails (or the platform has no candidates), the text is retained in-process via the `.text` property and a one-shot `HELP_REQUESTED` event explains the situation.
- The runner and `sys.platform` are injectable, so tests cover every fallthrough branch without spawning real subprocesses.
- `Application.build` keeps `MemoryClipboard` as the in-process default (test determinism stays intact) and gains a `clipboard_factory` kwarg. `python -m asat` passes `SystemClipboard` as the factory, so real CLI launches get OS-native clipboard behaviour automatically.

Tests: **581 → 591** (8 new `SystemClipboardTests`, 2 new `ApplicationBuildTests`).

## Test plan

- [x] `python -m unittest tests.test_actions.SystemClipboardTests -v`
- [x] `python -m unittest tests.test_app.ApplicationBuildTests -v`
- [x] `python -m unittest discover -s tests -t .` → 591 passing
- [ ] Manual (Linux): `python -m asat`, enter OUTPUT mode on a cell that produced output, open the action menu, pick `Copy focused line`, confirm the line pastes into another app.
- [ ] Manual (macOS): same flow — confirm `pbcopy` receives the text.
- [ ] Manual (Windows): same flow via `clip`.

https://claude.ai/code/session_01Bqqw4D3Hx2e9viK7HYavk6