### PR TITLE
F19: prompt context (exit code, CWD) on INPUT re-entry

### DIFF
--- a/asat/__init__.py
+++ b/asat/__init__.py
@@ -83,6 +83,7 @@ from asat.keyboard import (
 )
 from asat.keys import Key, Modifier
 from asat.notebook import FocusMode, FocusState, NotebookCursor
+from asat.prompt_context import PromptContext
 from asat.output_buffer import OutputBuffer, OutputLine, OutputRecorder
 from asat.output_cursor import OutputCursor
 from asat.runner import ProcessRunner
@@ -145,6 +146,7 @@ __all__ = [
     "OutputRecorder",
     "PosixKeyboard",
     "ProcessRunner",
+    "PromptContext",
     "ScreenCell",
     "ScreenSnapshot",
     "ScriptedKeyboard",

--- a/asat/app.py
+++ b/asat/app.py
@@ -41,6 +41,7 @@ from asat.keys import Key
 from asat.notebook import FocusMode, NotebookCursor
 from asat.output_buffer import OutputRecorder
 from asat.output_cursor import OutputCursor
+from asat.prompt_context import PromptContext
 from asat.session import Session
 from asat.settings_controller import SettingsController
 from asat.sound_bank import SoundBank
@@ -72,6 +73,7 @@ class Application:
     clipboard: Clipboard
     action_catalog: ActionCatalog
     action_menu: ActionMenu
+    prompt_context: PromptContext
     session_path: Optional[Path] = None
     running: bool = True
 
@@ -153,6 +155,12 @@ class Application:
         )
         resolved_sink: AudioSink = sink if sink is not None else MemorySink()
         sound_engine = SoundEngine(bus, resolved_bank, resolved_sink)
+        # PromptContext must subscribe BEFORE TerminalRenderer so that
+        # when the user transitions into INPUT mode post-command, the
+        # PROMPT_REFRESH event it publishes reaches the renderer in
+        # dispatch order (helpful for test assertions that check the
+        # rendered line sequence).
+        prompt_context = PromptContext(bus)
         if text_trace is not None:
             TerminalRenderer(bus, stream=text_trace)
         app = cls(
@@ -169,6 +177,7 @@ class Application:
             clipboard=clipboard,
             action_catalog=action_catalog,
             action_menu=action_menu,
+            prompt_context=prompt_context,
             session_path=Path(session_path) if session_path is not None else None,
         )
         # Everything below fires AFTER sound_engine and (if requested)

--- a/asat/default_bank.py
+++ b/asat/default_bank.py
@@ -78,6 +78,7 @@ COVERED_EVENT_TYPES: frozenset[EventType] = frozenset({
     EventType.SETTINGS_VALUE_EDITED,
     EventType.SETTINGS_SAVED,
     EventType.HELP_REQUESTED,
+    EventType.PROMPT_REFRESH,
 })
 
 
@@ -511,5 +512,19 @@ def _default_bindings() -> tuple[EventBinding, ...]:
                 "settings. Type colon quit to exit."
             ),
             priority=220,
+        ),
+
+        # Prompt context: when the user lands in INPUT mode AFTER a
+        # command has finished, narrate the trailing exit code so a
+        # blind user has an immediate auditory cue for "that failed".
+        # Success (exit 0) is intentionally silent — the completion
+        # chord already marked it, and this would double the audio.
+        EventBinding(
+            id="prompt_refresh_failure",
+            event_type=EventType.PROMPT_REFRESH.value,
+            voice_id="system",
+            say_template="last exit {last_exit_code}",
+            predicate="last_exit_code != 0",
+            priority=90,
         ),
     )

--- a/asat/events.py
+++ b/asat/events.py
@@ -62,6 +62,9 @@ class EventType(str, Enum):
 
     Help surface:
         HELP_REQUESTED
