### PR TITLE
F20: first-run onboarding tour

### DIFF
--- a/asat/__init__.py
+++ b/asat/__init__.py
@@ -83,6 +83,7 @@ from asat.keyboard import (
 )
 from asat.keys import Key, Modifier
 from asat.notebook import FocusMode, FocusState, NotebookCursor
+from asat.onboarding import DEFAULT_ONBOARDING_LINES, OnboardingCoordinator
 from asat.prompt_context import PromptContext
 from asat.output_buffer import OutputBuffer, OutputLine, OutputRecorder
 from asat.output_cursor import OutputCursor
@@ -114,6 +115,7 @@ __all__ = [
     "ChannelLayout",
     "Clipboard",
     "ControlToken",
+    "DEFAULT_ONBOARDING_LINES",
     "DEFAULT_SAMPLE_RATE",
     "EscapeToken",
     "Event",
@@ -140,6 +142,7 @@ __all__ = [
     "Modifier",
     "NotebookCursor",
     "OSCToken",
+    "OnboardingCoordinator",
     "OutputBuffer",
     "OutputCursor",
     "OutputLine",

--- a/asat/__main__.py
+++ b/asat/__main__.py
@@ -37,6 +37,7 @@ from asat.audio_sink import (
     pick_live_sink,
 )
 from asat.keyboard import KeyboardNotAvailable, KeyboardReader, pick_default
+from asat.onboarding import OnboardingCoordinator
 from asat.session import Session
 from asat.sound_bank import SoundBank
 
@@ -75,6 +76,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     # `SESSION_CREATED`/`FOCUS_CHANGED`, so the launch banner and the
     # first `[input #…]` line reach the user.
     trace_stream = None if args.quiet or args.check else sys.stdout
+    onboarding_factory = _onboarding_factory(quiet=args.quiet, check=args.check)
     app = Application.build(
         sink=sink,
         bank=bank,
@@ -83,6 +85,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         session_path=args.session,
         text_trace=trace_stream,
         clipboard_factory=SystemClipboard,
+        onboarding_factory=onboarding_factory,
     )
     if args.check:
         _print_check_report(app, args)
@@ -212,6 +215,26 @@ def _load_bank(path: Optional[Path]) -> Optional[SoundBank]:
             "the flag to use the built-in default bank."
         )
     return SoundBank.load(path)
+
+
+def _onboarding_factory(
+    *, quiet: bool, check: bool
+):
+    """Return an onboarding factory or None.
+
+    `--quiet` opts out of the tour (the user has explicitly asked for
+    a silent run). `--check` also skips it so the diagnostic report
+    stays pure. Otherwise we hand `Application.build` a factory that
+    builds an `OnboardingCoordinator` pointing at `~/.asat/first-run-done`.
+    """
+    if quiet or check:
+        return None
+    sentinel = Path.home() / ".asat" / "first-run-done"
+
+    def _factory(bus) -> OnboardingCoordinator:
+        return OnboardingCoordinator(bus, sentinel)
+
+    return _factory
 
 
 def _load_session(path: Optional[Path]) -> Optional[Session]:

--- a/asat/app.py
+++ b/asat/app.py
@@ -39,6 +39,7 @@ from asat.input_router import InputRouter, default_bindings
 from asat.kernel import ExecutionKernel
 from asat.keys import Key
 from asat.notebook import FocusMode, NotebookCursor
+from asat.onboarding import OnboardingCoordinator
 from asat.output_buffer import OutputRecorder
 from asat.output_cursor import OutputCursor
 from asat.prompt_context import PromptContext
@@ -74,6 +75,7 @@ class Application:
     action_catalog: ActionCatalog
     action_menu: ActionMenu
     prompt_context: PromptContext
+    onboarding: Optional[OnboardingCoordinator] = None
     session_path: Optional[Path] = None
     running: bool = True
 
@@ -94,6 +96,9 @@ class Application:
         text_trace: Optional[TextIO] = None,
         clipboard_factory: Optional[
             "Callable[[EventBus], Clipboard]"
+        ] = None,
+        onboarding_factory: Optional[
+            "Callable[[EventBus], OnboardingCoordinator]"
         ] = None,
     ) -> "Application":
         """Wire every collaborator with sensible defaults.
@@ -119,6 +124,15 @@ class Application:
         clipboard) without forcing the in-process `MemoryClipboard`
         default on every test. The factory receives the freshly built
         `EventBus` so adapters can publish warnings.
+
+        `onboarding_factory` hooks in an `OnboardingCoordinator` that
+        fires a one-time welcome tour the first time ASAT runs on a
+        machine. The factory receives the bus and is expected to
+        return a configured coordinator; `Application.build` invokes
+        `.run()` after the session banner publishes, so the greeting
+        lands after the newcomer knows the session is alive. Tests
+        and `--quiet` mode leave this unset, which skips onboarding
+        entirely.
         """
         bus = EventBus()
         seeded = session is None
