### PR TITLE
F21a: undo/redo for the settings editor

### DIFF
--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -168,6 +168,8 @@ def default_bindings() -> BindingMap:
             Key.printable("e"): "settings_begin_edit",
             Key.combo("s", Modifier.CTRL): "settings_save",
             Key.combo("q", Modifier.CTRL): "settings_close",
+            Key.combo("z", Modifier.CTRL): "settings_undo",
+            Key.combo("y", Modifier.CTRL): "settings_redo",
         },
     }
 
@@ -578,6 +580,16 @@ class InputRouter:
         if self._settings_controller is not None:
             self._settings_controller.backspace_edit()
 
+    def _settings_undo(self) -> None:
+        """Revert the most recent edit via the settings controller."""
+        if self._settings_controller is not None:
+            self._settings_controller.undo()
+
+    def _settings_redo(self) -> None:
+        """Re-apply the most recently undone edit via the settings controller."""
+        if self._settings_controller is not None:
+            self._settings_controller.redo()
+
     def _open_action_menu(self) -> Optional[dict[str, object]]:
         """Open the contextual actions menu against the current focus.
 
@@ -693,6 +705,8 @@ class InputRouter:
             "settings_edit_commit": self._settings_edit_commit,
             "settings_edit_cancel": _void(self._settings_edit_cancel),
             "settings_edit_backspace": _void(self._settings_edit_backspace),
+            "settings_undo": _void(self._settings_undo),
+            "settings_redo": _void(self._settings_redo),
             "open_action_menu": self._open_action_menu,
             "menu_prev": _void(self._menu_prev),
             "menu_next": _void(self._menu_next),

--- a/asat/settings_controller.py
+++ b/asat/settings_controller.py
@@ -170,6 +170,27 @@ class SettingsController:
         self._editing = False
         self._edit_buffer = ""
 
+    def undo(self) -> bool:
+        """Revert the most recent edit on the underlying editor.
+
+        Returns False when the session is closed, the user is
+        composing a replacement value (the edit sub-mode owns the
+        buffer; undo at that point would be surprising), or when
+        there is nothing on the undo stack. Otherwise delegates to
+        `SettingsEditor.undo()` which restores the prior bank,
+        refocuses the cursor on the field it mutated, and publishes
+        SETTINGS_VALUE_EDITED so narration reacts.
+        """
+        if self._editor is None or self._editing:
+            return False
+        return self._editor.undo()
+
+    def redo(self) -> bool:
+        """Re-apply the most recently undone edit. Mirror of `undo()`."""
+        if self._editor is None or self._editing:
+            return False
+        return self._editor.redo()
+
     def save(self, path: Optional[Path | str] = None) -> Path:
         """Persist the bank. Uses the configured save_path if none is given."""
         target = Path(path) if path is not None else self._save_path

--- a/asat/settings_editor.py
+++ b/asat/settings_editor.py
@@ -53,6 +53,22 @@ from asat.sound_bank import (
 SOURCE = "settings_editor"
 
 
+MAX_HISTORY = 64
+
+
+@dataclass(frozen=True)
+class _EditRecord:
+    """One undoable mutation, enough to both replay and reverse."""
+
+    section: "Section"
+    record_index: int
+    field: str
+    old_value: Any
+    new_value: Any
+    bank_before: "SoundBank"
+    bank_after: "SoundBank"
+
+
 class SettingsEditorError(ValueError):
     """Raised when a navigation or edit is not legal at the current state."""
 
@@ -119,7 +135,10 @@ class SettingsEditor:
         """Open an editor session over the given bank."""
         self._bus = bus
         self._bank = bank
+        self._saved_bank = bank
         self._state = EditorState()
+        self._undo_stack: list[_EditRecord] = []
+        self._redo_stack: list[_EditRecord] = []
         publish_event(
             bus,
             EventType.SETTINGS_OPENED,
@@ -217,8 +236,21 @@ class SettingsEditor:
         except SoundBankError as exc:
             raise SettingsEditorError(str(exc)) from exc
         old_value = getattr(old_record, field_name)
+        bank_before = self._bank
         self._bank = candidate
         self._state = replace(self._state, dirty=True)
+        self._push_undo(
+            _EditRecord(
+                section=self._state.section,
+                record_index=self._state.record_index,
+                field=field_name,
+                old_value=old_value,
+                new_value=parsed,
+                bank_before=bank_before,
+                bank_after=candidate,
+            )
+        )
+        self._redo_stack.clear()
         publish_event(
             self._bus,
             EventType.SETTINGS_VALUE_EDITED,
@@ -232,9 +264,122 @@ class SettingsEditor:
             source=SOURCE,
         )
 
+    @property
+    def can_undo(self) -> bool:
+        """True when there is at least one edit that could be reverted."""
+        return bool(self._undo_stack)
+
+    @property
+    def can_redo(self) -> bool:
+        """True when at least one undone edit could be re-applied."""
+        return bool(self._redo_stack)
+
+    def undo(self) -> bool:
+        """Revert the most recent edit and move it onto the redo stack.
+
+        Returns False when there is nothing to undo. Otherwise restores
+        the prior bank, refocuses the cursor on the edited field, and
+        re-publishes SETTINGS_VALUE_EDITED with old/new reversed so
+        subscribers (narration, logs) can react uniformly.
+        """
+        if not self._undo_stack:
+            return False
+        record = self._undo_stack.pop()
+        self._bank = record.bank_before
+        self._redo_stack.append(record)
+        self._apply_history_cursor(record)
+        self._state = replace(self._state, dirty=self._compute_dirty())
+        publish_event(
+            self._bus,
+            EventType.SETTINGS_VALUE_EDITED,
+            {
+                "section": record.section.value,
+                "record_index": record.record_index,
+                "field": record.field,
+                "old_value": _jsonable(record.new_value),
+                "new_value": _jsonable(record.old_value),
+            },
+            source=SOURCE,
+        )
+        self._publish_focus()
+        return True
+
+    def redo(self) -> bool:
+        """Re-apply the most recently undone edit.
+
+        Returns False when there is nothing to redo.
+        """
+        if not self._redo_stack:
+            return False
+        record = self._redo_stack.pop()
+        self._bank = record.bank_after
+        self._undo_stack.append(record)
+        self._apply_history_cursor(record)
+        self._state = replace(self._state, dirty=self._compute_dirty())
+        publish_event(
+            self._bus,
+            EventType.SETTINGS_VALUE_EDITED,
+            {
+                "section": record.section.value,
+                "record_index": record.record_index,
+                "field": record.field,
+                "old_value": _jsonable(record.old_value),
+                "new_value": _jsonable(record.new_value),
+            },
+            source=SOURCE,
+        )
+        self._publish_focus()
+        return True
+
+    def _push_undo(self, record: _EditRecord) -> None:
+        """Append record to the undo stack, dropping the oldest when bounded."""
+        self._undo_stack.append(record)
+        if len(self._undo_stack) > MAX_HISTORY:
+            # Drop from the oldest end; an older edit that rolls off
+            # simply can't be undone any more, but the rest of the
+            # stack still restores a coherent bank.
+            del self._undo_stack[0]
+
+    def _apply_history_cursor(self, record: _EditRecord) -> None:
+        """Park the cursor on the field the history step mutated.
+
+        Undo/redo implicitly "takes the user there" so the narration
+        and any visible focus cue reflect the change they just heard.
+        """
+        fields = self._fields_for(record.section)
+        try:
+            field_index = fields.index(record.field)
+        except ValueError:
+            field_index = 0
+        self._state = replace(
+            self._state,
+            level=Level.FIELD,
+            section=record.section,
+            record_index=record.record_index,
+            field_index=field_index,
+        )
+
+    def _compute_dirty(self) -> bool:
+        """True when the current bank differs from the last-saved baseline.
+
+        Undoing the only edit since the last save should clear dirty;
+        redoing past a saved point should reassert it. We compare by
+        identity because every mutation (edit, undo, redo) pins
+        `_bank` to one of the saved-baseline / undo-record references,
+        all of which are shared across the session.
+        """
+        return self._bank is not self._saved_bank
+
     def save(self, path: Path | str) -> None:
-        """Persist the current bank as JSON at path and clear the dirty flag."""
+        """Persist the current bank as JSON at path and clear the dirty flag.
+
+        The undo stack is preserved across saves so a user who realises
+        (post-save) they want to revert an earlier edit can still do
+        so. Subsequent `undo()` calls will re-mark the editor dirty
+        because the bank no longer matches the freshly-saved baseline.
+        """
         self._bank.save(path)
+        self._saved_bank = self._bank
         self._state = replace(self._state, dirty=False)
         publish_event(
             self._bus,

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -499,6 +499,9 @@ re-onboarding scenarios.
 
 ## F21 — Settings: undo, search, and reset
 
+**Status.** In progress. Undo/redo shipped; `/` search and `:reset`
+still pending.
+
 **Gap.** The settings editor has no undo, no search, and no "reset
 this field / record / whole bank to defaults". A user who mistypes
 a value and commits it has to remember the old value and re-enter it.
@@ -515,6 +518,24 @@ record's id / event_type / label. A `:reset` meta-command (or
 Ctrl+R keystroke) with a confirm to reload the built-in defaults
 for the current record, the current section, or the whole bank.
 Pairs naturally with F2 (create/delete) and F3 (reload from disk).
+
+**Sketch (shipped — undo/redo).** `SettingsEditor` now maintains
+bounded undo/redo stacks (`MAX_HISTORY = 64`). Each successful
+`edit()` pushes an `_EditRecord` carrying both the mutated
+coordinates (section / record_index / field / old_value /
+new_value) and the pre/post bank references; any fresh edit clears
+the redo stack (standard Word-style semantics). `undo()` pops the
+most recent record, restores the prior bank, parks the cursor on
+the field the history step touched, and re-publishes
+`SETTINGS_VALUE_EDITED` with old/new reversed so narration and
+logs react uniformly. `redo()` is the mirror image. The editor
+tracks a `_saved_bank` baseline so the `dirty` flag clears when
+undo restores the post-save state and reasserts when redo moves
+past it. `SettingsController` exposes `undo()` / `redo()` that
+refuse during the edit sub-mode and when the session is closed.
+`InputRouter` binds **Ctrl+Z** to `settings_undo` and **Ctrl+Y**
+to `settings_redo` inside `FocusMode.SETTINGS`. Search and reset
+will follow in later PRs.
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -329,8 +329,18 @@ FIELD    the typed fields on that record
 | Right / Enter       | Descend (section → record → field).             |
 | Left / Escape       | Ascend (or close at top level).                 |
 | `e`                 | Begin editing the focused field.                |
+| Ctrl+Z              | Undo the most recent field edit.                |
+| Ctrl+Y              | Redo the most recently undone edit.             |
 | Ctrl+S              | Save the bank to disk.                          |
 | Ctrl+Q              | Close the editor.                               |
+
+Undo / redo stacks hold up to 64 edits and survive saves, so you
+can revert past a save if you realise the regression landed
+earlier. Pressing Ctrl+Z while composing a replacement (inside the
+edit sub-mode) is ignored so it can't silently discard your
+in-progress text. The cursor jumps to the field each history step
+mutated so the narrator re-reads the value — useful when you want
+to hear "what changed" in the moment.
 
 ### Editing a field
 

--- a/tests/test_input_router.py
+++ b/tests/test_input_router.py
@@ -449,6 +449,60 @@ class SettingsModeDispatchTests(unittest.TestCase):
         router.handle_key(BACKSPACE)
         self.assertEqual(controller.edit_buffer, "sapi")
 
+    def test_ctrl_z_undoes_the_most_recent_settings_edit(self) -> None:
+        _, _, router, controller = _build_with_settings(["echo"])
+        router.handle_key(Key.combo(",", Modifier.CTRL))
+        router.handle_key(ENTER)
+        router.handle_key(ENTER)
+        router.handle_key(DOWN)  # engine
+        router.handle_key(Key.printable("e"))
+        for ch in "sapi":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)  # commit
+        self.assertEqual(controller.bank.voices[0].engine, "sapi")
+
+        router.handle_key(Key.combo("z", Modifier.CTRL))
+
+        self.assertEqual(controller.bank.voices[0].engine, "")
+
+    def test_ctrl_y_redoes_the_most_recently_undone_edit(self) -> None:
+        _, _, router, controller = _build_with_settings(["echo"])
+        router.handle_key(Key.combo(",", Modifier.CTRL))
+        router.handle_key(ENTER)
+        router.handle_key(ENTER)
+        router.handle_key(DOWN)
+        router.handle_key(Key.printable("e"))
+        for ch in "sapi":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+        router.handle_key(Key.combo("z", Modifier.CTRL))
+        self.assertEqual(controller.bank.voices[0].engine, "")
+
+        router.handle_key(Key.combo("y", Modifier.CTRL))
+
+        self.assertEqual(controller.bank.voices[0].engine, "sapi")
+
+    def test_ctrl_z_while_editing_is_discarded(self) -> None:
+        """While composing a replacement, Ctrl+Z must not sneak in as an
+        undo; the edit buffer stays intact and nothing is reverted."""
+        _, _, router, controller = _build_with_settings(["echo"])
+        router.handle_key(Key.combo(",", Modifier.CTRL))
+        router.handle_key(ENTER)
+        router.handle_key(ENTER)
+        router.handle_key(DOWN)
+        router.handle_key(Key.printable("e"))
+        for ch in "sapi":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)  # commit first edit
+        router.handle_key(Key.printable("e"))
+        router.handle_key(Key.printable("x"))
+
+        router.handle_key(Key.combo("z", Modifier.CTRL))
+
+        self.assertTrue(controller.editing)
+        self.assertEqual(controller.edit_buffer, "x")
+        self.assertEqual(controller.bank.voices[0].engine, "sapi")
+
     def test_invalid_commit_surfaces_in_action_payload(self) -> None:
         bus, _, router, _ = _build_with_settings(["echo"])
         recorder = _Recorder(bus)

--- a/tests/test_settings_controller.py
+++ b/tests/test_settings_controller.py
@@ -190,6 +190,59 @@ class EditSubModeTests(unittest.TestCase):
             controller.extend_edit("ab")
 
 
+class UndoRedoTests(unittest.TestCase):
+
+    def _parked_on_rate(self) -> SettingsController:
+        controller = SettingsController(EventBus(), _bank())
+        controller.open()
+        controller.descend()
+        controller.descend()
+        # Move to "rate" (VOICE_FIELDS: id, engine, rate, ...)
+        controller.next()  # engine
+        controller.next()  # rate
+        controller.begin_edit()
+        for ch in "1.3":
+            controller.extend_edit(ch)
+        controller.commit_edit()
+        return controller
+
+    def test_undo_reverts_committed_edit(self) -> None:
+        controller = self._parked_on_rate()
+        self.assertAlmostEqual(controller.bank.voices[0].rate, 1.3)
+
+        ok = controller.undo()
+
+        self.assertTrue(ok)
+        self.assertAlmostEqual(controller.bank.voices[0].rate, 1.0)
+
+    def test_undo_is_noop_when_session_closed(self) -> None:
+        controller = SettingsController(EventBus(), _bank())
+        self.assertFalse(controller.undo())
+
+    def test_undo_is_noop_while_composing_edit(self) -> None:
+        controller = self._parked_on_rate()
+        controller.begin_edit()
+        controller.extend_edit("2")
+
+        self.assertFalse(controller.undo())
+        # The buffer and edit sub-mode survive the ignored request.
+        self.assertTrue(controller.editing)
+        self.assertEqual(controller.edit_buffer, "2")
+
+    def test_redo_reapplies_undone_edit(self) -> None:
+        controller = self._parked_on_rate()
+        controller.undo()
+
+        ok = controller.redo()
+
+        self.assertTrue(ok)
+        self.assertAlmostEqual(controller.bank.voices[0].rate, 1.3)
+
+    def test_redo_is_noop_when_session_closed(self) -> None:
+        controller = SettingsController(EventBus(), _bank())
+        self.assertFalse(controller.redo())
+
+
 class SaveTests(unittest.TestCase):
 
     def test_save_to_configured_path(self) -> None:

--- a/tests/test_settings_editor.py
+++ b/tests/test_settings_editor.py
@@ -259,6 +259,152 @@ class EditTests(unittest.TestCase):
         self.assertEqual(edited[0].payload["new_value"], "sapi")
 
 
+class UndoRedoTests(unittest.TestCase):
+
+    def _rate_editor(self) -> SettingsEditor:
+        editor = SettingsEditor(EventBus(), _bank())
+        editor.enter()
+        editor.enter()
+        # move to "rate" field
+        for _ in range(VOICE_FIELDS.index("rate")):
+            editor.next()
+        return editor
+
+    def test_fresh_editor_has_no_history(self) -> None:
+        editor = SettingsEditor(EventBus(), _bank())
+        self.assertFalse(editor.can_undo)
+        self.assertFalse(editor.can_redo)
+
+    def test_undo_reverts_the_most_recent_edit(self) -> None:
+        editor = self._rate_editor()
+        editor.edit("1.3")
+        self.assertAlmostEqual(editor.bank.voices[0].rate, 1.3)
+        self.assertTrue(editor.can_undo)
+        self.assertFalse(editor.can_redo)
+
+        self.assertTrue(editor.undo())
+
+        self.assertAlmostEqual(editor.bank.voices[0].rate, 1.0)
+        self.assertFalse(editor.can_undo)
+        self.assertTrue(editor.can_redo)
+
+    def test_redo_reapplies_the_undone_edit(self) -> None:
+        editor = self._rate_editor()
+        editor.edit("1.3")
+        editor.undo()
+
+        self.assertTrue(editor.redo())
+
+        self.assertAlmostEqual(editor.bank.voices[0].rate, 1.3)
+        self.assertTrue(editor.can_undo)
+        self.assertFalse(editor.can_redo)
+
+    def test_undo_empty_stack_returns_false(self) -> None:
+        editor = SettingsEditor(EventBus(), _bank())
+        self.assertFalse(editor.undo())
+
+    def test_redo_empty_stack_returns_false(self) -> None:
+        editor = SettingsEditor(EventBus(), _bank())
+        self.assertFalse(editor.redo())
+
+    def test_new_edit_clears_the_redo_stack(self) -> None:
+        editor = self._rate_editor()
+        editor.edit("1.3")
+        editor.undo()
+        self.assertTrue(editor.can_redo)
+
+        editor.edit("1.7")
+
+        self.assertFalse(editor.can_redo)
+        self.assertAlmostEqual(editor.bank.voices[0].rate, 1.7)
+
+    def test_multiple_edits_unwind_in_reverse_order(self) -> None:
+        editor = self._rate_editor()
+        editor.edit("1.3")
+        editor.edit("1.5")
+        editor.edit("1.7")
+
+        editor.undo()
+        self.assertAlmostEqual(editor.bank.voices[0].rate, 1.5)
+        editor.undo()
+        self.assertAlmostEqual(editor.bank.voices[0].rate, 1.3)
+        editor.undo()
+        self.assertAlmostEqual(editor.bank.voices[0].rate, 1.0)
+        self.assertFalse(editor.can_undo)
+
+    def test_undo_restores_bank_identity_so_dirty_flag_clears(self) -> None:
+        editor = self._rate_editor()
+        editor.edit("1.3")
+        self.assertTrue(editor.state.dirty)
+
+        editor.undo()
+
+        self.assertFalse(editor.state.dirty)
+
+    def test_undo_past_save_marks_editor_dirty_again(self) -> None:
+        editor = self._rate_editor()
+        editor.edit("1.3")
+        with tempfile.TemporaryDirectory() as tmp:
+            editor.save(Path(tmp) / "bank.json")
+            self.assertFalse(editor.state.dirty)
+
+            editor.undo()
+
+            self.assertTrue(editor.state.dirty)
+
+    def test_undo_publishes_value_edited_with_reversed_values(self) -> None:
+        bus = EventBus()
+        edited: list[Event] = []
+        bus.subscribe(EventType.SETTINGS_VALUE_EDITED, edited.append)
+        editor = SettingsEditor(bus, _bank())
+        editor.enter()
+        editor.enter()
+        for _ in range(VOICE_FIELDS.index("rate")):
+            editor.next()
+        editor.edit("1.3")
+        edited.clear()
+
+        editor.undo()
+
+        self.assertEqual(len(edited), 1)
+        self.assertAlmostEqual(edited[0].payload["old_value"], 1.3)
+        self.assertAlmostEqual(edited[0].payload["new_value"], 1.0)
+
+    def test_undo_parks_cursor_on_the_mutated_field(self) -> None:
+        editor = SettingsEditor(EventBus(), _bank())
+        # Edit voices[0].rate via the helper, then navigate away entirely.
+        editor.enter()
+        editor.enter()
+        for _ in range(VOICE_FIELDS.index("rate")):
+            editor.next()
+        editor.edit("1.3")
+        editor.back()
+        editor.back()
+        editor.next()  # Section → sounds
+
+        editor.undo()
+
+        self.assertEqual(editor.state.level, Level.FIELD)
+        self.assertEqual(editor.state.section, Section.VOICES)
+        self.assertEqual(editor.state.record_index, 0)
+        self.assertEqual(editor.current_field_name(), "rate")
+
+    def test_history_is_bounded(self) -> None:
+        # The bounded stack drops the oldest record; editing more than
+        # MAX_HISTORY times should leave exactly MAX_HISTORY undos
+        # available rather than growing without limit.
+        from asat.settings_editor import MAX_HISTORY
+
+        editor = self._rate_editor()
+        for i in range(MAX_HISTORY + 5):
+            editor.edit(f"{1.0 + 0.01 * (i + 1):.3f}")
+
+        undone = 0
+        while editor.undo():
+            undone += 1
+        self.assertEqual(undone, MAX_HISTORY)
+
+
 class SaveTests(unittest.TestCase):
 
     def test_save_writes_file_and_clears_dirty(self) -> None:


### PR DESCRIPTION
## Summary

First slice of F21 (search and `:reset` will follow in later PRs). Adds Word-style undo/redo to the settings editor so a misplaced value doesn't force the user to remember and retype the prior one.

- `SettingsEditor` maintains bounded undo/redo stacks (`MAX_HISTORY = 64`). Each successful `edit()` pushes an `_EditRecord` with the mutated coordinates plus pre/post bank references; any fresh edit clears the redo stack.
- `undo()` / `redo()` restore the appropriate bank, park the cursor on the mutated field, recompute `dirty` against a `_saved_bank` baseline, and re-publish `SETTINGS_VALUE_EDITED` with reversed old/new so narration and logs stay uniform.
- `SettingsController` exposes `undo()` / `redo()` that refuse during the edit sub-mode and when closed.
- `InputRouter` binds **Ctrl+Z** → `settings_undo` and **Ctrl+Y** → `settings_redo` inside `FocusMode.SETTINGS`; the edit sub-mode dispatch ignores non-printable Ctrl keys so in-progress buffers survive a stray Ctrl+Z.

## Test plan

- [x] `python -m unittest tests.test_settings_editor tests.test_settings_controller tests.test_input_router` — 150/150 green.
- [x] `python -m unittest discover -s tests -t .` — **629/629** green (was 609 before F21a).

**New tests:** 11 editor cases (round-trip, multi-edit unwinding, redo-stack clearing, bounded stack, published-event symmetry, cursor jump on history, dirty-after-save); 5 controller cases (forwarding, noop guards for closed session / sub-mode); 3 router cases (Ctrl+Z / Ctrl+Y dispatch + sub-mode discard).

https://claude.ai/code/session_01Bqqw4D3Hx2e9viK7HYavk6