+
+    Prompt context:
+        PROMPT_REFRESH
     """
 
     SESSION_CREATED = "session.created"
@@ -105,6 +108,8 @@ class EventType(str, Enum):
     AUDIO_INTERRUPTED = "audio.interrupted"
 
     HELP_REQUESTED = "help.requested"
+
+    PROMPT_REFRESH = "prompt.refresh"
 
     SETTINGS_OPENED = "settings.opened"
     SETTINGS_CLOSED = "settings.closed"

--- a/asat/prompt_context.py
+++ b/asat/prompt_context.py
@@ -1,0 +1,104 @@
+"""PromptContext: attach trailing exit-code + CWD to INPUT-mode entries.
+
+The `[input #…]` banner that fires on every FOCUS_CHANGED tells the
+user they are in a fresh cell but carries no audit of the command
+they just ran. A blind user has no quick cue for "the last thing
+failed" or "you're now in a different directory".
+
+PromptContext watches two streams on the bus:
+
+- COMMAND_COMPLETED / COMMAND_FAILED — to remember the last exit code.
+- FOCUS_CHANGED with `new_mode == input` — the trigger to publish a
+  PROMPT_REFRESH event carrying that trailing context.
+
+Consumers react to PROMPT_REFRESH rather than re-deriving the state
+themselves: the TerminalRenderer prints a compact one-liner, and the
+default SoundBank binds it to a short spoken summary via the `system`
+voice.
+
+The module is intentionally a thin coordinator. No I/O, no threading,
+no persistence. `cwd_provider` is injectable so tests can pin the
+value; the default uses `os.getcwd`.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Callable, Optional
+
+from asat.event_bus import EventBus, publish_event
+from asat.events import Event, EventType
+
+
+class PromptContext:
+    """Aggregate exit-code + CWD and republish on every INPUT entry."""
+
+    SOURCE = "prompt_context"
+
+    def __init__(
+        self,
+        bus: EventBus,
+        *,
+        cwd_provider: Optional[Callable[[], str]] = None,
+    ) -> None:
+        """Attach to `bus` and start tracking completion + focus events.
+
+        `cwd_provider` defaults to `os.getcwd`. Override for tests or
+        for a future feature that wants a virtual CWD (a sandbox, a
+        chroot, etc.).
+        """
+        self._bus = bus
+        self._cwd_provider = cwd_provider if cwd_provider is not None else os.getcwd
+        self._last_exit_code: Optional[int] = None
+        self._last_cell_id: Optional[str] = None
+        self._last_timed_out: bool = False
+        bus.subscribe(EventType.COMMAND_COMPLETED, self._on_command_finished)
+        bus.subscribe(EventType.COMMAND_FAILED, self._on_command_finished)
+        bus.subscribe(EventType.FOCUS_CHANGED, self._on_focus_changed)
+
+    @property
+    def last_exit_code(self) -> Optional[int]:
+        """Return the exit code of the most recently finished command, or None."""
+        return self._last_exit_code
+
+    @property
+    def last_cell_id(self) -> Optional[str]:
+        """Return the cell id of the most recently finished command, or None."""
+        return self._last_cell_id
+
+    def refresh(self) -> None:
+        """Explicitly publish a PROMPT_REFRESH (used on INPUT transitions)."""
+        if self._last_exit_code is None:
+            # Nothing to say yet — no command has completed since launch.
+            # Publishing here would make the renderer spam `[prompt ...]`
+            # lines on every new cell before the first run.
+            return
+        publish_event(
+            self._bus,
+            EventType.PROMPT_REFRESH,
+            {
+                "last_exit_code": self._last_exit_code,
+                "last_cell_id": self._last_cell_id,
+                "last_timed_out": self._last_timed_out,
+                "cwd": self._cwd_provider(),
+            },
+            source=self.SOURCE,
+        )
+
+    def _on_command_finished(self, event: Event) -> None:
+        """Record the exit code so the next INPUT entry can report it."""
+        payload = event.payload
+        exit_code = payload.get("exit_code")
+        if isinstance(exit_code, int):
+            self._last_exit_code = exit_code
+        cell_id = payload.get("cell_id")
+        if isinstance(cell_id, str):
+            self._last_cell_id = cell_id
+        timed_out = payload.get("timed_out")
+        self._last_timed_out = bool(timed_out)
+
+    def _on_focus_changed(self, event: Event) -> None:
+        """Fire PROMPT_REFRESH when the user lands in INPUT mode."""
+        if event.payload.get("new_mode") != "input":
+            return
+        self.refresh()