@@ -163,6 +177,7 @@ class Application:
         prompt_context = PromptContext(bus)
         if text_trace is not None:
             TerminalRenderer(bus, stream=text_trace)
+        onboarding = onboarding_factory(bus) if onboarding_factory is not None else None
         app = cls(
             bus=bus,
             session=resolved_session,
@@ -178,6 +193,7 @@ class Application:
             action_catalog=action_catalog,
             action_menu=action_menu,
             prompt_context=prompt_context,
+            onboarding=onboarding,
             session_path=Path(session_path) if session_path is not None else None,
         )
         # Everything below fires AFTER sound_engine and (if requested)
@@ -201,6 +217,8 @@ class Application:
             )
         if seeded:
             cursor.new_cell()
+        if onboarding is not None:
+            onboarding.run()
         return app
 
     def handle_key(self, key: Key) -> Optional[str]:

--- a/asat/default_bank.py
+++ b/asat/default_bank.py
@@ -79,6 +79,7 @@ COVERED_EVENT_TYPES: frozenset[EventType] = frozenset({
     EventType.SETTINGS_SAVED,
     EventType.HELP_REQUESTED,
     EventType.PROMPT_REFRESH,
+    EventType.FIRST_RUN_DETECTED,
 })
 
 
@@ -512,6 +513,23 @@ def _default_bindings() -> tuple[EventBinding, ...]:
                 "settings. Type colon quit to exit."
             ),
             priority=220,
+        ),
+
+        # First-run onboarding: a returning user never hears this.
+        # The TerminalRenderer prints each welcome line; the narrator
+        # voice speaks a short greeting so the audio-only experience
+        # still acknowledges the tour. High priority so it wins over
+        # whatever else is queued during startup.
+        EventBinding(
+            id="first_run_welcome",
+            event_type=EventType.FIRST_RUN_DETECTED.value,
+            voice_id="narrator",
+            sound_id="settings_chime",
+            say_template=(
+                "Welcome to ASAT. Type colon help to hear the keystroke "
+                "cheat sheet."
+            ),
+            priority=250,
         ),
 
         # Prompt context: when the user lands in INPUT mode AFTER a

--- a/asat/events.py
+++ b/asat/events.py
@@ -65,6 +65,9 @@ class EventType(str, Enum):
 
     Prompt context:
         PROMPT_REFRESH
