### PR TITLE
F21b: `/` search overlay for SettingsEditor

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -31,13 +31,14 @@ F9 README · F11 auto-advance after submit · F13 in-line buffer editing
 · F14 action-menu keystroke · F15 cell delete/move/duplicate · F16
 output search + jump-to-line · F17 richer meta-commands · F18 OS
 clipboard · F19 prompt context on re-entry · F20 first-run onboarding
-· F21a settings undo/redo · F6 Windows live audio (POSIX still open).
+· F21a settings undo/redo · F21b settings `/` search overlay · F6
+Windows live audio (POSIX still open).
 
 ## Open (roadmap)
 F1/F10 cancel + non-blocking exec · F2 settings create/delete · F3
 bank reload · F4 command history · F5 SAPI TTS · F6 POSIX live audio
 · F7 OSC 133 · F8 measured-HRTF user surface · F12 shell mode +
-session CWD · F21b/c settings search + reset · F22 diagnostic log
+session CWD · F21c settings `:reset` · F22 diagnostic log
 (`--log path.jsonl`) · F23 tab completion · F24 continuous output
 playback · **F25** remappable keybindings · **F26** cell clipboard
 (cut/copy/paste cells) · **F27** heading/text cells + outline
@@ -54,7 +55,7 @@ tabs with per-tab kernel (and child tabs sharing one kernel).
   clocks, no real audio.
 - One feature per PR on branch `claude/accessible-audio-terminal-cOh64`.
 - Test command: `python -m unittest discover -s tests -t .` —
-  currently **629 passing**.
+  currently **682 passing**.
 
 ## Entry points for the next session
 - **Roadmap (authoritative):** `docs/FEATURE_REQUESTS.md`
@@ -64,12 +65,18 @@ tabs with per-tab kernel (and child tabs sharing one kernel).
 - **CLI:** `python -m asat [--live | --wav-dir DIR] [--session PATH] [--quiet]`
 
 ## Suggested next PR
-**F21b** — `/` search overlay for `SettingsEditor`. Sub-modes mirror
-the existing edit sub-mode (`begin_search` / `extend_search` /
-`commit_search` / `cancel_search`). Cross-section substring match on
-Voice.id / SoundRecipe.id / EventBinding.(id | event_type | voice_id
-| sound_id). Park cursor at RECORD level on match. Controller API +
-InputRouter `/` binding + tests + docs, then PR.
+**F21c** — `:reset` for `SettingsEditor`. Reload the built-in
+defaults for the currently focused record, the whole section, or
+the whole bank, with a confirm step (either an InputRouter confirm
+sub-mode or an action-menu "Reset to defaults → {scope}" row).
+Integrate cleanly with the undo stack so a reset is itself undoable.
+Narrate scope + record count in the confirmation prompt. Controller
+API + InputRouter key (Ctrl+R?) + tests + docs, then PR.
+
+Alternative one-shot PRs if F21c feels heavy: **F22** `--log
+path.jsonl` diagnostic file (a single `JsonlEventLogger` subscriber,
+CLI flag, tests); **F4** command history (ring buffer + Up/Down in
+INPUT mode); **F23** Tab completion of executables + paths.
 
 ---
 

