### PR TITLE
docs: repo audit — close gaps and scope accessibility features

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -31,8 +31,10 @@ F9 README · F11 auto-advance after submit · F13 in-line buffer editing
 · F14 action-menu keystroke · F15 cell delete/move/duplicate · F16
 output search + jump-to-line · F17 richer meta-commands · F18 OS
 clipboard · F19 prompt context on re-entry · F20 first-run onboarding
-· F21a settings undo/redo · F21b settings `/` search overlay · F6
-Windows live audio (POSIX still open).
+· F21a settings undo/redo · F21b settings `/` search overlay.
+
+## Partially shipped
+· **F6** Windows live audio shipped; POSIX still open.
 
 ## Open (roadmap)
 F1/F10 cancel + non-blocking exec · F2 settings create/delete · F3
@@ -44,7 +46,12 @@ playback · **F25** remappable keybindings · **F26** cell clipboard
 (cut/copy/paste cells) · **F27** heading/text cells + outline
 navigation + heading-scope selection · **F28** speech output console
 (programmatic + braille / screen-reader routing) · **F29** notebook
-tabs with per-tab kernel (and child tabs sharing one kernel).
+tabs with per-tab kernel (and child tabs sharing one kernel) ·
+**F30** audio history / repeat last narration · **F31** verbosity
+presets · **F32** audio ducking under narration · **F34** completion
+alert when focus has moved · **F35** cell bookmarks · **F36** auto-
+read stderr tail on failure · **F37** long-output pacing (silence +
+progress beats) · **F38** self-voicing help topics.
 
 ## Non-negotiables
 - Pure stdlib. Optional numpy only; no other third-party deps.
@@ -76,12 +83,40 @@ API + InputRouter key (Ctrl+R?) + tests + docs, then PR.
 Alternative one-shot PRs if F21c feels heavy: **F22** `--log
 path.jsonl` diagnostic file (a single `JsonlEventLogger` subscriber,
 CLI flag, tests); **F4** command history (ring buffer + Up/Down in
-INPUT mode); **F23** Tab completion of executables + paths.
+INPUT mode); **F23** Tab completion of executables + paths; **F36**
+auto-read stderr tail on failure (one default binding + a buffer-tail
+helper — highest UX payoff for the effort).
+
+## Maintenance backlog (non-feature cleanups)
+Each of these is a small standalone PR. Pick one off the top of the
+stack when you want a palate cleanser between features.
+
+- Factor the `if self._settings_controller is None: return` /
+  `if self._output_cursor is None: return` guards in
+  `asat/input_router.py` (9 sites) and `asat/output_cursor.py` (3
+  sites) into a helper or decorator.
+- Split `InputRouter._action_handler` (currently an 84-line inline
+  dict) into per-subsystem dicts: `_settings_handlers()`,
+  `_output_handlers()`, `_menu_handlers()` merged at init.
+- Table-drive `SettingsEditor._parse_field_value()`: replace the
+  per-section if/elif ladders with a `FIELD_PARSERS` dict keyed by
+  `(section, field_name)`.
+- Table-drive `InputRouter._handle_meta_command()`: replace the
+  if/elif chain with a `_META_HANDLERS: dict[str, Callable]`.
+- Replace the `"search"` / `"goto"` magic strings in
+  `asat/output_cursor.py` with a `ComposerMode(str, Enum)`.
+- Add doc-link comments (single lines) above the state-machine
+  transitions in `settings_editor.py` and `output_cursor.py` pointing
+  to the relevant `docs/ARCHITECTURE.md` / `docs/USER_MANUAL.md`
+  sections, so future readers can orient themselves without reading
+  the surrounding code.
+- Guard the `_search_position = -1` edge in
+  `SettingsEditor._recompute_matches(jump_to_first=False)` — today,
+  the `-1` sentinel can persist and make `prev_search_match()` wrap
+  to the last match unexpectedly. Tiny fix; add a regression test.
 
 ---
 
 Paste this entire file as the first message of the new session and it
 will pick up without further priming.
-
-<!-- MCP PR-creation smoke test: trivial edit to verify Claude Code can open PRs via the GitHub MCP server. -->
 

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -197,13 +197,23 @@ See [AUDIO.md](AUDIO.md) for the full reference.
 Producer: `asat.settings_editor.SettingsEditor`
 (`source="settings_editor"`).
 