+
+    Onboarding:
+        FIRST_RUN_DETECTED
     """
 
     SESSION_CREATED = "session.created"
@@ -110,6 +113,8 @@ class EventType(str, Enum):
     HELP_REQUESTED = "help.requested"
 
     PROMPT_REFRESH = "prompt.refresh"
+
+    FIRST_RUN_DETECTED = "onboarding.first_run"
 
     SETTINGS_OPENED = "settings.opened"
     SETTINGS_CLOSED = "settings.closed"

--- a/asat/onboarding.py
+++ b/asat/onboarding.py
@@ -1,0 +1,103 @@
+"""OnboardingCoordinator: a one-shot welcome tour for first-time users.
+
+The first launch of ASAT on a fresh machine looks identical to the
+hundredth. The banner says "session ready"; the audio chord plays;
+nothing tells a newcomer that `:help` lists keystrokes or that
+`--live` / `--wav-dir` choose where audio goes.
+
+OnboardingCoordinator closes that gap without intruding on returning
+users. It owns a sentinel file (by default `~/.asat/first-run-done`):
+
+- If the sentinel is missing, `.run()` publishes a FIRST_RUN_DETECTED
+  event carrying a short spoken tour and the path to the sentinel,
+  then writes the sentinel so subsequent launches stay quiet.
+- If the sentinel exists, `.run()` is a no-op and returns False.
+
+The coordinator does no keystroke capture and does not block the
+session loop — the tour is a single event the TerminalRenderer prints
+and the default SoundBank narrates. Callers (CLI, tests) decide when
+to invoke `.run()` and whether to suppress it entirely (e.g. with
+`--quiet`).
+
+Keeping sentinel creation *after* publishing ensures a crash mid-tour
+leaves the flag unset so the user is greeted again on the next
+launch — but the common case is a clean write.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Optional
+
+from asat.event_bus import EventBus, publish_event
+from asat.events import EventType
+
+
+DEFAULT_ONBOARDING_LINES: tuple[str, ...] = (
+    "Welcome to the Accessible Spatial Audio Terminal.",
+    "Type colon, h, e, l, p, Enter for the keystroke cheat sheet.",
+    "Type colon, c, o, m, m, a, n, d, s, Enter to list every meta-command.",
+    "Press Escape any time to return to notebook mode.",
+    "Type colon, q, u, i, t, Enter to exit when you are done.",
+)
+
+
+class OnboardingCoordinator:
+    """Publish a welcome tour once per machine, gated by a sentinel file."""
+
+    SOURCE = "onboarding"
+
+    def __init__(
+        self,
+        bus: EventBus,
+        sentinel_path: Path | str,
+        *,
+        lines: Optional[Iterable[str]] = None,
+    ) -> None:
+        """Remember the bus, sentinel location, and welcome lines.
+
+        `lines` defaults to `DEFAULT_ONBOARDING_LINES`. Callers can
+        override to localise, shorten, or extend the tour without
+        touching this module.
+        """
+        self._bus = bus
+        self._sentinel_path = Path(sentinel_path)
+        self._lines: tuple[str, ...] = (
+            tuple(lines) if lines is not None else DEFAULT_ONBOARDING_LINES
+        )
+
+    @property
+    def sentinel_path(self) -> Path:
+        """Return the sentinel path so tests and CLI code can inspect it."""
+        return self._sentinel_path
+
+    def is_first_run(self) -> bool:
+        """Return True when the sentinel is absent (no prior welcome)."""
+        return not self._sentinel_path.exists()
+
+    def run(self) -> bool:
+        """Publish the tour once and create the sentinel; return True if fired.
+
+        Returns False on subsequent calls so the CLI can treat the
+        result as "did I just onboard a newcomer?" without re-checking
+        the filesystem itself.
+        """
+        if not self.is_first_run():
+            return False
+        publish_event(
+            self._bus,
+            EventType.FIRST_RUN_DETECTED,
+            {
+                "lines": list(self._lines),
+                "sentinel_path": str(self._sentinel_path),
+            },
+            source=self.SOURCE,
+        )
+        self._sentinel_path.parent.mkdir(parents=True, exist_ok=True)
+        self._sentinel_path.write_text("first-run-done\n", encoding="utf-8")
+        return True
+
+    def reset(self) -> None:
+        """Delete the sentinel so the next `.run()` re-fires the tour."""
+        if self._sentinel_path.exists():
+            self._sentinel_path.unlink()