--- a/asat/default_bank.py
+++ b/asat/default_bank.py
@@ -77,6 +77,9 @@ COVERED_EVENT_TYPES: frozenset[EventType] = frozenset({
     EventType.SETTINGS_FOCUSED,
     EventType.SETTINGS_VALUE_EDITED,
     EventType.SETTINGS_SAVED,
+    EventType.SETTINGS_SEARCH_OPENED,
+    EventType.SETTINGS_SEARCH_UPDATED,
+    EventType.SETTINGS_SEARCH_CLOSED,
     EventType.HELP_REQUESTED,
     EventType.PROMPT_REFRESH,
     EventType.FIRST_RUN_DETECTED,
@@ -498,6 +501,34 @@ def _default_bindings() -> tuple[EventBinding, ...]:
             sound_id="settings_save",
             say_template="settings saved",
             priority=220,
+        ),
+
+        # F21b search overlay — three short cues so a blind user hears
+        # the composer open, the match count change on each keystroke,
+        # and the composer close. The record-level jump that follows a
+        # match is narrated by the existing `settings_focused` binding.
+        EventBinding(
+            id="settings_search_opened",
+            event_type=EventType.SETTINGS_SEARCH_OPENED.value,
+            voice_id="system",
+            sound_id="nav_blip",
+            say_template="search",
+            priority=200,
+        ),
+        EventBinding(
+            id="settings_search_updated",
+            event_type=EventType.SETTINGS_SEARCH_UPDATED.value,
+            voice_id="system",
+            say_template="{match_count} matches",
+            priority=150,
+        ),
+        EventBinding(
+            id="settings_search_closed",
+            event_type=EventType.SETTINGS_SEARCH_CLOSED.value,
+            voice_id="system",
+            sound_id="soft_tick",
+            say_template="search closed",
+            priority=150,
         ),
 
         # Help: speak a short summary so :help is useful without a

--- a/asat/events.py
+++ b/asat/events.py
@@ -121,6 +121,9 @@ class EventType(str, Enum):
     SETTINGS_FOCUSED = "settings.focused"
     SETTINGS_VALUE_EDITED = "settings.value.edited"
     SETTINGS_SAVED = "settings.saved"
+    SETTINGS_SEARCH_OPENED = "settings.search.opened"
+    SETTINGS_SEARCH_UPDATED = "settings.search.updated"
+    SETTINGS_SEARCH_CLOSED = "settings.search.closed"
 
     ANSI_CURSOR_MOVED = "ansi.cursor.moved"
     ANSI_SGR_CHANGED = "ansi.sgr.changed"

--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -105,6 +105,9 @@ def default_bindings() -> BindingMap:
         Right / Enter descend one level,
         Left ascends one level,
         `e` begins editing the focused field,
+        `/` opens the cross-section search composer (typed chars
+        narrow matches live, Enter commits, Escape restores the
+        pre-search cursor), `n` / `N` cycle through matches,
         Ctrl+S saves the bank, Ctrl+Q closes the editor,
         Escape ascends or (at the top level) closes.
     """
@@ -166,6 +169,9 @@ def default_bindings() -> BindingMap:
             kc.ENTER: "settings_descend",
             kc.ESCAPE: "settings_ascend",
             Key.printable("e"): "settings_begin_edit",
+            Key.printable("/"): "settings_search_begin",
+            Key.printable("n"): "settings_search_next",
+            Key.printable("N"): "settings_search_prev",
             Key.combo("s", Modifier.CTRL): "settings_save",
             Key.combo("q", Modifier.CTRL): "settings_close",
             Key.combo("z", Modifier.CTRL): "settings_undo",
@@ -218,6 +224,7 @@ HELP_LINES: tuple[str, ...] = (
     "OUTPUT:    Up/Down step lines, PageUp/PageDown page, Escape leaves.",
     "           / search (type query, Enter commits), n / N next / prev hit, g jump-to-line.",
     "SETTINGS:  Up/Down walk, Right/Enter descend, Left/Escape ascend, e edit, Ctrl+S save, Ctrl+Q close.",
+    "           / search (cross-section; Enter commits, Escape restores), n / N cycle matches.",
     "Menu:      F2 (or Ctrl+.) opens contextual actions; Up/Down walk, Enter invokes, Escape closes.",
     "Meta:      :help, :settings, :save, :quit, :delete, :duplicate, :pwd, :commands.",
     "           Meta-commands are case-insensitive and accept a trailing argument.",
@@ -281,6 +288,8 @@ class InputRouter:
         mode = self._cursor.focus.mode
         if mode == FocusMode.SETTINGS and self._settings_active_editing():
             return self._dispatch_settings_edit_key(key)
+        if mode == FocusMode.SETTINGS and self._settings_active_searching():
+            return self._dispatch_settings_search_key(key)
         if mode == FocusMode.OUTPUT and self._output_composing():
             return self._dispatch_output_composer_key(key)
         mode_map = self._bindings.get(mode, {})
@@ -385,6 +394,44 @@ class InputRouter:
             self._settings_controller.extend_edit(key.char)
             self._publish_action("settings_edit_extend", key, {"char": key.char})
             return "settings_edit_extend"
+        return None
+
+    def _settings_active_searching(self) -> bool:
+        """Return True when the settings controller is composing a search."""
+        return (
+            self._settings_controller is not None
+            and self._settings_controller.is_open
+            and self._settings_controller.searching
+        )
+
+    def _dispatch_settings_search_key(self, key: Key) -> Optional[str]:
+        """Route keys while the user is typing a `/` search query.
+
+        Printable characters (including `/`) extend the query so a
+        user can search for a literal slash; Backspace trims; Enter
+        commits and leaves the cursor on the current match; Escape
+        cancels and restores the pre-search cursor. Every other key
+        is swallowed so arrow motions don't silently dismiss the
+        overlay.
+        """
+        assert self._settings_controller is not None
+        if key == kc.ENTER:
+            self._invoke("settings_search_commit", key)
+            return "settings_search_commit"
+        if key == kc.ESCAPE:
+            self._invoke("settings_search_cancel", key)
+            return "settings_search_cancel"
+        if key == kc.BACKSPACE:
+            self._invoke("settings_search_backspace", key)
+            return "settings_search_backspace"
+        if key.is_printable() and key.char is not None:
+            self._settings_controller.extend_search(key.char)
+            self._publish_action(
+                "settings_search_extend",
+                key,
+                {"char": key.char, "query": self._settings_controller.search_buffer},
+            )
+            return "settings_search_extend"
         return None
 
     def _invoke(self, action: str, key: Key) -> None:
@@ -590,6 +637,49 @@ class InputRouter:
         if self._settings_controller is not None:
             self._settings_controller.redo()
 
+    def _settings_search_begin(self) -> Optional[dict[str, object]]:
+        """Open the `/` search overlay; report whether it started."""
+        if self._settings_controller is None:
+            return None
+        started = self._settings_controller.begin_search()
+        return {"opened": started}
+
+    def _settings_search_commit(self) -> Optional[dict[str, object]]:
+        """Apply the in-progress search; surface the query + match count."""
+        if self._settings_controller is None:
+            return None
+        editor = self._settings_controller.editor
+        query = editor.search_buffer
+        match_count = editor.search_match_count
+        self._settings_controller.commit_search()
+        return {"query": query, "match_count": match_count}
+
+    def _settings_search_cancel(self) -> None:
+        """Discard the in-progress search and restore the cursor."""
+        if self._settings_controller is not None:
+            self._settings_controller.cancel_search()
+
+    def _settings_search_backspace(self) -> None:
+        """Trim the last character from the search buffer."""
+        if self._settings_controller is not None:
+            self._settings_controller.backspace_search()
+
+    def _settings_search_next(self) -> Optional[dict[str, object]]:
+        """Cycle to the next match; no-op without prior results."""
+        if self._settings_controller is None:
+            return None
+        editor = self._settings_controller.editor
+        matched = editor.next_search_match()
+        return {"matched": matched}
+
+    def _settings_search_prev(self) -> Optional[dict[str, object]]:
+        """Cycle to the previous match; no-op without prior results."""
+        if self._settings_controller is None:
+            return None
+        editor = self._settings_controller.editor
+        matched = editor.prev_search_match()
+        return {"matched": matched}
+
     def _open_action_menu(self) -> Optional[dict[str, object]]:
         """Open the contextual actions menu against the current focus.
 
@@ -707,6 +797,13 @@ class InputRouter:
             "settings_edit_backspace": _void(self._settings_edit_backspace),
             "settings_undo": _void(self._settings_undo),
             "settings_redo": _void(self._settings_redo),
+            "settings_search_begin": self._settings_search_begin,
+            "settings_search_commit": self._settings_search_commit,
+            "settings_search_cancel": _void(self._settings_search_cancel),
+            "settings_search_backspace": _void(self._settings_search_backspace),
+            "settings_search_extend": lambda: None,
+            "settings_search_next": self._settings_search_next,
+            "settings_search_prev": self._settings_search_prev,
             "open_action_menu": self._open_action_menu,
             "menu_prev": _void(self._menu_prev),
             "menu_next": _void(self._menu_next),

--- a/asat/settings_controller.py
+++ b/asat/settings_controller.py
@@ -117,9 +117,13 @@ class SettingsController:
         """Rise one level; return False at the top so the caller can close.
 
         While editing, ascend cancels the in-progress edit instead.
+        While searching, ascend cancels the in-progress search.
         """
         if self._editing:
             self.cancel_edit()
+            return True
+        if self.searching:
+            self.cancel_search()
             return True
         if self.editor.state.level == Level.SECTION:
             return False
@@ -175,21 +179,72 @@ class SettingsController:
 
         Returns False when the session is closed, the user is
         composing a replacement value (the edit sub-mode owns the
-        buffer; undo at that point would be surprising), or when
-        there is nothing on the undo stack. Otherwise delegates to
+        buffer; undo at that point would be surprising), the user is
+        composing a `/` search query (same rationale), or when there
+        is nothing on the undo stack. Otherwise delegates to
         `SettingsEditor.undo()` which restores the prior bank,
         refocuses the cursor on the field it mutated, and publishes
         SETTINGS_VALUE_EDITED so narration reacts.
         """
-        if self._editor is None or self._editing:
+        if self._editor is None or self._editing or self.searching:
             return False
         return self._editor.undo()
 
     def redo(self) -> bool:
         """Re-apply the most recently undone edit. Mirror of `undo()`."""
-        if self._editor is None or self._editing:
+        if self._editor is None or self._editing or self.searching:
             return False
         return self._editor.redo()
+
+    @property
+    def searching(self) -> bool:
+        """Return True when a `/` search composer is active."""
+        return self._editor is not None and self._editor.searching
+
+    @property
+    def search_buffer(self) -> str:
+        """Return the in-progress search query (empty when not searching)."""
+        return self._editor.search_buffer if self._editor is not None else ""
+
+    def begin_search(self) -> bool:
+        """Open the `/` search overlay. Cancels any in-progress edit first.
+
+        Returns False when no session is open or the bank has no
+        records to search across. Opening a second search over an
+        active one is a no-op (the buffer is preserved so an
+        accidental retap can't wipe the query).
+        """
+        if self._editor is None:
+            return False
+        if self._editing:
+            self.cancel_edit()
+        return self._editor.begin_search()
+
+    def extend_search(self, character: str) -> None:
+        """Append a character to the search buffer."""
+        if self._editor is None or not self.searching:
+            raise SettingsControllerError("not in search sub-mode")
+        if len(character) != 1:
+            raise ValueError("extend_search expects exactly one character")
+        self._editor.extend_search(character)
+
+    def backspace_search(self) -> None:
+        """Remove the last character from the search buffer."""
+        if self._editor is None or not self.searching:
+            raise SettingsControllerError("not in search sub-mode")
+        self._editor.backspace_search()
+
+    def commit_search(self) -> bool:
+        """Close the overlay, keeping the cursor on the matched record."""
+        if self._editor is None or not self.searching:
+            return False
+        return self._editor.commit_search()
+
+    def cancel_search(self) -> bool:
+        """Close the overlay and restore the cursor to its pre-search spot."""
+        if self._editor is None or not self.searching:
+            return False
+        return self._editor.cancel_search()
 
     def save(self, path: Optional[Path | str] = None) -> Path:
         """Persist the bank. Uses the configured save_path if none is given."""

--- a/asat/settings_editor.py
+++ b/asat/settings_editor.py
@@ -139,6 +139,18 @@ class SettingsEditor:
         self._state = EditorState()
         self._undo_stack: list[_EditRecord] = []
         self._redo_stack: list[_EditRecord] = []
+        # F21b search overlay. When `_search_mode` is True the editor
+        # is in the `/` composer sub-mode; keys flow into `extend_search`
+        # / `backspace_search` and every mutation recomputes matches.
+        # `_search_origin` remembers the cursor position the user opened
+        # the overlay from so `cancel_search` can restore it verbatim.
+        self._search_mode: bool = False
+        self._search_buffer: str = ""
+        self._search_matches: tuple[tuple[Section, int], ...] = ()
+        self._search_position: int = -1
+        self._search_origin: Optional[
+            tuple[Level, Section, int, int]
+        ] = None
         publish_event(
             bus,
             EventType.SETTINGS_OPENED,
@@ -370,6 +382,233 @@ class SettingsEditor:
         """
         return self._bank is not self._saved_bank
 
+    @property
+    def searching(self) -> bool:
+        """True while the `/` search composer is active."""
+        return self._search_mode
+
+    @property
+    def search_buffer(self) -> str:
+        """Return the query the user is currently composing."""
+        return self._search_buffer
+
+    @property
+    def search_matches(self) -> tuple[tuple["Section", int], ...]:
+        """Return the ordered `(section, record_index)` pairs that match."""
+        return self._search_matches
+
+    @property
+    def search_match_count(self) -> int:
+        """Return the number of matches for the current / last search."""
+        return len(self._search_matches)
+
+    def begin_search(self) -> bool:
+        """Enter SEARCH sub-mode. Returns False if the bank is empty.
+
+        The overlay is cross-section: keystrokes that follow compose a
+        substring query matched against record ids (every section) plus
+        `event_type` / `voice_id` / `sound_id` on bindings. On the first
+        matching character the cursor parks at RECORD level inside the
+        section that owns the match. `cancel_search` restores the
+        cursor to its pre-search location; `commit_search` leaves the
+        cursor wherever the query landed.
+        """
+        if self._is_bank_empty():
+            return False
+        if self._search_mode:
+            # Second `/` while already open is a no-op; the existing
+            # buffer is intentionally preserved so an accidental retap
+            # doesn't wipe the query.
+            return True
+        self._search_mode = True
+        self._search_buffer = ""
+        self._search_matches = ()
+        self._search_position = -1
+        self._search_origin = (
+            self._state.level,
+            self._state.section,
+            self._state.record_index,
+            self._state.field_index,
+        )
+        publish_event(
+            self._bus,
+            EventType.SETTINGS_SEARCH_OPENED,
+            {
+                "origin_level": self._state.level.value,
+                "origin_section": self._state.section.value,
+                "origin_record_index": self._state.record_index,
+                "origin_field_index": self._state.field_index,
+            },
+            source=SOURCE,
+        )
+        return True
+
+    def extend_search(self, character: str) -> None:
+        """Append a character to the search buffer and recompute matches."""
+        if not self._search_mode:
+            raise SettingsEditorError("not in search sub-mode")
+        if len(character) != 1:
+            raise ValueError("extend_search expects exactly one character")
+        self._search_buffer += character
+        self._recompute_matches(jump_to_first=True)
+
+    def backspace_search(self) -> None:
+        """Trim the last character from the search buffer.
+
+        A backspace on an empty buffer is a silent no-op so the user
+        can hammer the key without closing the overlay.
+        """
+        if not self._search_mode:
+            raise SettingsEditorError("not in search sub-mode")
+        if not self._search_buffer:
+            return
+        self._search_buffer = self._search_buffer[:-1]
+        self._recompute_matches(jump_to_first=True)
+
+    def commit_search(self) -> bool:
+        """Close the overlay and leave the cursor on the current match.
+
+        Preserves `_search_matches` so a later `next_search_match` /
+        `prev_search_match` can keep cycling without retyping. Returns
+        False when no search was active.
+        """
+        if not self._search_mode:
+            return False
+        query = self._search_buffer
+        match_count = len(self._search_matches)
+        self._search_mode = False
+        self._search_origin = None
+        publish_event(
+            self._bus,
+            EventType.SETTINGS_SEARCH_CLOSED,
+            {
+                "query": query,
+                "match_count": match_count,
+                "committed": True,
+            },
+            source=SOURCE,
+        )
+        return True
+
+    def cancel_search(self) -> bool:
+        """Close the overlay and restore the cursor to the pre-search spot."""
+        if not self._search_mode:
+            return False
+        query = self._search_buffer
+        origin = self._search_origin
+        self._search_mode = False
+        self._search_buffer = ""
+        self._search_matches = ()
+        self._search_position = -1
+        self._search_origin = None
+        if origin is not None:
+            level, section, record_index, field_index = origin
+            self._state = replace(
+                self._state,
+                level=level,
+                section=section,
+                record_index=record_index,
+                field_index=field_index,
+            )
+            self._publish_focus()
+        publish_event(
+            self._bus,
+            EventType.SETTINGS_SEARCH_CLOSED,
+            {
+                "query": query,
+                "match_count": 0,
+                "committed": False,
+            },
+            source=SOURCE,
+        )
+        return True
+
+    def next_search_match(self) -> bool:
+        """Advance the cursor to the next match; wraps at the end."""
+        if not self._search_matches:
+            return False
+        self._search_position = (self._search_position + 1) % len(self._search_matches)
+        section, record_index = self._search_matches[self._search_position]
+        self._goto_record_match(section, record_index)
+        return True
+
+    def prev_search_match(self) -> bool:
+        """Step the cursor to the previous match; wraps at the start."""
+        if not self._search_matches:
+            return False
+        self._search_position = (self._search_position - 1) % len(self._search_matches)
+        section, record_index = self._search_matches[self._search_position]
+        self._goto_record_match(section, record_index)
+        return True
+
+    def _is_bank_empty(self) -> bool:
+        """True when every section is empty — nothing to search across."""
+        return not any(
+            getattr(self._bank, section.value) for section in SECTION_ORDER
+        )
+
+    def _recompute_matches(self, jump_to_first: bool) -> None:
+        """Rebuild the match list from the current query and bank.
+
+        Publishes `SETTINGS_SEARCH_UPDATED` with the match count; on a
+        hit, also parks the cursor at RECORD level inside the matching
+        section so the existing `SETTINGS_FOCUSED` narration reads the
+        record the user just landed on.
+        """
+        if not self._search_buffer:
+            self._search_matches = ()
+            self._search_position = -1
+            self._publish_search_update(match=None)
+            return
+        query = self._search_buffer.lower()
+        matches: list[tuple[Section, int]] = []
+        for section in SECTION_ORDER:
+            for idx, record in enumerate(getattr(self._bank, section.value)):
+                if query in _search_haystack(section, record).lower():
+                    matches.append((section, idx))
+        self._search_matches = tuple(matches)
+        if not matches:
+            self._search_position = -1
+            self._publish_search_update(match=None)
+            return
+        if jump_to_first:
+            self._search_position = 0
+            section, record_index = matches[0]
+            self._goto_record_match(section, record_index)
+        self._publish_search_update(match=matches[self._search_position])
+
+    def _goto_record_match(self, section: Section, record_index: int) -> None:
+        """Park the cursor at RECORD level on the given match."""
+        self._state = replace(
+            self._state,
+            level=Level.RECORD,
+            section=section,
+            record_index=record_index,
+            field_index=0,
+        )
+        self._publish_focus()
+
+    def _publish_search_update(
+        self, match: Optional[tuple["Section", int]]
+    ) -> None:
+        """Emit SETTINGS_SEARCH_UPDATED with the latest query + match."""
+        payload: dict[str, Any] = {
+            "query": self._search_buffer,
+            "match_count": len(self._search_matches),
+        }
+        if match is not None:
+            section, record_index = match
+            payload["section"] = section.value
+            payload["record_index"] = record_index
+            records = getattr(self._bank, section.value)
+            payload["record_id"] = getattr(records[record_index], "id", "")
+        publish_event(
+            self._bus,
+            EventType.SETTINGS_SEARCH_UPDATED,
+            payload,
+            source=SOURCE,
+        )
+
     def save(self, path: Path | str) -> None:
         """Persist the current bank as JSON at path and clear the dirty flag.
 
@@ -564,6 +803,25 @@ def _parse_override_mapping(
             )
         result[key] = _parse_float(str(value), f"{field_name}.{key}")
     return result
+
+
+def _search_haystack(section: Section, record: Any) -> str:
+    """Return the concatenated searchable text for a record.
+
+    Voice and SoundRecipe contribute only their `id`; EventBinding
+    contributes `id`, `event_type`, and the two references
+    (`voice_id` / `sound_id`, each None-safe). Joined with spaces so a
+    query that accidentally spans two fields still matches.
+    """
+    if section == Section.BINDINGS:
+        parts = (
+            record.id,
+            record.event_type,
+            record.voice_id or "",
+            record.sound_id or "",
+        )
+        return " ".join(part for part in parts if part)
+    return record.id or ""
 
 
 def _jsonable(value: Any) -> Any:

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -499,7 +499,7 @@ re-onboarding scenarios.
 
 ## F21 — Settings: undo, search, and reset
 
-**Status.** In progress. Undo/redo shipped; `/` search and `:reset`
+**Status.** In progress. Undo/redo and `/` search shipped; `:reset`
 still pending.
 
 **Gap.** The settings editor has no undo, no search, and no "reset
@@ -534,8 +534,30 @@ undo restores the post-save state and reasserts when redo moves
 past it. `SettingsController` exposes `undo()` / `redo()` that
 refuse during the edit sub-mode and when the session is closed.
 `InputRouter` binds **Ctrl+Z** to `settings_undo` and **Ctrl+Y**
-to `settings_redo` inside `FocusMode.SETTINGS`. Search and reset
-will follow in later PRs.
+to `settings_redo` inside `FocusMode.SETTINGS`.
+
+**Sketch (shipped — `/` search overlay).** Pressing `/` anywhere
+in the settings tree enters a search sub-mode that mirrors the
+edit and F16 output-search composers: printable characters extend
+the query, Backspace trims, Enter commits, Escape restores the
+pre-search cursor (level / section / record / field). Matching is
+case-insensitive substring across every section at once — Voice
+and SoundRecipe match on `id`; EventBinding matches on `id`,
+`event_type`, `voice_id`, or `sound_id` — and the first hit parks
+the cursor at **record** level so the narrator reads the matched
+record and the user can descend into fields if they choose. After
+commit, `n` / `N` cycle forward / backward through the preserved
+match list (wrapping). New events `SETTINGS_SEARCH_OPENED`,
+`SETTINGS_SEARCH_UPDATED`, and `SETTINGS_SEARCH_CLOSED` narrate
+the overlay; the default bank binds them to the system voice so
+they narrate cleanly on every platform. `SettingsController`
+exposes `begin_search` / `extend_search` / `backspace_search` /
+`commit_search` / `cancel_search`; `ascend()`, `undo()`, and
+`redo()` all refuse while the search sub-mode is active.
+`InputRouter` binds `/` to open, `n` / `N` to cycle, and routes
+every key through a dedicated dispatch while searching so motion
+keys do not leak into the editor. Reset is the remaining F21
+sub-feature.
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -329,6 +329,8 @@ FIELD    the typed fields on that record
 | Right / Enter       | Descend (section → record → field).             |
 | Left / Escape       | Ascend (or close at top level).                 |
 | `e`                 | Begin editing the focused field.                |
+| `/`                 | Open the cross-section search overlay.          |
+| `n` / `N`           | Next / previous search match after commit.      |
 | Ctrl+Z              | Undo the most recent field edit.                |
 | Ctrl+Y              | Redo the most recently undone edit.             |
 | Ctrl+S              | Save the bank to disk.                          |
@@ -372,6 +374,28 @@ A rejected edit keeps your old value and the narrator reads the
 error. A successful edit plays the `settings_chime` and immediately
 takes effect — you don't need to restart. Ctrl+S writes the whole
 bank to disk so the change survives a restart.
+
+### Searching the bank
+
+Press `/` at any level to open a cross-section search overlay. The
+overlay is a sub-mode modelled on the output-cursor search (F16):
+while it is active, printable characters extend the query buffer,
+Backspace trims it, Enter commits, and Escape restores the cursor
+to exactly where you were before.
+
+The query runs a case-insensitive substring match across every
+section at once:
+
+* **Voices** and **Sounds** match on their `id`.
+* **Bindings** match on `id`, `event_type`, `voice_id`, or
+  `sound_id` — enough to find "every binding that uses the narrator
+  voice" or "every routing for `command.completed`".
+
+The first hit is announced and the cursor parks at **record** level
+so you can descend with Right/Enter to the fields if you want to
+edit. After committing, `n` and `N` cycle forward and backward
+through the remaining matches (wrapping at the ends). A zero-match
+query still narrates the count so you know the overlay heard you.
 
 ### What the fields mean
 
@@ -442,6 +466,9 @@ Every key you need, one table.
 | SETTINGS   | Right / Enter     | Descend                               |
 | SETTINGS   | Left / Escape     | Ascend / close                        |
 | SETTINGS   | `e`               | Begin edit (at field level)           |
+| SETTINGS   | `/`               | Search (live), Enter commits, Escape restores |
+| SETTINGS   | `n` / `N`         | Next / previous search match          |
+| SETTINGS   | Ctrl+Z / Ctrl+Y   | Undo / redo field edit                |
 | SETTINGS   | Ctrl+S            | Save bank                             |
 | SETTINGS   | Ctrl+Q            | Close editor                          |
 

--- a/tests/test_default_bank.py
+++ b/tests/test_default_bank.py
@@ -92,6 +92,24 @@ SAMPLE_PAYLOADS: dict[EventType, dict[str, object]] = {
         "new_value": 1.1,
     },
     EventType.SETTINGS_SAVED: {"path": "/tmp/bank.json"},
+    EventType.SETTINGS_SEARCH_OPENED: {
+        "origin_level": "section",
+        "origin_section": "voices",
+        "origin_record_index": 0,
+        "origin_field_index": 0,
+    },
+    EventType.SETTINGS_SEARCH_UPDATED: {
+        "query": "nar",
+        "match_count": 1,
+        "section": "voices",
+        "record_index": 0,
+        "record_id": "narrator",
+    },
+    EventType.SETTINGS_SEARCH_CLOSED: {
+        "query": "nar",
+        "match_count": 1,
+        "committed": True,
+    },
     EventType.HELP_REQUESTED: {"lines": ["help"]},
     EventType.PROMPT_REFRESH: {
         "last_exit_code": 1,

--- a/tests/test_input_router.py
+++ b/tests/test_input_router.py
@@ -503,6 +503,142 @@ class SettingsModeDispatchTests(unittest.TestCase):
         self.assertEqual(controller.edit_buffer, "x")
         self.assertEqual(controller.bank.voices[0].engine, "sapi")
 
+    def test_slash_opens_settings_search_composer(self) -> None:
+        _, _, router, controller = _build_with_settings(["echo"])
+        router.handle_key(Key.combo(",", Modifier.CTRL))
+        result = router.handle_key(Key.printable("/"))
+        self.assertEqual(result, "settings_search_begin")
+        self.assertTrue(controller.searching)
+
+    def test_typed_chars_extend_search_and_jump_to_match(self) -> None:
+        _, _, router, controller = _build_with_settings(["echo"])
+        router.handle_key(Key.combo(",", Modifier.CTRL))
+        router.handle_key(Key.printable("/"))
+        for ch in "s1":
+            router.handle_key(Key.printable(ch))
+        self.assertEqual(controller.search_buffer, "s1")
+        # "s1" matches sounds[0] (id="s1") — cursor parks there.
+        self.assertEqual(controller.editor.state.section.value, "sounds")
+        self.assertEqual(controller.editor.state.record_index, 0)
+
+    def test_enter_commits_settings_search(self) -> None:
+        _, _, router, controller = _build_with_settings(["echo"])
+        router.handle_key(Key.combo(",", Modifier.CTRL))
+        router.handle_key(Key.printable("/"))
+        router.handle_key(Key.printable("s"))
+        result = router.handle_key(ENTER)
+        self.assertEqual(result, "settings_search_commit")
+        self.assertFalse(controller.searching)
+        self.assertEqual(controller.editor.state.section.value, "sounds")
+
+    def test_escape_cancels_settings_search_and_restores_cursor(self) -> None:
+        _, _, router, controller = _build_with_settings(["echo"])
+        router.handle_key(Key.combo(",", Modifier.CTRL))
+        # Drop into voices RECORD so we have a pre-search origin worth
+        # restoring.
+        router.handle_key(ENTER)
+        router.handle_key(Key.printable("/"))
+        for ch in "s1":
+            router.handle_key(Key.printable(ch))
+        self.assertEqual(controller.editor.state.section.value, "sounds")
+        result = router.handle_key(ESCAPE)
+        self.assertEqual(result, "settings_search_cancel")
+        self.assertFalse(controller.searching)
+        self.assertEqual(controller.editor.state.section.value, "voices")
+
+    def test_backspace_trims_settings_search_buffer(self) -> None:
+        _, _, router, controller = _build_with_settings(["echo"])
+        router.handle_key(Key.combo(",", Modifier.CTRL))
+        router.handle_key(Key.printable("/"))
+        for ch in "abc":
+            router.handle_key(Key.printable(ch))
+        result = router.handle_key(BACKSPACE)
+        self.assertEqual(result, "settings_search_backspace")
+        self.assertEqual(controller.search_buffer, "ab")
+
+    def test_motion_keys_swallowed_while_searching(self) -> None:
+        """Up / Down must not step records while a `/` composer is open —
+        that would silently dismiss the overlay and confuse narration."""
+        _, _, router, controller = _build_with_settings(["echo"])
+        router.handle_key(Key.combo(",", Modifier.CTRL))
+        router.handle_key(Key.printable("/"))
+        router.handle_key(Key.printable("s"))
+        section_before = controller.editor.state.section
+        # Arrow keys should NOT change section while composer is active.
+        self.assertIsNone(router.handle_key(UP))
+        self.assertIsNone(router.handle_key(DOWN))
+        self.assertTrue(controller.searching)
+        self.assertEqual(controller.editor.state.section, section_before)
+
+    def test_commit_payload_reports_query_and_match_count(self) -> None:
+        bus, _, router, _ = _build_with_settings(["echo"])
+        recorder = _Recorder(bus)
+        router.handle_key(Key.combo(",", Modifier.CTRL))
+        router.handle_key(Key.printable("/"))
+        for ch in "v1":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+        commit_events = [
+            e for e in recorder.types_of(EventType.ACTION_INVOKED)
+            if e.payload.get("action") == "settings_search_commit"
+        ]
+        self.assertEqual(len(commit_events), 1)
+        payload = commit_events[0].payload
+        self.assertEqual(payload["query"], "v1")
+        self.assertGreaterEqual(payload["match_count"], 1)
+
+    def test_n_and_N_cycle_matches_after_commit(self) -> None:
+        _, _, router, controller = _build_with_settings(["echo"])
+        router.handle_key(Key.combo(",", Modifier.CTRL))
+        router.handle_key(Key.printable("/"))
+        # "v1" matches voices[0] and bindings[0] (voice_id=v1) — 2 results.
+        for ch in "v1":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+        first_location = (
+            controller.editor.state.section,
+            controller.editor.state.record_index,
+        )
+        result = router.handle_key(Key.printable("n"))
+        self.assertEqual(result, "settings_search_next")
+        second_location = (
+            controller.editor.state.section,
+            controller.editor.state.record_index,
+        )
+        self.assertNotEqual(first_location, second_location)
+        self.assertEqual(router.handle_key(Key.printable("N")), "settings_search_prev")
+        self.assertEqual(
+            (controller.editor.state.section, controller.editor.state.record_index),
+            first_location,
+        )
+
+    def test_search_without_controller_is_noop(self) -> None:
+        """Router with no settings_controller: the binding dispatches but
+        the handler silently no-ops."""
+        bus = EventBus()
+        session = Session.new()
+        session.add_cell(Cell.new("echo"))
+        cursor = NotebookCursor(session, bus)
+        cursor.enter_settings_mode()  # simulate being in SETTINGS focus
+        router = InputRouter(cursor, bus)
+        self.assertEqual(
+            router.handle_key(Key.printable("/")),
+            "settings_search_begin",
+        )
+
+    def test_slash_is_not_bound_outside_settings_mode(self) -> None:
+        """The `/` key in NOTEBOOK mode must not accidentally open the
+        settings search (settings may not even be open)."""
+        _, _, router, controller = _build_with_settings(["echo"])
+        # Start in NOTEBOOK; `/` should be unbound there.
+        self.assertIsNone(router.handle_key(Key.printable("/")))
+        self.assertFalse(controller.searching)
+
+    def test_help_mentions_settings_search(self) -> None:
+        from asat.input_router import HELP_LINES
+        joined = "\n".join(HELP_LINES)
+        self.assertIn("search", joined.lower())
+
     def test_invalid_commit_surfaces_in_action_payload(self) -> None:
         bus, _, router, _ = _build_with_settings(["echo"])
         recorder = _Recorder(bus)

--- a/tests/test_settings_controller.py
+++ b/tests/test_settings_controller.py
@@ -243,6 +243,132 @@ class UndoRedoTests(unittest.TestCase):
         self.assertFalse(controller.redo())
 
 
+class SearchSubModeTests(unittest.TestCase):
+    """F21b: the controller exposes begin/extend/backspace/commit/cancel
+    that mirror the existing edit sub-mode."""
+
+    def test_begin_search_returns_false_when_closed(self) -> None:
+        controller = SettingsController(EventBus(), _bank())
+        self.assertFalse(controller.begin_search())
+
+    def test_begin_search_enters_sub_mode(self) -> None:
+        controller = SettingsController(EventBus(), _bank())
+        controller.open()
+        self.assertTrue(controller.begin_search())
+        self.assertTrue(controller.searching)
+        self.assertEqual(controller.search_buffer, "")
+
+    def test_extend_search_appends_to_buffer(self) -> None:
+        controller = SettingsController(EventBus(), _bank())
+        controller.open()
+        controller.begin_search()
+        for ch in "v1":
+            controller.extend_search(ch)
+        self.assertEqual(controller.search_buffer, "v1")
+
+    def test_backspace_trims_search_buffer(self) -> None:
+        controller = SettingsController(EventBus(), _bank())
+        controller.open()
+        controller.begin_search()
+        for ch in "abc":
+            controller.extend_search(ch)
+        controller.backspace_search()
+        self.assertEqual(controller.search_buffer, "ab")
+
+    def test_commit_search_leaves_sub_mode(self) -> None:
+        controller = SettingsController(EventBus(), _bank())
+        controller.open()
+        controller.begin_search()
+        for ch in "v1":
+            controller.extend_search(ch)
+        self.assertTrue(controller.commit_search())
+        self.assertFalse(controller.searching)
+
+    def test_cancel_search_restores_cursor(self) -> None:
+        controller = SettingsController(EventBus(), _bank())
+        controller.open()
+        controller.descend()  # to RECORD in voices
+        controller.begin_search()
+        for ch in "s1":
+            controller.extend_search(ch)
+        # Should have jumped to sounds section.
+        self.assertEqual(controller.editor.state.section.value, "sounds")
+        self.assertTrue(controller.cancel_search())
+        self.assertFalse(controller.searching)
+        self.assertEqual(controller.editor.state.section.value, "voices")
+
+    def test_ascend_while_searching_cancels_search(self) -> None:
+        controller = SettingsController(EventBus(), _bank())
+        controller.open()
+        controller.descend()
+        controller.begin_search()
+        for ch in "s1":
+            controller.extend_search(ch)
+        ok = controller.ascend()
+        self.assertTrue(ok)
+        self.assertFalse(controller.searching)
+        # Cursor restored to voices RECORD level, not ascended further.
+        self.assertEqual(controller.editor.state.section.value, "voices")
+
+    def test_extend_without_begin_raises(self) -> None:
+        controller = SettingsController(EventBus(), _bank())
+        controller.open()
+        with self.assertRaises(SettingsControllerError):
+            controller.extend_search("a")
+
+    def test_backspace_without_begin_raises(self) -> None:
+        controller = SettingsController(EventBus(), _bank())
+        controller.open()
+        with self.assertRaises(SettingsControllerError):
+            controller.backspace_search()
+
+    def test_extend_rejects_multi_character(self) -> None:
+        controller = SettingsController(EventBus(), _bank())
+        controller.open()
+        controller.begin_search()
+        with self.assertRaises(ValueError):
+            controller.extend_search("ab")
+
+    def test_begin_search_while_editing_cancels_edit(self) -> None:
+        controller = SettingsController(EventBus(), _bank())
+        controller.open()
+        controller.descend()
+        controller.descend()
+        controller.next()  # engine field
+        controller.begin_edit()
+        controller.extend_edit("s")
+        self.assertTrue(controller.editing)
+        self.assertTrue(controller.begin_search())
+        self.assertFalse(controller.editing)
+        self.assertTrue(controller.searching)
+
+    def test_undo_is_noop_while_searching(self) -> None:
+        controller = SettingsController(EventBus(), _bank())
+        controller.open()
+        # Land a real edit so the undo stack has something to revert.
+        controller.descend()
+        controller.descend()
+        controller.next()  # engine
+        controller.begin_edit()
+        for ch in "sapi":
+            controller.extend_edit(ch)
+        controller.commit_edit()
+        # Now start a search and confirm undo is refused.
+        controller.begin_search()
+        self.assertFalse(controller.undo())
+        self.assertEqual(controller.bank.voices[0].engine, "sapi")
+
+    def test_commit_without_search_returns_false(self) -> None:
+        controller = SettingsController(EventBus(), _bank())
+        controller.open()
+        self.assertFalse(controller.commit_search())
+
+    def test_cancel_without_search_returns_false(self) -> None:
+        controller = SettingsController(EventBus(), _bank())
+        controller.open()
+        self.assertFalse(controller.cancel_search())
+
+
 class SaveTests(unittest.TestCase):
 
     def test_save_to_configured_path(self) -> None:

--- a/tests/test_settings_editor.py
+++ b/tests/test_settings_editor.py
@@ -405,6 +405,304 @@ class UndoRedoTests(unittest.TestCase):
         self.assertEqual(undone, MAX_HISTORY)
 
 
+class SearchOverlayTests(unittest.TestCase):
+    """F21b: `/` search sub-mode over all three sections."""
+
+    def _search_bank(self) -> SoundBank:
+        """A multi-section bank with distinguishable ids for search asserts."""
+        return SoundBank(
+            voices=(
+                Voice(id="narrator", rate=1.0),
+                Voice(id="alert", rate=1.0),
+            ),
+            sounds=(
+                SoundRecipe(id="tick", kind="tone", params={"frequency": 880.0}),
+                SoundRecipe(id="chord", kind="chord", params={"frequencies": [440.0, 660.0]}),
+            ),
+            bindings=(
+                EventBinding(
+                    id="session_opened",
+                    event_type="session.created",
+                    voice_id="narrator",
+                    say_template="hi",
+                ),
+                EventBinding(
+                    id="submit_cue",
+                    event_type="command.submitted",
+                    voice_id="alert",
+                    sound_id="tick",
+                ),
+            ),
+        )
+
+    def test_begin_search_enters_sub_mode(self) -> None:
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        self.assertFalse(editor.searching)
+        self.assertTrue(editor.begin_search())
+        self.assertTrue(editor.searching)
+        self.assertEqual(editor.search_buffer, "")
+
+    def test_begin_search_empty_bank_returns_false(self) -> None:
+        editor = SettingsEditor(EventBus(), SoundBank())
+        self.assertFalse(editor.begin_search())
+        self.assertFalse(editor.searching)
+
+    def test_begin_search_publishes_opened_event_with_origin(self) -> None:
+        bus = EventBus()
+        opened = _Recorder(bus, EventType.SETTINGS_SEARCH_OPENED)
+        editor = SettingsEditor(bus, self._search_bank())
+        editor.enter()  # descend to RECORD so origin is non-default
+        editor.begin_search()
+        self.assertEqual(len(opened.events), 1)
+        payload = opened.events[0].payload
+        self.assertEqual(payload["origin_level"], "record")
+        self.assertEqual(payload["origin_section"], "voices")
+
+    def test_second_begin_while_open_preserves_buffer(self) -> None:
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        editor.begin_search()
+        editor.extend_search("n")
+        editor.extend_search("a")
+        editor.begin_search()  # accidental retap
+        self.assertEqual(editor.search_buffer, "na")
+
+    def test_extend_jumps_to_first_matching_record(self) -> None:
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        editor.begin_search()
+        editor.extend_search("n")  # matches "narrator"
+        self.assertEqual(editor.state.level, Level.RECORD)
+        self.assertEqual(editor.state.section, Section.VOICES)
+        self.assertEqual(editor.state.record_index, 0)
+
+    def test_extend_crosses_section_boundaries(self) -> None:
+        """A query that only matches in SOUNDS or BINDINGS must jump there
+        regardless of the section the user was parked on."""
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        editor.begin_search()
+        editor.extend_search("c")  # "chord" in sounds, plus "tick" / "session_opened" partial? No — just chord
+        editor.extend_search("h")  # narrows
+        editor.extend_search("o")
+        editor.extend_search("r")
+        editor.extend_search("d")
+        self.assertEqual(editor.state.section, Section.SOUNDS)
+        self.assertEqual(editor.state.record_index, 1)
+
+    def test_extend_matches_binding_event_type(self) -> None:
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        editor.begin_search()
+        for ch in "command.":
+            editor.extend_search(ch)
+        self.assertEqual(editor.state.section, Section.BINDINGS)
+        self.assertEqual(editor.state.record_index, 1)
+
+    def test_extend_matches_binding_voice_id(self) -> None:
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        editor.begin_search()
+        for ch in "alert":
+            editor.extend_search(ch)
+        # "alert" matches voices[1].id first in SECTION_ORDER, but that's
+        # expected: cross-section order is voices → sounds → bindings.
+        self.assertEqual(editor.state.section, Section.VOICES)
+        self.assertEqual(editor.state.record_index, 1)
+        # Every match is still tracked, including bindings[1] whose
+        # voice_id = "alert".
+        matches = editor.search_matches
+        self.assertIn((Section.VOICES, 1), matches)
+        self.assertIn((Section.BINDINGS, 1), matches)
+
+    def test_extend_matches_are_case_insensitive(self) -> None:
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        editor.begin_search()
+        for ch in "NAR":
+            editor.extend_search(ch)
+        self.assertEqual(editor.state.record_index, 0)
+
+    def test_extend_no_match_leaves_cursor_in_place(self) -> None:
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        editor.enter()
+        editor.next()  # voices[1] = alert
+        editor.begin_search()
+        editor.extend_search("z")  # no match anywhere
+        self.assertEqual(editor.search_match_count, 0)
+        # Cursor stays wherever it was — composer silently reports "no match".
+        self.assertEqual(editor.state.section, Section.VOICES)
+        self.assertEqual(editor.state.record_index, 1)
+
+    def test_backspace_recomputes_matches(self) -> None:
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        editor.begin_search()
+        for ch in "chord":
+            editor.extend_search(ch)
+        self.assertEqual(editor.search_match_count, 1)
+        editor.backspace_search()  # "chor"
+        editor.backspace_search()  # "cho"
+        editor.backspace_search()  # "ch" — still 1 match ("chord")
+        editor.backspace_search()  # "c" — now matches chord AND both bindings (command. / submit_cue)
+        self.assertEqual(editor.search_buffer, "c")
+        self.assertGreater(editor.search_match_count, 1)
+        editor.backspace_search()  # ""
+        # An empty buffer resets to zero matches (we don't advertise
+        # every record as a "match" of an empty query).
+        self.assertEqual(editor.search_buffer, "")
+        self.assertEqual(editor.search_match_count, 0)
+
+    def test_backspace_on_empty_buffer_is_noop(self) -> None:
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        editor.begin_search()
+        editor.backspace_search()  # must not raise
+        self.assertEqual(editor.search_buffer, "")
+        self.assertTrue(editor.searching)
+
+    def test_extend_without_begin_raises(self) -> None:
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        with self.assertRaises(SettingsEditorError):
+            editor.extend_search("a")
+
+    def test_extend_rejects_multi_character(self) -> None:
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        editor.begin_search()
+        with self.assertRaises(ValueError):
+            editor.extend_search("abc")
+
+    def test_commit_search_leaves_cursor_on_match(self) -> None:
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        editor.begin_search()
+        for ch in "chord":
+            editor.extend_search(ch)
+        self.assertTrue(editor.commit_search())
+        self.assertFalse(editor.searching)
+        self.assertEqual(editor.state.section, Section.SOUNDS)
+        self.assertEqual(editor.state.record_index, 1)
+
+    def test_commit_search_preserves_matches_for_cycling(self) -> None:
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        editor.begin_search()
+        editor.extend_search("a")
+        editor.commit_search()
+        self.assertGreater(editor.search_match_count, 1)
+
+    def test_commit_without_search_returns_false(self) -> None:
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        self.assertFalse(editor.commit_search())
+
+    def test_cancel_restores_pre_search_cursor(self) -> None:
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        editor.enter()  # RECORD on voices[0]
+        editor.enter()  # FIELD on voices[0].id
+        editor.next()   # voices[0].engine
+        origin_level = editor.state.level
+        origin_section = editor.state.section
+        origin_record = editor.state.record_index
+        origin_field = editor.state.field_index
+        editor.begin_search()
+        for ch in "chord":
+            editor.extend_search(ch)
+        self.assertEqual(editor.state.section, Section.SOUNDS)
+
+        self.assertTrue(editor.cancel_search())
+
+        self.assertFalse(editor.searching)
+        self.assertEqual(editor.state.level, origin_level)
+        self.assertEqual(editor.state.section, origin_section)
+        self.assertEqual(editor.state.record_index, origin_record)
+        self.assertEqual(editor.state.field_index, origin_field)
+
+    def test_cancel_without_search_returns_false(self) -> None:
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        self.assertFalse(editor.cancel_search())
+
+    def test_next_and_prev_search_match_cycle_matches(self) -> None:
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        editor.begin_search()
+        editor.extend_search("a")  # matches narrator, alert, (chord?), bindings with voice_id=alert
+        editor.commit_search()
+        start = (editor.state.section, editor.state.record_index)
+        editor.next_search_match()
+        after_next = (editor.state.section, editor.state.record_index)
+        self.assertNotEqual(start, after_next)
+        editor.prev_search_match()
+        self.assertEqual((editor.state.section, editor.state.record_index), start)
+
+    def test_next_search_match_wraps_around(self) -> None:
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        editor.begin_search()
+        editor.extend_search("a")
+        editor.commit_search()
+        first = (editor.state.section, editor.state.record_index)
+        count = editor.search_match_count
+        for _ in range(count):
+            editor.next_search_match()
+        self.assertEqual((editor.state.section, editor.state.record_index), first)
+
+    def test_next_match_without_any_matches_returns_false(self) -> None:
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        self.assertFalse(editor.next_search_match())
+
+    def test_search_update_event_carries_query_and_count(self) -> None:
+        bus = EventBus()
+        updates = _Recorder(bus, EventType.SETTINGS_SEARCH_UPDATED)
+        editor = SettingsEditor(bus, self._search_bank())
+        editor.begin_search()
+        editor.extend_search("n")
+        self.assertGreater(len(updates.events), 0)
+        last = updates.events[-1].payload
+        self.assertEqual(last["query"], "n")
+        self.assertGreaterEqual(last["match_count"], 1)
+        self.assertEqual(last["section"], "voices")
+
+    def test_search_update_for_no_match_has_zero_count(self) -> None:
+        bus = EventBus()
+        updates = _Recorder(bus, EventType.SETTINGS_SEARCH_UPDATED)
+        editor = SettingsEditor(bus, self._search_bank())
+        editor.begin_search()
+        editor.extend_search("z")
+        last = updates.events[-1].payload
+        self.assertEqual(last["match_count"], 0)
+        self.assertNotIn("section", last)
+
+    def test_commit_publishes_closed_with_committed_true(self) -> None:
+        bus = EventBus()
+        closed = _Recorder(bus, EventType.SETTINGS_SEARCH_CLOSED)
+        editor = SettingsEditor(bus, self._search_bank())
+        editor.begin_search()
+        editor.extend_search("n")
+        editor.commit_search()
+        self.assertEqual(len(closed.events), 1)
+        self.assertTrue(closed.events[0].payload["committed"])
+        self.assertEqual(closed.events[0].payload["query"], "n")
+
+    def test_cancel_publishes_closed_with_committed_false(self) -> None:
+        bus = EventBus()
+        closed = _Recorder(bus, EventType.SETTINGS_SEARCH_CLOSED)
+        editor = SettingsEditor(bus, self._search_bank())
+        editor.begin_search()
+        editor.extend_search("n")
+        editor.cancel_search()
+        self.assertEqual(len(closed.events), 1)
+        self.assertFalse(closed.events[0].payload["committed"])
+
+    def test_focus_event_publishes_when_match_jumps_cursor(self) -> None:
+        bus = EventBus()
+        focused = _Recorder(bus, EventType.SETTINGS_FOCUSED)
+        editor = SettingsEditor(bus, self._search_bank())
+        before = len(focused.events)
+        editor.begin_search()
+        editor.extend_search("n")  # matches narrator
+        self.assertGreater(len(focused.events), before)
+        self.assertEqual(focused.events[-1].payload["level"], "record")
+        self.assertEqual(focused.events[-1].payload["section"], "voices")
+
+    def test_search_does_not_mutate_bank_or_dirty_flag(self) -> None:
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        baseline = editor.bank
+        editor.begin_search()
+        for ch in "narrator":
+            editor.extend_search(ch)
+        editor.commit_search()
+        self.assertIs(editor.bank, baseline)
+        self.assertFalse(editor.state.dirty)
+
+
 class SaveTests(unittest.TestCase):
 
     def test_save_writes_file_and_clears_dirty(self) -> None:


### PR DESCRIPTION
## Summary
- Add a `/` search sub-mode to `SettingsEditor` that searches every section at once (Voice.id, SoundRecipe.id, EventBinding.id/event_type/voice_id/sound_id) and parks the cursor at RECORD level on the first match.
- Mirror the edit / F16 composer shape: `/` opens, printable characters extend, Backspace trims, Enter commits, Escape restores the pre-search cursor. After commit, `n` / `N` cycle through the preserved match list with wrap-around.
- New events `SETTINGS_SEARCH_OPENED`, `SETTINGS_SEARCH_UPDATED`, `SETTINGS_SEARCH_CLOSED` carry query / match count / section / record id / committed flag. Default bank binds them to the system voice so narration works out of the box.
- `SettingsController` exposes `begin_search` / `extend_search` / `backspace_search` / `commit_search` / `cancel_search`. `ascend()`, `undo()`, and `redo()` refuse while searching. `InputRouter` binds `/`, `n`, `N` and dispatches every key through a dedicated search path so motion keys can't leak into the editor.
- Docs: cheat-sheet row and "Searching the bank" section in USER_MANUAL; FEATURE_REQUESTS F21 sketch updated; HANDOFF shipped list + test count (682) + next-PR suggestion (F21c reset).

## Test plan
- [x] `python -m unittest discover -s tests -t .` — 682 passing (up from 629 baseline; 53 new tests across editor / controller / router / default-bank).
- [x] Editor: begin/extend/backspace/commit/cancel; cross-section match on voices / sounds / bindings (id, event_type, voice_id); case-insensitivity; no-match stays put; bank not mutated; cancel restores origin cursor exactly.
- [x] Controller: begin during edit cancels the edit; ascend while searching cancels search; undo/redo refused while searching; closed-session rejects.
- [x] Router: `/` opens; typed chars jump-to-match; Enter commits with `{query, match_count}`; Escape cancels + restores cursor; Backspace trims; motion keys swallowed while searching; `n` / `N` cycle post-commit; `/` unbound outside SETTINGS.
- [x] Default bank: new SETTINGS_SEARCH_* events are in COVERED_EVENT_TYPES with payloads + bindings; `test_engine_plays_something_for_every_covered_event` exercises them.