--- a/asat/terminal.py
+++ b/asat/terminal.py
@@ -56,6 +56,7 @@ class TerminalRenderer:
         bus.subscribe(EventType.ERROR_CHUNK, self._on_error_chunk)
         bus.subscribe(EventType.COMMAND_COMPLETED, self._on_command_completed)
         bus.subscribe(EventType.COMMAND_FAILED, self._on_command_failed)
+        bus.subscribe(EventType.PROMPT_REFRESH, self._on_prompt_refresh)
 
     def _write_line(self, text: str) -> None:
         """Print a full line, ending any in-flight keystroke echo first."""
@@ -133,3 +134,9 @@ class TerminalRenderer:
         else:
             exit_code = payload.get("exit_code", "?")
             self._write_line(f"[failed exit={exit_code}]")
+
+    def _on_prompt_refresh(self, event: Event) -> None:
+        payload = event.payload
+        exit_code = payload.get("last_exit_code", "?")
+        cwd = payload.get("cwd", "?")
+        self._write_line(f"[prompt exit={exit_code} cwd={cwd}]")

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -422,6 +422,8 @@ clipboard support automatically.
 
 ## F19 — Prompt context (exit code, CWD)
 
+**Status.** Done.
+
 **Gap.** The `[input #…]` banner that fires on entering INPUT mode
 carries no context about the prior command's exit code, the
 current working directory, or the session's git branch. Blind
@@ -438,6 +440,20 @@ cue that CWD changed.
 TerminalRenderer prints it; a default binding narrates it briefly
 via the `system` voice ("input; last exit 1; /tmp"). Keep it one
 compact line so fast typists can skip past it.
+
+**Sketch (shipped).** A new `PROMPT_REFRESH` event carries
+`last_exit_code`, `last_cell_id`, `last_timed_out`, and `cwd`. A
+new `PromptContext` module (`asat/prompt_context.py`) subscribes to
+`COMMAND_COMPLETED` / `COMMAND_FAILED` to remember the trailing
+exit code, then publishes `PROMPT_REFRESH` whenever FOCUS_CHANGED
+transitions into INPUT mode. The first INPUT transition on a
+pristine session (no prior run) is intentionally silent so we
+don't spam `[prompt exit=None]` noise. `TerminalRenderer` prints
+`[prompt exit=N cwd=…]`; the default sound bank only narrates
+non-zero exits via the `system` voice with predicate
+`last_exit_code != 0`, keeping the success path quiet. The CWD
+provider is injectable (defaults to `os.getcwd`) so tests stay
+deterministic.
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -217,6 +217,18 @@ On Enter:
 Cancelling a running command is a future keyboard binding; for now
 let commands finish or send `:quit` to bail out of the whole session.
 
+### Prompt context on re-entry
+
+Every time you step back into INPUT mode on a cell *after at least
+one command has finished*, ASAT emits a `PROMPT_REFRESH` event that
+carries the trailing exit code, the finishing cell id, whether the
+last run timed out, and the current working directory. The visible
+terminal prints a compact line like `[prompt exit=0 cwd=/work]`;
+the system voice stays quiet after a clean run but narrates
+`"last exit 1"` (or whatever the nonzero code was) when the last
+command failed. A pristine session emits nothing until the first
+command finishes, so you won't hear noise on launch.
+
 ---
 
 ## OUTPUT mode — re-reading output

--- a/tests/test_default_bank.py
+++ b/tests/test_default_bank.py
@@ -93,6 +93,12 @@ SAMPLE_PAYLOADS: dict[EventType, dict[str, object]] = {
     },
     EventType.SETTINGS_SAVED: {"path": "/tmp/bank.json"},
     EventType.HELP_REQUESTED: {"lines": ["help"]},