--- a/asat/terminal.py
+++ b/asat/terminal.py
@@ -57,6 +57,7 @@ class TerminalRenderer:
         bus.subscribe(EventType.COMMAND_COMPLETED, self._on_command_completed)
         bus.subscribe(EventType.COMMAND_FAILED, self._on_command_failed)
         bus.subscribe(EventType.PROMPT_REFRESH, self._on_prompt_refresh)
+        bus.subscribe(EventType.FIRST_RUN_DETECTED, self._on_first_run)
 
     def _write_line(self, text: str) -> None:
         """Print a full line, ending any in-flight keystroke echo first."""
@@ -140,3 +141,8 @@ class TerminalRenderer:
         exit_code = payload.get("last_exit_code", "?")
         cwd = payload.get("cwd", "?")
         self._write_line(f"[prompt exit={exit_code} cwd={cwd}]")
+
+    def _on_first_run(self, event: Event) -> None:
+        lines = event.payload.get("lines", [])
+        for line in lines:
+            self._write_line(str(line))

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -459,6 +459,8 @@ deterministic.
 
 ## F20 — First-run onboarding
 
+**Status.** Done.
+
 **Gap.** The very first launch of ASAT on a fresh machine is
 indistinguishable from the 100th. The session banner is identical;
 nothing walks a newcomer through `--live` vs `--wav-dir` vs
@@ -473,6 +475,25 @@ hears a chime, sees `[input #…]`, and stalls. The existing
 tour: "Welcome. Press colon, h, e, l, p, Enter for the keystroke
 cheat sheet. Press Escape any time to return to notebook mode."
 Skip on subsequent launches and on any run with `--quiet`.
+
+**Sketch (shipped).** A new `FIRST_RUN_DETECTED` event carries
+the welcome `lines` and the resolved `sentinel_path`. `OnboardingCoordinator`
+(`asat/onboarding.py`) owns the sentinel — by default
+`~/.asat/first-run-done`. Its `.run()` method is idempotent: when
+the sentinel is missing it publishes the event, creates any
+missing parent directories, and writes the sentinel; when the
+sentinel already exists it returns `False` without touching the
+bus. `Application.build` takes an optional `onboarding_factory`
+kwarg and invokes `.run()` *after* `SESSION_CREATED` publishes, so
+the greeting lands just after the newcomer knows the session is
+alive. The CLI (`python -m asat`) wires the factory automatically,
+and gates it on `--quiet` / `--check`. The default SoundBank binds
+the event to the narrator voice with a high priority and a short
+spoken greeting (the TerminalRenderer prints the full spelled-out
+tour). The spelled form (`"h, e, l, p"`) makes TTS pronounce each
+character so the user learns the keystroke cadence, not just the
+word. A tiny `.reset()` method deletes the sentinel for tests or
+re-onboarding scenarios.
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -78,6 +78,21 @@ If neither the chime nor the banner appear, the session did not
 start cleanly — see the troubleshooting table at the end of this
 file.
 