-| EventType                | Payload keys                                                        |
-|--------------------------|---------------------------------------------------------------------|
-| `SETTINGS_OPENED`        | `section`, `record_count`                                           |
-| `SETTINGS_CLOSED`        | `dirty`                                                             |
-| `SETTINGS_FOCUSED`       | `level`, `section`, (optional) `record_index`, `record_id`, `field`, `value` |
-| `SETTINGS_VALUE_EDITED`  | `section`, `record_index`, `field`, `old_value`, `new_value`        |
-| `SETTINGS_SAVED`         | `path`                                                              |
+| EventType                  | Payload keys                                                        |
+|----------------------------|---------------------------------------------------------------------|
+| `SETTINGS_OPENED`          | `section`, `record_count`                                           |
+| `SETTINGS_CLOSED`          | `dirty`                                                             |
+| `SETTINGS_FOCUSED`         | `level`, `section`, (optional) `record_index`, `record_id`, `field`, `value` |
+| `SETTINGS_VALUE_EDITED`    | `section`, `record_index`, `field`, `old_value`, `new_value`        |
+| `SETTINGS_SAVED`           | `path`                                                              |
+| `SETTINGS_SEARCH_OPENED`   | `origin_level`, `origin_section`, `origin_record_index`, `origin_field_index` |
+| `SETTINGS_SEARCH_UPDATED`  | `query`, `match_count`, (optional, when matched) `section`, `record_index`, `record_id` |
+| `SETTINGS_SEARCH_CLOSED`   | `query`, `match_count`, `committed`                                 |
+
+The `SETTINGS_SEARCH_*` family fires from the `/` search overlay
+described in [USER_MANUAL.md § Searching the bank](USER_MANUAL.md#searching-the-bank).
+`SETTINGS_SEARCH_UPDATED` publishes on every buffer edit, including
+zero-match queries (so narration can announce "0 matches").
+`SETTINGS_SEARCH_CLOSED` carries `committed=True` on Enter and
+`committed=False` on Escape / ascend cancel.
 
 ## Help surface
 

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -97,9 +97,11 @@ deterministic fallback for headless tests.
 
 ## F6 — Live-speaker audio sink (POSIX)
 
-**Status.** Windows live playback shipped (`WindowsLiveAudioSink` in
-`asat/audio_sink.py`, selected by `python -m asat --live`). The
-remaining gap is POSIX.
+**Status.** Partially shipped. Windows live playback ships
+(`WindowsLiveAudioSink` in `asat/audio_sink.py`, selected by
+`python -m asat --live`). POSIX (macOS / Linux) is still open —
+`pick_live_sink()` raises `LiveAudioUnavailable` on those platforms
+and the CLI falls back to `MemorySink` with a spoken warning.
 
 **Gap.** On macOS and Linux, `pick_live_sink()` raises
 `LiveAudioUnavailable` and the CLI falls back to `MemorySink` with a
@@ -801,6 +803,190 @@ but strip the UI to: one line at the top announcing
 navigation, nothing for the screen reader to wade through. Every
 visual surface stays single-pane and minimal so navigation cost is
 purely in keystrokes, not in spoken chrome.
+
+---
+
+## F30 — Audio history / "repeat last narration"
+
+**Gap.** When a narration passes by faster than the user can absorb
+it — or a new event speaks over the one they wanted to catch — there
+is no way to re-hear the last phrase. Assistive tech on desktops
+universally provides a "say-it-again" key; ASAT does not.
+
+**Where it surfaces.** Output-line narration during a noisy `pytest`
+run, or quick focus transitions that chain several short cues, where
+the user realises "what did that last one say?" too late.
+
+**Sketch.** Add a bounded ring buffer (default 20 entries) inside
+`SoundEngine` that records every rendered speech phrase with its
+`event_type`, `binding_id`, rendered `text`, and timestamp. Bind
+`Ctrl+R` (repeat) to replay the most recent entry via the same voice,
+and `Ctrl+Shift+R` to open an "audio history" overlay sub-mode where
+Up/Down walks back through the buffer and Enter replays the focused
+entry. Emit `NARRATION_REPLAYED` so tests can assert on the buffer
+depth and replay ordering. History is purely in-memory; it resets
+on process exit.
+
+---
+
+## F31 — Narration verbosity presets
+
+**Gap.** Some users want bare-minimum narration (errors + exit codes
+only), others want chatty feedback on every keystroke. Today, the
+only way to quiet a class of events is to manually disable bindings
+one-by-one in the settings editor.
+
+**Where it surfaces.** A user running a 10-minute build doesn't need
+per-line narration but does want the failure cue; today they have
+to navigate to each output binding and flip `enabled = false`.
+
+**Sketch.** Add a `verbosity: Literal["minimal", "normal", "verbose"]`
+field to each `EventBinding` (default `"normal"`) and a top-level
+`SoundBank.verbosity_level` with the same shape. The sound engine
+skips any binding whose `verbosity` is stricter than the bank's
+current level. Expose a `:verbosity <level>` meta-command and cycle
+via `Ctrl+M` inside SETTINGS. Every preset change fires a
+`VERBOSITY_CHANGED` event the narrator announces so the user hears
+which profile they just entered. Pairs cleanly with F21c reset so
+"reset to defaults" can include "and verbosity=normal".
+
+---
+
+## F32 — Audio ducking under active narration
+
+**Gap.** When TTS narration plays while non-speech output cues fire
+(output-line chords, keystroke blips), the speech gets masked. There
+is no automatic gain management to keep voice intelligible.
+
+**Where it surfaces.** Streaming output during a command: the
+per-line sound cues stack on top of the narrator reading a single
+line, and the combined mix is hard to parse.
+
+**Sketch.** Add `ducking_enabled: bool` (default `True`) and
+`duck_level: float` (0-1, default 0.4) to the top of `SoundBank`.
+`SoundEngine` tracks whether a speech buffer is currently mixing; if
+so, any concurrent non-speech buffer has its gain multiplied by
+`duck_level` before being mixed. The attenuation releases on the
+next mix cycle after the speech buffer finishes. Expose both fields
+as settings you can live-edit. The implementation lives entirely in
+the engine's mixing loop — no events or new subsystems.
+
+---
+
+## F34 — Completion alert when focus has moved
+
+**Gap.** A long-running command that completes in the background
+fires the normal completion cue, but if the user has tabbed to a
+different window or moved to OUTPUT mode on a different cell, the
+cue is easy to miss. Shells historically rang the terminal bell; we
+have no equivalent "I'm done, come back" signal.
+
+**Where it surfaces.** `make test` starts on cell 3, user moves to
+cell 5 to keep working, `make test` finishes and says "command
+completed exit 0" — but only once, at conversational volume, and
+the user is already typing into cell 5.
+
+**Sketch.** `ExecutionRunner` already knows the originating
+`cell_id` and start time. If `COMMAND_COMPLETED` fires and the
+current focus (notebook cursor + mode) has moved away from the
+originating cell since `COMMAND_STARTED`, publish an additional
+`COMMAND_COMPLETED_AWAY` event. Bind that to a distinctive chime
+(louder, wider spatial placement) in the default bank. Two-tier
+semantics: the normal completion cue still fires for correctness;
+the away-cue is a bonus nudge. Silence it with a binding-level
+toggle.
+
+---
+
+## F35 — Cell bookmarks
+
+**Gap.** In a long session the user wants to mark significant cells
+("the one where I set up the venv", "the broken test run") and jump
+back by name. There's no positional shortcut — a sighted user would
+scroll visually, but we don't have that affordance.
+
+**Where it surfaces.** Debugging a multi-step issue where the user
+needs to repeatedly revisit the same two or three cells while
+interleaving exploration in between.
+
+**Sketch.** Introduce a `BookmarkRegistry` stored on `Session`
+mapping user-chosen names to cell ids. Meta-commands: `:bookmark
+<name>` captures the focused cell, `:jump <name>` navigates to it,
+`:bookmarks` narrates the full list, `:unbookmark <name>` removes
+one. Persist the registry in the session JSON so it survives reload.
+Emit `BOOKMARK_CREATED` / `BOOKMARK_JUMPED` / `BOOKMARK_REMOVED` for
+narration. Tab-completes cleanly once F23 lands.
+
+---
+
+## F36 — Auto-read stderr tail on command failure
+
+**Gap.** When a command fails, the user hears the failure chord and
+the exit code, but has to manually enter OUTPUT mode and scroll to
+find the error text. The single most useful piece of information
+(what went wrong) is an extra navigation step away.
+
+**Where it surfaces.** Every failed build, failed test run, failed
+`cd`, failed `git pull`. The narrator says "command failed exit 1"
+— not "command failed: fatal: not a git repository".
+
+**Sketch.** On `COMMAND_FAILED` (or `COMMAND_COMPLETED` with
+`exit_code != 0`), the sound engine inspects the cell's captured
+output buffer, takes the last N stderr lines (default 3, configurable
+via `stderr_tail_lines` on the bank), and speaks them through the
+`alert` voice after the failure chord. The binding's predicate
+already supports `exit_code != 0`, so this is one new default
+binding plus a small helper to fetch the tail from the buffer.
+Explicitly opt-outable via a settings toggle — some users will
+prefer the minimal cue and navigate manually.
+
+---
+
+## F37 — Long-output pacing
+
+**Gap.** A command emitting thousands of lines produces a continuous
+narration stream. After thirty seconds the user has lost sense of
+progress and the per-line cues become noise. There's no silence
+detection ("it's been quiet for 10s — still running?") and no
+periodic progress beat during streaming.
+
+**Where it surfaces.** `pytest -v`, `make`, log-tailing. Also:
+commands that hang silently have no distinguishing cue from commands
+that are just slow.
+
+**Sketch.** A `StreamingMonitor` subscribes to `OUTPUT_CHUNK` and
+`COMMAND_STARTED`/`_COMPLETED` for the active cell. It tracks the
+time since the last chunk; if the gap crosses `silence_threshold_sec`
+(default 5.0) it publishes `OUTPUT_STREAM_PAUSED`, and every
+`progress_beat_interval_sec` (default 30.0) while output is
+streaming it publishes `OUTPUT_STREAM_BEAT`. Both are opt-in
+bindings — the default bank binds them to subtle non-speech cues.
+Pairs with F24 (continuous playback): together they give the user a
+temporal frame for long-running output.
+
+---
+
+## F38 — Self-voicing help topics
+
+**Gap.** `:help` prints the cheat sheet. A brand-new user — blind,
+with no sighted context — needs a spoken tour that explains the mode
+model, the key keystrokes, and how to discover things like `Ctrl+,`
+for settings. Today the only path is "read the USER_MANUAL in a
+screen reader".
+
+**Where it surfaces.** First-run onboarding (F20 shipped) reads a
+short welcome but doesn't cover navigation, settings, audio tuning,
+or search. A user who wants to learn more has to leave the terminal
+to do so.
+
+**Sketch.** Extend `:help` to accept a topic: `:help navigation`,
+`:help audio`, `:help settings`, `:help cells`, `:help search`,
+`:help topics` (lists the rest). Each topic narrates a 10-20 second
+tour via the `system` voice — short enough to absorb, long enough to
+be useful. Topics live as plain strings in a new
+`asat/help_topics.py` module so they're easy to edit and translate.
+`:help` with no argument keeps the current print-the-cheat-sheet
+behaviour for users who already know the layout.
 
 ---
 


### PR DESCRIPTION
Docs-only outcome of a full-repo audit. Three concerns, one commit.

## Summary

**1. Close the doc-regression from F21b.** `docs/EVENTS.md` was missing `SETTINGS_SEARCH_OPENED` / `UPDATED` / `CLOSED`, even though those events ship in the default bank. This PR adds them to the Settings-editor table with their exact payload keys (pulled from the code and verified against `tests/test_default_bank.py`), plus a short note on the `committed=True/False` contract and that zero-match queries still publish.

**2. Normalise F6 status.** `FEATURE_REQUESTS.md` said "Windows live playback shipped" while `HANDOFF.md` had it under fully-shipped. Now both say the same thing: Windows done, POSIX open. A new "Partially shipped" section in HANDOFF avoids the ambiguity for future entries.

**3. Scope eight accessibility-oriented feature requests (F30–F38)** from a gap-analysis pass thinking like an a11y engineer building a CLI for a blind user:

- **F30** audio history / repeat last narration
- **F31** verbosity presets (`minimal` / `normal` / `verbose`)
- **F32** audio ducking under active narration
- **F34** completion alert when focus has moved (the shell-bell replacement)
- **F35** cell bookmarks
- **F36** auto-read stderr tail on failure — highest-ROI of the group
- **F37** long-output pacing (silence threshold + progress beats)
- **F38** self-voicing help topics

Each entry follows the existing `Gap` / `Where it surfaces` / `Sketch` template. HANDOFF's "alternatives to F21c" hint now points at F36 as the easiest next feature PR.

**Also added:** a "Maintenance backlog" section in HANDOFF capturing seven small code-simplification PRs surfaced during the audit — null-guard consolidation in `input_router.py`/`output_cursor.py`, splitting the 84-line `_action_handler` dict, table-driven meta-command and field parsers, a `ComposerMode` enum for composer magic strings, doc-link comments at state-machine transitions, and a subtle `_search_position = -1` wrap edge case. These are parked deliberately — each is its own small PR so it stays reviewable.

## Test plan
- [x] `python -m unittest discover -s tests -t .` — **682 passing** (unchanged; docs-only PR)
- [x] No code or test files modified (verify with `git diff --stat main`)
- [x] EVENTS.md payload keys cross-checked against `tests/test_default_bank.py` `SAMPLE_PAYLOADS`
- [x] HANDOFF.md and FEATURE_REQUESTS.md F6 wording now consistent
- [x] All new F30–F38 entries follow the repo's existing section template