+    EventType.PROMPT_REFRESH: {
+        "last_exit_code": 1,
+        "last_cell_id": "c1",
+        "last_timed_out": False,
+        "cwd": "/tmp",
+    },
 }
 
 

--- a/tests/test_prompt_context.py
+++ b/tests/test_prompt_context.py
@@ -1,0 +1,167 @@
+"""Unit tests for PromptContext (F19)."""
+
+from __future__ import annotations
+
+import unittest
+
+from asat.event_bus import EventBus, publish_event
+from asat.events import Event, EventType
+from asat.prompt_context import PromptContext
+
+
+class _Recorder:
+    """Collect every event so tests can filter by type."""
+
+    def __init__(self, bus: EventBus) -> None:
+        self.events: list[Event] = []
+        bus.subscribe("*", self.events.append)
+
+    def of(self, event_type: EventType) -> list[Event]:
+        return [e for e in self.events if e.event_type == event_type]
+
+
+def _completed(bus: EventBus, *, cell_id: str = "c1", exit_code: int = 0) -> None:
+    publish_event(
+        bus,
+        EventType.COMMAND_COMPLETED,
+        {"cell_id": cell_id, "exit_code": exit_code, "timed_out": False},
+        source="test",
+    )
+
+
+def _failed(
+    bus: EventBus,
+    *,
+    cell_id: str = "c1",
+    exit_code: int = 1,
+    timed_out: bool = False,
+) -> None:
+    publish_event(
+        bus,
+        EventType.COMMAND_FAILED,
+        {"cell_id": cell_id, "exit_code": exit_code, "timed_out": timed_out},
+        source="test",
+    )
+
+
+def _focus_input(bus: EventBus, *, cell_id: str = "c1") -> None:
+    publish_event(
+        bus,
+        EventType.FOCUS_CHANGED,
+        {
+            "old_mode": "notebook",
+            "new_mode": "input",
+            "old_cell_id": None,
+            "new_cell_id": cell_id,
+            "input_buffer": "",
+            "transition": "mode",
+            "command": "",
+        },
+        source="test",
+    )
+
+
+def _focus_notebook(bus: EventBus) -> None:
+    publish_event(
+        bus,
+        EventType.FOCUS_CHANGED,
+        {
+            "old_mode": "input",
+            "new_mode": "notebook",
+            "old_cell_id": "c1",
+            "new_cell_id": "c1",
+            "input_buffer": "",
+            "transition": "mode",
+            "command": "",
+        },
+        source="test",
+    )
+
+
+class PromptContextTests(unittest.TestCase):
+
+    def test_no_refresh_before_any_command_completes(self) -> None:
+        """Entering INPUT mode before any command has finished must
+        NOT publish PROMPT_REFRESH — there is nothing trailing to
+        report and we don't want to spam `[prompt exit=None]` noise."""
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        PromptContext(bus, cwd_provider=lambda: "/work")
+        _focus_input(bus)
+        self.assertEqual(recorder.of(EventType.PROMPT_REFRESH), [])
+
+    def test_refresh_fires_on_input_transition_after_success(self) -> None:
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        PromptContext(bus, cwd_provider=lambda: "/work")
+        _completed(bus, cell_id="c1", exit_code=0)
+        _focus_input(bus, cell_id="c2")
+        refresh = recorder.of(EventType.PROMPT_REFRESH)
+        self.assertEqual(len(refresh), 1)
+        self.assertEqual(refresh[0].payload["last_exit_code"], 0)
+        self.assertEqual(refresh[0].payload["last_cell_id"], "c1")
+        self.assertEqual(refresh[0].payload["cwd"], "/work")
+        self.assertFalse(refresh[0].payload["last_timed_out"])
+
+    def test_refresh_fires_after_failure_with_nonzero_exit(self) -> None:
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        PromptContext(bus, cwd_provider=lambda: "/sandbox")
+        _failed(bus, cell_id="c1", exit_code=127)
+        _focus_input(bus)
+        refresh = recorder.of(EventType.PROMPT_REFRESH)
+        self.assertEqual(len(refresh), 1)
+        self.assertEqual(refresh[0].payload["last_exit_code"], 127)
+
+    def test_timed_out_flag_is_forwarded(self) -> None:
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        PromptContext(bus, cwd_provider=lambda: "/")
+        _failed(bus, cell_id="c1", exit_code=-9, timed_out=True)
+        _focus_input(bus)
+        refresh = recorder.of(EventType.PROMPT_REFRESH)
+        self.assertTrue(refresh[0].payload["last_timed_out"])
+
+    def test_only_fires_on_input_transitions(self) -> None:
+        """Transitions into NOTEBOOK or OUTPUT must not emit a refresh."""
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        PromptContext(bus, cwd_provider=lambda: "/")
+        _completed(bus, exit_code=0)
+        _focus_notebook(bus)
+        self.assertEqual(recorder.of(EventType.PROMPT_REFRESH), [])
+
+    def test_later_run_overwrites_earlier_exit_code(self) -> None:
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        PromptContext(bus, cwd_provider=lambda: "/")
+        _failed(bus, exit_code=2)
+        _completed(bus, exit_code=0)
+        _focus_input(bus)
+        refresh = recorder.of(EventType.PROMPT_REFRESH)
+        self.assertEqual(refresh[0].payload["last_exit_code"], 0)
+
+    def test_properties_track_latest_completion(self) -> None:
+        bus = EventBus()
+        context = PromptContext(bus, cwd_provider=lambda: "/")
+        self.assertIsNone(context.last_exit_code)
+        _failed(bus, cell_id="cA", exit_code=42)
+        self.assertEqual(context.last_exit_code, 42)
+        self.assertEqual(context.last_cell_id, "cA")
+        _completed(bus, cell_id="cB", exit_code=0)
+        self.assertEqual(context.last_exit_code, 0)
+        self.assertEqual(context.last_cell_id, "cB")
+
+    def test_refresh_is_idempotent_per_focus_event(self) -> None:
+        """Two INPUT transitions back-to-back produce two refreshes (one each)."""
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        PromptContext(bus, cwd_provider=lambda: "/")
+        _completed(bus, exit_code=0)
+        _focus_input(bus, cell_id="c2")
+        _focus_input(bus, cell_id="c3")
+        self.assertEqual(len(recorder.of(EventType.PROMPT_REFRESH)), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds a new `PROMPT_REFRESH` event carrying `last_exit_code`, `last_cell_id`, `last_timed_out`, and `cwd`.
- New `asat/prompt_context.py` module tracks the trailing exit code across `COMMAND_COMPLETED` / `COMMAND_FAILED` and republishes the summary whenever `FOCUS_CHANGED` enters INPUT mode. Pristine sessions stay silent until the first command finishes, so no `[prompt exit=None]` noise on launch.
- `TerminalRenderer` prints `[prompt exit=N cwd=…]`. The default sound bank narrates only non-zero exits via the `system` voice (predicate `last_exit_code != 0`), keeping the success path quiet.
- CWD provider is injectable (defaults to `os.getcwd`) so tests are deterministic.
- 8 new unit tests in `tests/test_prompt_context.py`; `SAMPLE_PAYLOADS` updated so the default-bank coverage sweep covers the new event.
- Docs: F19 marked **Done** in `docs/FEATURE_REQUESTS.md` with shipped sketch; new "Prompt context on re-entry" section in `docs/USER_MANUAL.md`.

## Test plan

- [x] `python -m unittest tests.test_prompt_context -v` — 8/8 green.
- [x] `python -m unittest discover -s tests -t .` — **599/599** green (was 591 before F19).
- [x] Default-bank coverage sweep plays a cue for `PROMPT_REFRESH` via the new binding.

https://claude.ai/code/session_01Bqqw4D3Hx2e9viK7HYavk6