+### First-run onboarding
+
+The **very first** time ASAT starts on a given machine you will
+also hear a short spoken welcome ("Welcome to ASAT. Type colon
+help to hear the keystroke cheat sheet.") and the text trace prints
+a four-line tour explaining the key meta-commands (`:help`,
+`:commands`, Escape, `:quit`). The tour plays from the narrator
+voice, on the left, and is spelled letter-by-letter
+(`"h, e, l, p"`) so the TTS pronounces each character.
+
+A sentinel file at `~/.asat/first-run-done` records that you've
+seen the tour; subsequent launches skip it. `--quiet` and
+`--check` also skip the tour. Delete the sentinel file and re-launch
+if you ever want to hear the welcome again.
+
 ---
 
 ## The five-minute tour

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -96,6 +96,39 @@ class ApplicationBuildTests(unittest.TestCase):
         self.assertIs(seen_bus[0], app.bus)
         self.assertIsInstance(app.clipboard, _StubClipboard)
 
+    def test_default_onboarding_is_none(self) -> None:
+        app = Application.build()
+        self.assertIsNone(app.onboarding)
+
+    def test_onboarding_factory_runs_after_session_created(self) -> None:
+        """F20: when a coordinator is installed, `.run()` must fire
+        during `Application.build` so the welcome event reaches any
+        subscribed renderers before the user sees the first prompt."""
+        import tempfile
+        from pathlib import Path
+
+        from asat.event_bus import EventBus
+        from asat.onboarding import OnboardingCoordinator
+
+        with tempfile.TemporaryDirectory() as td:
+            sentinel = Path(td) / "first-run-done"
+            seen: list[EventType] = []
+
+            def _factory(bus: EventBus) -> OnboardingCoordinator:
+                bus.subscribe("*", lambda e: seen.append(e.event_type))
+                return OnboardingCoordinator(bus, sentinel)
+
+            app = Application.build(onboarding_factory=_factory)
+
+            self.assertIsInstance(app.onboarding, OnboardingCoordinator)
+            self.assertIn(EventType.FIRST_RUN_DETECTED, seen)
+            # FIRST_RUN_DETECTED must follow SESSION_CREATED so the user
+            # hears the greeting after the session announces itself.
+            session_idx = seen.index(EventType.SESSION_CREATED)
+            welcome_idx = seen.index(EventType.FIRST_RUN_DETECTED)
+            self.assertLess(session_idx, welcome_idx)
+            self.assertTrue(sentinel.exists())
+
 
 class ApplicationSubmissionTests(unittest.TestCase):
     def test_typing_and_submit_executes_a_cell(self) -> None:

--- a/tests/test_default_bank.py
+++ b/tests/test_default_bank.py
@@ -99,6 +99,10 @@ SAMPLE_PAYLOADS: dict[EventType, dict[str, object]] = {
         "last_timed_out": False,
         "cwd": "/tmp",
     },
+    EventType.FIRST_RUN_DETECTED: {
+        "lines": ["Welcome."],
+        "sentinel_path": "/tmp/first-run-done",
+    },
 }
 
 

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,120 @@
+"""Unit tests for OnboardingCoordinator (F20)."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from asat.event_bus import EventBus
+from asat.events import Event, EventType
+from asat.onboarding import DEFAULT_ONBOARDING_LINES, OnboardingCoordinator
+
+
+class _Recorder:
+    """Collect every event so tests can filter by type."""
+
+    def __init__(self, bus: EventBus) -> None:
+        self.events: list[Event] = []
+        bus.subscribe("*", self.events.append)
+
+    def of(self, event_type: EventType) -> list[Event]:
+        return [e for e in self.events if e.event_type == event_type]
+
+
+class OnboardingCoordinatorTests(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self._tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tempdir.cleanup)
+        self.sentinel = Path(self._tempdir.name) / "asat" / "first-run-done"
+
+    def test_first_run_publishes_event_and_creates_sentinel(self) -> None:
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        coordinator = OnboardingCoordinator(bus, self.sentinel)
+
+        self.assertTrue(coordinator.is_first_run())
+        fired = coordinator.run()
+
+        self.assertTrue(fired)
+        events = recorder.of(EventType.FIRST_RUN_DETECTED)
+        self.assertEqual(len(events), 1)
+        payload = events[0].payload
+        self.assertEqual(payload["lines"], list(DEFAULT_ONBOARDING_LINES))
+        self.assertEqual(payload["sentinel_path"], str(self.sentinel))
+        self.assertTrue(self.sentinel.exists())
+        self.assertFalse(coordinator.is_first_run())
+
+    def test_second_run_is_silent_noop(self) -> None:
+        bus = EventBus()
+        coordinator = OnboardingCoordinator(bus, self.sentinel)
+        coordinator.run()
+
+        recorder = _Recorder(bus)  # Recorder after first run to catch round-2.
+        fired = coordinator.run()
+
+        self.assertFalse(fired)
+        self.assertEqual(recorder.of(EventType.FIRST_RUN_DETECTED), [])
+
+    def test_run_creates_missing_parent_directories(self) -> None:
+        bus = EventBus()
+        nested = Path(self._tempdir.name) / "deeply" / "nested" / "done"
+        coordinator = OnboardingCoordinator(bus, nested)
+
+        coordinator.run()
+
+        self.assertTrue(nested.exists())
+        self.assertTrue(nested.parent.is_dir())
+
+    def test_custom_lines_are_forwarded(self) -> None:
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        custom = ("one", "two", "three")
+        coordinator = OnboardingCoordinator(bus, self.sentinel, lines=custom)
+
+        coordinator.run()
+
+        payload = recorder.of(EventType.FIRST_RUN_DETECTED)[0].payload
+        self.assertEqual(payload["lines"], list(custom))
+
+    def test_reset_clears_sentinel(self) -> None:
+        bus = EventBus()
+        coordinator = OnboardingCoordinator(bus, self.sentinel)
+        coordinator.run()
+        self.assertFalse(coordinator.is_first_run())
+
+        coordinator.reset()
+
+        self.assertTrue(coordinator.is_first_run())
+        self.assertFalse(self.sentinel.exists())
+
+    def test_reset_is_safe_when_sentinel_is_missing(self) -> None:
+        bus = EventBus()
+        coordinator = OnboardingCoordinator(bus, self.sentinel)
+
+        coordinator.reset()  # Must not raise.
+
+        self.assertTrue(coordinator.is_first_run())
+
+    def test_sentinel_path_property_returns_path_object(self) -> None:
+        bus = EventBus()
+        coordinator = OnboardingCoordinator(bus, str(self.sentinel))
+        self.assertEqual(coordinator.sentinel_path, self.sentinel)
+
+    def test_default_lines_mention_help_and_quit(self) -> None:
+        # Sanity check the welcome text a newcomer will actually hear
+        # so a careless edit doesn't ship a tour without the two
+        # instructions that unstick every stuck user. The tour spells
+        # out meta-commands letter-by-letter so TTS pronounces each
+        # character; we check for the spelled form ("h, e, l, p") and
+        # the "cheat sheet" / "exit" anchors it names.
+        joined = " ".join(DEFAULT_ONBOARDING_LINES).lower()
+        self.assertIn("h, e, l, p", joined)
+        self.assertIn("q, u, i, t", joined)
+        self.assertIn("cheat sheet", joined)
+        self.assertIn("escape", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds a one-shot spoken welcome that fires the first time ASAT launches on a given machine. A sentinel file at `~/.asat/first-run-done` records that the user has seen the tour; subsequent launches stay silent.
- New `FIRST_RUN_DETECTED` event carries the welcome lines and the resolved sentinel path.
- New `asat/onboarding.py` with `OnboardingCoordinator`: `.run()` is idempotent (publishes + writes sentinel on first call, no-op afterwards); parent directories are created on demand; `.reset()` deletes the sentinel for tests / re-onboarding.
- `Application.build` takes an optional `onboarding_factory` kwarg and invokes `.run()` after `SESSION_CREATED` so the greeting lands after the newcomer knows the session is alive.
- `python -m asat` wires the factory automatically and gates it on `--quiet` / `--check`.
- `TerminalRenderer` prints each welcome line; the default SoundBank binds the event to the narrator voice with a short spoken greeting. The printed tour spells out meta-commands letter-by-letter (`"h, e, l, p"`) so the TTS pronounces each character.

## Test plan

- [x] `python -m unittest tests.test_onboarding -v` — 8/8 green.
- [x] `python -m unittest tests.test_app` — Application.build default-none + factory ordering tests both pass.
- [x] `python -m unittest discover -s tests -t .` — **609/609** green (was 599 before F20).

https://claude.ai/code/session_01Bqqw4D3Hx2e9viK7HYavk6