### PR TITLE
F21c: settings `:reset` / Ctrl+R reset-to-defaults

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -31,8 +31,9 @@ F9 README · F11 auto-advance after submit · F13 in-line buffer editing
 · F14 action-menu keystroke · F15 cell delete/move/duplicate · F16
 output search + jump-to-line · F17 richer meta-commands · F18 OS
 clipboard · F19 prompt context on re-entry · F20 first-run onboarding
-· F21a settings undo/redo · F21b settings `/` search overlay · F36
-auto-read stderr tail on failure.
+· F21a settings undo/redo · F21b settings `/` search overlay · F21c
+settings `:reset` / Ctrl+R reset-to-defaults · F36 auto-read stderr
+tail on failure.
 
 ## Partially shipped
 · **F6** Windows live audio shipped; POSIX still open.
@@ -41,7 +42,7 @@ auto-read stderr tail on failure.
 F1/F10 cancel + non-blocking exec · F2 settings create/delete · F3
 bank reload · F4 command history · F5 SAPI TTS · F6 POSIX live audio
 · F7 OSC 133 · F8 measured-HRTF user surface · F12 shell mode +
-session CWD · F21c settings `:reset` · F22 diagnostic log
+session CWD · F22 diagnostic log
 (`--log path.jsonl`) · F23 tab completion · F24 continuous output
 playback · **F25** remappable keybindings · **F26** cell clipboard
 (cut/copy/paste cells) · **F27** heading/text cells + outline
@@ -63,7 +64,7 @@ help topics.
   clocks, no real audio.
 - One feature per PR on branch `claude/accessible-audio-terminal-cOh64`.
 - Test command: `python -m unittest discover -s tests -t .` —
-  currently **696 passing**.
+  currently **760 passing**.
 
 ## Entry points for the next session
 - **Roadmap (authoritative):** `docs/FEATURE_REQUESTS.md`
@@ -73,20 +74,24 @@ help topics.
 - **CLI:** `python -m asat [--live | --wav-dir DIR] [--session PATH] [--quiet]`
 
 ## Suggested next PR
-**F21c** — `:reset` for `SettingsEditor`. Reload the built-in
-defaults for the currently focused record, the whole section, or
-the whole bank, with a confirm step (either an InputRouter confirm
-sub-mode or an action-menu "Reset to defaults → {scope}" row).
-Integrate cleanly with the undo stack so a reset is itself undoable.
-Narrate scope + record count in the confirmation prompt. Controller
-API + InputRouter key (Ctrl+R?) + tests + docs, then PR.
+**F22** — `--log path.jsonl` diagnostic file. A single
+`JsonlEventLogger` subscriber that writes every `Event` it sees to
+a newline-delimited JSON file (one event per line), wired up through
+a new `--log PATH` CLI flag. The file rotates on every session so a
+long-running ASAT does not grow an unbounded log. Tests: fixture
+that pipes a scripted sequence of events through the logger and
+asserts the file round-trips. Doc: a short "Replaying a log" entry
+in the user manual plus a payload reference in EVENTS.md. Unlocks
+remote debugging of audio issues — the user can attach a log to an
+issue and a maintainer can replay it locally into a test harness.
 
-Alternative one-shot PRs if F21c feels heavy: **F22** `--log
-path.jsonl` diagnostic file (a single `JsonlEventLogger` subscriber,
-CLI flag, tests); **F4** command history (ring buffer + Up/Down in
-INPUT mode); **F23** Tab completion of executables + paths; **F34**
-completion alert when focus has moved (quiet sentinel cue so the user
-learns a run finished while they were elsewhere in the notebook).
+Alternative one-shot PRs if F22 feels heavy: **F4** command history
+(ring buffer + Up/Down in INPUT mode); **F23** Tab completion of
+executables + paths; **F34** completion alert when focus has moved
+(quiet sentinel cue so the user learns a run finished while they
+were elsewhere in the notebook); **F3** bank reload (a
+`:reload-bank` meta-command plus a file-mtime watcher so hand-edits
+to the saved JSON reload live without quitting).
 
 ## Maintenance backlog (non-feature cleanups)
 Each of these is a small standalone PR. Pick one off the top of the

--- a/asat/app.py
+++ b/asat/app.py
@@ -148,6 +148,7 @@ class Application:
             bus,
             resolved_bank,
             save_path=bank_path,
+            defaults_bank=default_sound_bank(),
         )
         if clipboard_factory is None:
             clipboard: Clipboard = MemoryClipboard()

--- a/asat/default_bank.py
+++ b/asat/default_bank.py
@@ -81,6 +81,8 @@ COVERED_EVENT_TYPES: frozenset[EventType] = frozenset({
     EventType.SETTINGS_SEARCH_OPENED,
     EventType.SETTINGS_SEARCH_UPDATED,
     EventType.SETTINGS_SEARCH_CLOSED,
+    EventType.SETTINGS_RESET_OPENED,
+    EventType.SETTINGS_RESET_CLOSED,
     EventType.HELP_REQUESTED,
     EventType.PROMPT_REFRESH,
     EventType.FIRST_RUN_DETECTED,
@@ -540,6 +542,50 @@ def _default_bindings() -> tuple[EventBinding, ...]:
             sound_id="soft_tick",
             say_template="search closed",
             priority=150,
+        ),
+
+        # F21c reset overlay — confirmation prompt narrates the scope
+        # and how many records would change, so the user can back out
+        # before they lose any in-progress tweaks. Closing narrates
+        # three distinct outcomes (applied, already-at-defaults, or
+        # cancelled) so the audible feedback matches what actually
+        # happened.
+        EventBinding(
+            id="settings_reset_opened",
+            event_type=EventType.SETTINGS_RESET_OPENED.value,
+            voice_id="alert",
+            sound_id="settings_chime",
+            say_template=(
+                "reset {scope}? press enter to confirm, escape to cancel"
+            ),
+            priority=230,
+        ),
+        EventBinding(
+            id="settings_reset_applied",
+            event_type=EventType.SETTINGS_RESET_CLOSED.value,
+            voice_id="system",
+            sound_id="settings_save",
+            say_template="reset {scope} to defaults",
+            predicate="outcome == applied",
+            priority=220,
+        ),
+        EventBinding(
+            id="settings_reset_already_default",
+            event_type=EventType.SETTINGS_RESET_CLOSED.value,
+            voice_id="system",
+            sound_id="soft_tick",
+            say_template="{scope} already at defaults",
+            predicate="outcome == already_default",
+            priority=215,
+        ),
+        EventBinding(
+            id="settings_reset_cancelled",
+            event_type=EventType.SETTINGS_RESET_CLOSED.value,
+            voice_id="system",
+            sound_id="soft_tick",
+            say_template="reset cancelled",
+            predicate="outcome == cancelled",
+            priority=210,
         ),
 
         # Help: speak a short summary so :help is useful without a

--- a/asat/events.py
+++ b/asat/events.py
@@ -125,6 +125,8 @@ class EventType(str, Enum):
     SETTINGS_SEARCH_OPENED = "settings.search.opened"
     SETTINGS_SEARCH_UPDATED = "settings.search.updated"
     SETTINGS_SEARCH_CLOSED = "settings.search.closed"
+    SETTINGS_RESET_OPENED = "settings.reset.opened"
+    SETTINGS_RESET_CLOSED = "settings.reset.closed"
 
     ANSI_CURSOR_MOVED = "ansi.cursor.moved"
     ANSI_SGR_CHANGED = "ansi.sgr.changed"

--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -38,7 +38,7 @@ from asat.keys import Key, Modifier
 from asat.notebook import FocusMode, NotebookCursor
 from asat.output_cursor import OutputCursor
 from asat.settings_controller import SettingsController
-from asat.settings_editor import SettingsEditorError
+from asat.settings_editor import ResetScope, SettingsEditorError
 
 
 BindingMap = dict[FocusMode, dict[Key, str]]
@@ -109,6 +109,8 @@ def default_bindings() -> BindingMap:
         narrow matches live, Enter commits, Escape restores the
         pre-search cursor), `n` / `N` cycle through matches,
         Ctrl+S saves the bank, Ctrl+Q closes the editor,
+        Ctrl+R opens a reset-to-defaults confirmation for the
+        cursor's current scope (Enter confirms, Escape cancels),
         Escape ascends or (at the top level) closes.
     """
     menu_open = Key.combo(".", Modifier.CTRL)
@@ -176,6 +178,7 @@ def default_bindings() -> BindingMap:
             Key.combo("q", Modifier.CTRL): "settings_close",
             Key.combo("z", Modifier.CTRL): "settings_undo",
             Key.combo("y", Modifier.CTRL): "settings_redo",
+            Key.combo("r", Modifier.CTRL): "settings_reset_begin",
         },
     }
 
@@ -193,6 +196,7 @@ META_COMMANDS: tuple[str, ...] = (
     "duplicate",
     "pwd",
     "commands",
+    "reset",
 )
 
 # "Ambient" meta-commands do their job without taking focus away from
@@ -225,8 +229,9 @@ HELP_LINES: tuple[str, ...] = (
     "           / search (type query, Enter commits), n / N next / prev hit, g jump-to-line.",
     "SETTINGS:  Up/Down walk, Right/Enter descend, Left/Escape ascend, e edit, Ctrl+S save, Ctrl+Q close.",
     "           / search (cross-section; Enter commits, Escape restores), n / N cycle matches.",
+    "           Ctrl+R resets to defaults at cursor scope (Enter confirms, Escape cancels).",
     "Menu:      F2 (or Ctrl+.) opens contextual actions; Up/Down walk, Enter invokes, Escape closes.",
-    "Meta:      :help, :settings, :save, :quit, :delete, :duplicate, :pwd, :commands.",
+    "Meta:      :help, :settings, :save, :quit, :delete, :duplicate, :pwd, :commands, :reset.",
     "           Meta-commands are case-insensitive and accept a trailing argument.",
     "Exit:      :quit, or EOF (Ctrl+D on POSIX, Ctrl+Z Enter on Windows).",
     "Docs:      docs/USER_MANUAL.md for the full keystroke reference.",
@@ -290,6 +295,8 @@ class InputRouter:
             return self._dispatch_settings_edit_key(key)
         if mode == FocusMode.SETTINGS and self._settings_active_searching():
             return self._dispatch_settings_search_key(key)
+        if mode == FocusMode.SETTINGS and self._settings_active_resetting():
+            return self._dispatch_settings_reset_key(key)
         if mode == FocusMode.OUTPUT and self._output_composing():
             return self._dispatch_output_composer_key(key)
         mode_map = self._bindings.get(mode, {})
@@ -434,6 +441,32 @@ class InputRouter:
             return "settings_search_extend"
         return None
 
+    def _settings_active_resetting(self) -> bool:
+        """Return True while the reset confirmation sub-mode is active."""
+        return (
+            self._settings_controller is not None
+            and self._settings_controller.is_open
+            and self._settings_controller.resetting
+        )
+
+    def _dispatch_settings_reset_key(self, key: Key) -> Optional[str]:
+        """Route keys while the user is being asked to confirm a reset.
+
+        Enter confirms and applies the reset; Escape cancels and
+        leaves the bank untouched. Every other key is swallowed so
+        stray input can neither silently confirm nor dismiss the
+        prompt — a user has to acknowledge the confirmation
+        deliberately.
+        """
+        assert self._settings_controller is not None
+        if key == kc.ENTER:
+            self._invoke("settings_reset_confirm", key)
+            return "settings_reset_confirm"
+        if key == kc.ESCAPE:
+            self._invoke("settings_reset_cancel", key)
+            return "settings_reset_cancel"
+        return None
+
     def _invoke(self, action: str, key: Key) -> None:
         """Run a named action and publish ACTION_INVOKED for it.
 
@@ -507,6 +540,41 @@ class InputRouter:
             self._publish_pwd()
         elif command == "commands":
             self._publish_commands()
+        elif command == "reset":
+            self._handle_meta_reset(argument)
+
+    def _handle_meta_reset(self, argument: str) -> None:
+        """Open settings mode and begin a reset confirmation.
+
+        `:reset bank` / `:reset all` start a bank-level confirmation.
+        Any other argument (or none) surfaces a HELP_REQUESTED hint
+        instead of silently picking a scope — from INPUT mode there
+        is no cursor-level context, so asking the user to be explicit
+        avoids the "oops, I reset the wrong thing" failure mode. For
+        finer-grained scopes, the user is directed to press Ctrl+R
+        inside SETTINGS mode.
+        """
+        scope = _parse_reset_scope(argument)
+        if scope is not ResetScope.BANK:
+            publish_event(
+                self._bus,
+                EventType.HELP_REQUESTED,
+                {
+                    "lines": [
+                        "`:reset` from INPUT mode only supports `:reset bank` "
+                        "(also `:reset all`) for a whole-bank reset.",
+                        "For finer-grained resets, press Ctrl+, to open "
+                        "settings then Ctrl+R at the record, field, or "
+                        "section you want to restore.",
+                    ],
+                },
+                source=self.SOURCE,
+            )
+            return
+        if self._settings_controller is None:
+            return
+        self._open_settings()
+        self._settings_controller.begin_reset(ResetScope.BANK)
 
     def _publish_pwd(self) -> None:
         """Announce the current working directory via HELP_REQUESTED."""
@@ -664,6 +732,44 @@ class InputRouter:
         if self._settings_controller is not None:
             self._settings_controller.backspace_search()
 
+    def _settings_reset_begin(
+        self, scope: Optional[ResetScope] = None
+    ) -> Optional[dict[str, object]]:
+        """Open the reset confirmation; report the scope the editor chose.
+
+        When `scope` is None (Ctrl+R with no argument, or `:reset`
+        with no scope), the controller picks the cursor-level default
+        — FIELD at FIELD, RECORD at RECORD, SECTION at SECTION. For
+        explicit scope arguments (`:reset record`, `:reset bank`, …)
+        the caller passes the parsed enum value through.
+        """
+        if self._settings_controller is None:
+            return None
+        started = self._settings_controller.begin_reset(scope)
+        payload: dict[str, object] = {"opened": started}
+        active_scope = self._settings_controller.reset_scope
+        if active_scope is not None:
+            payload["scope"] = active_scope.value
+        elif scope is not None:
+            payload["scope"] = scope.value
+        return payload
+
+    def _settings_reset_confirm(self) -> Optional[dict[str, object]]:
+        """Confirm the pending reset; report whether the bank changed."""
+        if self._settings_controller is None:
+            return None
+        scope = self._settings_controller.reset_scope
+        applied = self._settings_controller.confirm_reset()
+        payload: dict[str, object] = {"applied": applied}
+        if scope is not None:
+            payload["scope"] = scope.value
+        return payload
+
+    def _settings_reset_cancel(self) -> None:
+        """Cancel the pending reset; leave the bank untouched."""
+        if self._settings_controller is not None:
+            self._settings_controller.cancel_reset()
+
     def _settings_search_next(self) -> Optional[dict[str, object]]:
         """Cycle to the next match; no-op without prior results."""
         if self._settings_controller is None:
@@ -804,6 +910,9 @@ class InputRouter:
             "settings_search_extend": lambda: None,
             "settings_search_next": self._settings_search_next,
             "settings_search_prev": self._settings_search_prev,
+            "settings_reset_begin": self._settings_reset_begin,
+            "settings_reset_confirm": self._settings_reset_confirm,
+            "settings_reset_cancel": _void(self._settings_reset_cancel),
             "open_action_menu": self._open_action_menu,
             "menu_prev": _void(self._menu_prev),
             "menu_next": _void(self._menu_next),
@@ -960,3 +1069,23 @@ def _suggest_meta_command(name: str) -> Optional[str]:
         name.lower(), META_COMMANDS, n=1, cutoff=0.6
     )
     return matches[0] if matches else None
+
+
+def _parse_reset_scope(argument: str) -> Optional[ResetScope]:
+    """Map a `:reset <arg>` argument to a ResetScope, or None for "unknown".
+
+    `bank` and `all` both resolve to ResetScope.BANK; `section` /
+    `record` / `field` resolve to their matching enums. Empty or
+    unrecognised arguments return None so the caller can surface a
+    help hint rather than a silent wrong scope.
+    """
+    normalized = argument.strip().lower()
+    if normalized in ("bank", "all"):
+        return ResetScope.BANK
+    if normalized == "section":
+        return ResetScope.SECTION
+    if normalized == "record":
+        return ResetScope.RECORD
+    if normalized == "field":
+        return ResetScope.FIELD
+    return None

--- a/asat/settings_controller.py
+++ b/asat/settings_controller.py
@@ -18,7 +18,12 @@ from pathlib import Path
 from typing import Optional
 
 from asat.event_bus import EventBus
-from asat.settings_editor import Level, SettingsEditor, SettingsEditorError
+from asat.settings_editor import (
+    Level,
+    ResetScope,
+    SettingsEditor,
+    SettingsEditorError,
+)
 from asat.sound_bank import SoundBank
 
 
@@ -40,11 +45,18 @@ class SettingsController:
         bus: EventBus,
         bank: SoundBank,
         save_path: Optional[Path | str] = None,
+        defaults_bank: Optional[SoundBank] = None,
     ) -> None:
-        """Create a controller bound to a bus with an initial bank."""
+        """Create a controller bound to a bus with an initial bank.
+
+        `defaults_bank` is the factory-fresh bank that F21c reset
+        operations restore from. Pass `None` to disable the reset
+        sub-mode; `begin_reset` will then return False.
+        """
         self._bus = bus
         self._bank = bank
         self._save_path = Path(save_path) if save_path is not None else None
+        self._defaults_bank = defaults_bank
         self._editor: Optional[SettingsEditor] = None
         self._editing = False
         self._edit_buffer = ""
@@ -86,7 +98,9 @@ class SettingsController:
         if self._editor is not None:
             # Already open; leave state alone so we don't lose in-flight edits.
             return self._editor
-        self._editor = SettingsEditor(self._bus, self._bank)
+        self._editor = SettingsEditor(
+            self._bus, self._bank, defaults_bank=self._defaults_bank
+        )
         self._editing = False
         self._edit_buffer = ""
         return self._editor
@@ -118,12 +132,16 @@ class SettingsController:
 
         While editing, ascend cancels the in-progress edit instead.
         While searching, ascend cancels the in-progress search.
+        While resetting, ascend cancels the reset confirmation.
         """
         if self._editing:
             self.cancel_edit()
             return True
         if self.searching:
             self.cancel_search()
+            return True
+        if self.resetting:
+            self.cancel_reset()
             return True
         if self.editor.state.level == Level.SECTION:
             return False
@@ -134,6 +152,10 @@ class SettingsController:
         """Start composing a new value for the focused field."""
         if self.editor.state.level != Level.FIELD:
             raise SettingsControllerError("can only edit at the FIELD level")
+        if self.resetting:
+            raise SettingsControllerError(
+                "cannot begin edit while a reset confirmation is open"
+            )
         self._editing = True
         self._edit_buffer = ""
 
@@ -180,19 +202,30 @@ class SettingsController:
         Returns False when the session is closed, the user is
         composing a replacement value (the edit sub-mode owns the
         buffer; undo at that point would be surprising), the user is
-        composing a `/` search query (same rationale), or when there
-        is nothing on the undo stack. Otherwise delegates to
-        `SettingsEditor.undo()` which restores the prior bank,
-        refocuses the cursor on the field it mutated, and publishes
-        SETTINGS_VALUE_EDITED so narration reacts.
+        composing a `/` search query (same rationale), the user is
+        confirming a reset, or when there is nothing on the undo
+        stack. Otherwise delegates to `SettingsEditor.undo()` which
+        restores the prior bank, refocuses the cursor on the field it
+        mutated, and publishes SETTINGS_VALUE_EDITED so narration
+        reacts.
         """
-        if self._editor is None or self._editing or self.searching:
+        if (
+            self._editor is None
+            or self._editing
+            or self.searching
+            or self.resetting
+        ):
             return False
         return self._editor.undo()
 
     def redo(self) -> bool:
         """Re-apply the most recently undone edit. Mirror of `undo()`."""
-        if self._editor is None or self._editing or self.searching:
+        if (
+            self._editor is None
+            or self._editing
+            or self.searching
+            or self.resetting
+        ):
             return False
         return self._editor.redo()
 
@@ -209,12 +242,15 @@ class SettingsController:
     def begin_search(self) -> bool:
         """Open the `/` search overlay. Cancels any in-progress edit first.
 
-        Returns False when no session is open or the bank has no
-        records to search across. Opening a second search over an
-        active one is a no-op (the buffer is preserved so an
-        accidental retap can't wipe the query).
+        Returns False when no session is open, the user is inside a
+        reset confirmation, or the bank has no records to search
+        across. Opening a second search over an active one is a no-op
+        (the buffer is preserved so an accidental retap can't wipe
+        the query).
         """
         if self._editor is None:
+            return False
+        if self.resetting:
             return False
         if self._editing:
             self.cancel_edit()
@@ -245,6 +281,52 @@ class SettingsController:
         if self._editor is None or not self.searching:
             return False
         return self._editor.cancel_search()
+
+    @property
+    def resetting(self) -> bool:
+        """Return True while a reset confirmation sub-mode is active."""
+        return self._editor is not None and self._editor.resetting
+
+    @property
+    def reset_scope(self) -> Optional[ResetScope]:
+        """Return the scope of the in-progress reset confirmation, if any."""
+        return self._editor.reset_scope if self._editor is not None else None
+
+    def default_reset_scope(self) -> ResetScope:
+        """Scope `:reset` / Ctrl+R picks when the user doesn't name one."""
+        return self.editor.default_reset_scope()
+
+    def begin_reset(self, scope: Optional[ResetScope] = None) -> bool:
+        """Open the reset confirmation for `scope` (default: cursor-level).
+
+        Cancels any in-progress edit first — the user tapping Ctrl+R
+        while mid-edit clearly wants to drop the half-typed value.
+        Refuses while a search composer is active so the two overlays
+        don't race. Returns False when no session is open, the reset
+        cannot be applied (no defaults bank, or unsupported scope for
+        the current cursor, or the focused record has no default).
+        """
+        if self._editor is None:
+            return False
+        if self.searching:
+            return False
+        if self._editing:
+            self.cancel_edit()
+        if scope is None:
+            scope = self.default_reset_scope()
+        return self._editor.begin_reset(scope)
+
+    def confirm_reset(self) -> bool:
+        """Apply the pending reset and close the confirmation sub-mode."""
+        if self._editor is None or not self.resetting:
+            return False
+        return self._editor.confirm_reset()
+
+    def cancel_reset(self) -> bool:
+        """Leave the reset confirmation without mutating the bank."""
+        if self._editor is None or not self.resetting:
+            return False
+        return self._editor.cancel_reset()
 
     def save(self, path: Optional[Path | str] = None) -> Path:
         """Persist the bank. Uses the configured save_path if none is given."""

--- a/asat/settings_editor.py
+++ b/asat/settings_editor.py
@@ -58,7 +58,16 @@ MAX_HISTORY = 64
 
 @dataclass(frozen=True)
 class _EditRecord:
-    """One undoable mutation, enough to both replay and reverse."""
+    """One undoable mutation, enough to both replay and reverse.
+
+    `scope` marks the grain of the mutation: a single `"field"` edit
+    (the default, produced by `edit()`), or a wider `"record"` /
+    `"section"` / `"bank"` reset produced by `confirm_reset()`. The
+    scope decides where `_apply_history_cursor` parks the cursor when
+    the step is replayed, and whether the cursor re-fires
+    `SETTINGS_VALUE_EDITED` (field-scope only — broader resets don't
+    map to a single field-shaped payload).
+    """
 
     section: "Section"
     record_index: int
@@ -67,6 +76,7 @@ class _EditRecord:
     new_value: Any
     bank_before: "SoundBank"
     bank_after: "SoundBank"
+    scope: str = "field"
 
 
 class SettingsEditorError(ValueError):
@@ -87,6 +97,21 @@ class Level(str, Enum):
     SECTION = "section"
     RECORD = "record"
     FIELD = "field"
+
+
+class ResetScope(str, Enum):
+    """Grain of a reset-to-defaults operation.
+
+    FIELD resets just the focused field on the focused record; RECORD
+    replaces the whole focused record; SECTION swaps the entire
+    section tuple; BANK replaces voices, sounds, and bindings all at
+    once. Each scope is applied as a single atomic undoable step.
+    """
+
+    FIELD = "field"
+    RECORD = "record"
+    SECTION = "section"
+    BANK = "bank"
 
 
 # Ordered field lists per record type. Using tuples keeps the editor
@@ -131,11 +156,24 @@ class SettingsEditor:
     SoundEngine can narrate in real time.
     """
 
-    def __init__(self, bus: EventBus, bank: SoundBank) -> None:
-        """Open an editor session over the given bank."""
+    def __init__(
+        self,
+        bus: EventBus,
+        bank: SoundBank,
+        defaults_bank: Optional[SoundBank] = None,
+    ) -> None:
+        """Open an editor session over the given bank.
+
+        `defaults_bank` is the "factory fresh" bank that
+        `confirm_reset()` restores from. Callers that don't need reset
+        can pass `None`; `begin_reset` will then refuse. Tests can
+        inject a bespoke defaults bank to verify scope logic without
+        loading the stock one.
+        """
         self._bus = bus
         self._bank = bank
         self._saved_bank = bank
+        self._defaults_bank = defaults_bank
         self._state = EditorState()
         self._undo_stack: list[_EditRecord] = []
         self._redo_stack: list[_EditRecord] = []
@@ -151,6 +189,13 @@ class SettingsEditor:
         self._search_origin: Optional[
             tuple[Level, Section, int, int]
         ] = None
+        # F21c reset confirm sub-mode. Set while the user is being
+        # asked "reset to defaults? press Enter to confirm". The scope
+        # chosen at `begin_reset` time is remembered so confirm_reset
+        # can apply the right-size mutation. No origin is stored — a
+        # cancel leaves the cursor where it was when the user asked.
+        self._reset_mode: bool = False
+        self._reset_scope: Optional[ResetScope] = None
         publish_event(
             bus,
             EventType.SETTINGS_OPENED,
@@ -301,18 +346,19 @@ class SettingsEditor:
         self._redo_stack.append(record)
         self._apply_history_cursor(record)
         self._state = replace(self._state, dirty=self._compute_dirty())
-        publish_event(
-            self._bus,
-            EventType.SETTINGS_VALUE_EDITED,
-            {
-                "section": record.section.value,
-                "record_index": record.record_index,
-                "field": record.field,
-                "old_value": _jsonable(record.new_value),
-                "new_value": _jsonable(record.old_value),
-            },
-            source=SOURCE,
-        )
+        if record.scope == "field":
+            publish_event(
+                self._bus,
+                EventType.SETTINGS_VALUE_EDITED,
+                {
+                    "section": record.section.value,
+                    "record_index": record.record_index,
+                    "field": record.field,
+                    "old_value": _jsonable(record.new_value),
+                    "new_value": _jsonable(record.old_value),
+                },
+                source=SOURCE,
+            )
         self._publish_focus()
         return True
 
@@ -328,18 +374,19 @@ class SettingsEditor:
         self._undo_stack.append(record)
         self._apply_history_cursor(record)
         self._state = replace(self._state, dirty=self._compute_dirty())
-        publish_event(
-            self._bus,
-            EventType.SETTINGS_VALUE_EDITED,
-            {
-                "section": record.section.value,
-                "record_index": record.record_index,
-                "field": record.field,
-                "old_value": _jsonable(record.old_value),
-                "new_value": _jsonable(record.new_value),
-            },
-            source=SOURCE,
-        )
+        if record.scope == "field":
+            publish_event(
+                self._bus,
+                EventType.SETTINGS_VALUE_EDITED,
+                {
+                    "section": record.section.value,
+                    "record_index": record.record_index,
+                    "field": record.field,
+                    "old_value": _jsonable(record.old_value),
+                    "new_value": _jsonable(record.new_value),
+                },
+                source=SOURCE,
+            )
         self._publish_focus()
         return True
 
@@ -353,11 +400,42 @@ class SettingsEditor:
             del self._undo_stack[0]
 
     def _apply_history_cursor(self, record: _EditRecord) -> None:
-        """Park the cursor on the field the history step mutated.
+        """Park the cursor on the slice the history step mutated.
 
         Undo/redo implicitly "takes the user there" so the narration
         and any visible focus cue reflect the change they just heard.
+        For field-scope edits the cursor lands on the exact field;
+        for wider reset scopes it lands at the coarsest level that
+        still makes sense so the narrated record_id / section frames
+        the change.
         """
+        if record.scope == "bank":
+            self._state = replace(
+                self._state,
+                level=Level.SECTION,
+                section=record.section,
+                record_index=0,
+                field_index=0,
+            )
+            return
+        if record.scope == "section":
+            self._state = replace(
+                self._state,
+                level=Level.SECTION,
+                section=record.section,
+                record_index=0,
+                field_index=0,
+            )
+            return
+        if record.scope == "record":
+            self._state = replace(
+                self._state,
+                level=Level.RECORD,
+                section=record.section,
+                record_index=record.record_index,
+                field_index=0,
+            )
+            return
         fields = self._fields_for(record.section)
         try:
             field_index = fields.index(record.field)
@@ -540,6 +618,244 @@ class SettingsEditor:
         section, record_index = self._search_matches[self._search_position]
         self._goto_record_match(section, record_index)
         return True
+
+    @property
+    def resetting(self) -> bool:
+        """True while the reset confirm sub-mode is active."""
+        return self._reset_mode
+
+    @property
+    def reset_scope(self) -> Optional[ResetScope]:
+        """Return the scope `begin_reset` captured, or None outside sub-mode."""
+        return self._reset_scope
+
+    def default_reset_scope(self) -> ResetScope:
+        """Scope `:reset` / Ctrl+R picks when the user doesn't name one.
+
+        Matches the cursor's current level: FIELD at FIELD, RECORD at
+        RECORD, SECTION at SECTION. Whole-bank reset is always
+        explicit (`:reset all` / `:reset bank`).
+        """
+        if self._state.level == Level.FIELD:
+            return ResetScope.FIELD
+        if self._state.level == Level.RECORD:
+            return ResetScope.RECORD
+        return ResetScope.SECTION
+
+    def begin_reset(self, scope: ResetScope) -> bool:
+        """Enter the reset confirm sub-mode at the given scope.
+
+        Returns False when no defaults bank is available (the editor
+        was constructed without one), when the requested scope cannot
+        be applied from the current cursor (e.g. FIELD scope at RECORD
+        level), or when the focused record has no matching default
+        (user-added record with a novel id). Already-open sub-mode is
+        a no-op and returns True so an accidental retap does nothing.
+
+        Publishes `SETTINGS_RESET_OPENED` describing what would change
+        so the default bank can narrate the confirmation prompt.
+        """
+        if self._defaults_bank is None:
+            return False
+        if self._reset_mode:
+            return True
+        if not self._is_scope_applicable(scope):
+            return False
+        self._reset_mode = True
+        self._reset_scope = scope
+        publish_event(
+            self._bus,
+            EventType.SETTINGS_RESET_OPENED,
+            self._reset_opened_payload(scope),
+            source=SOURCE,
+        )
+        return True
+
+    def confirm_reset(self) -> bool:
+        """Apply the pending reset, push one history entry, close sub-mode.
+
+        `changed` in the closing payload is False when the current
+        state already matched defaults — no history entry is pushed
+        in that case, but the sub-mode still closes so the user hears
+        "already at defaults". Returns False if not in the sub-mode.
+        """
+        if not self._reset_mode or self._reset_scope is None:
+            return False
+        scope = self._reset_scope
+        bank_before = self._bank
+        bank_after = self._compute_reset_bank(scope)
+        try:
+            bank_after.validate()
+        except SoundBankError as exc:  # pragma: no cover - defaults are valid
+            raise SettingsEditorError(str(exc)) from exc
+        changed = bank_after is not bank_before
+        if changed:
+            self._bank = bank_after
+            self._push_undo(
+                _EditRecord(
+                    section=self._state.section,
+                    record_index=self._state.record_index,
+                    field=self._current_field_name() if self._state.level == Level.FIELD else "",
+                    old_value=None,
+                    new_value=None,
+                    bank_before=bank_before,
+                    bank_after=bank_after,
+                    scope=scope.value,
+                )
+            )
+            self._redo_stack.clear()
+            self._state = replace(self._state, dirty=self._compute_dirty())
+            self._publish_focus()
+        self._reset_mode = False
+        self._reset_scope = None
+        publish_event(
+            self._bus,
+            EventType.SETTINGS_RESET_CLOSED,
+            {
+                "scope": scope.value,
+                "committed": True,
+                "changed": changed,
+                "outcome": "applied" if changed else "already_default",
+            },
+            source=SOURCE,
+        )
+        return True
+
+    def cancel_reset(self) -> bool:
+        """Leave the reset sub-mode without mutating the bank."""
+        if not self._reset_mode or self._reset_scope is None:
+            return False
+        scope = self._reset_scope
+        self._reset_mode = False
+        self._reset_scope = None
+        publish_event(
+            self._bus,
+            EventType.SETTINGS_RESET_CLOSED,
+            {
+                "scope": scope.value,
+                "committed": False,
+                "changed": False,
+                "outcome": "cancelled",
+            },
+            source=SOURCE,
+        )
+        return True
+
+    def _is_scope_applicable(self, scope: ResetScope) -> bool:
+        """True when the current cursor position permits the requested scope."""
+        if scope == ResetScope.BANK:
+            return True
+        if scope == ResetScope.SECTION:
+            return True
+        if scope == ResetScope.RECORD:
+            if self._state.level == Level.SECTION:
+                return False
+            return self._current_record_has_default()
+        # FIELD
+        if self._state.level != Level.FIELD:
+            return False
+        return self._current_record_has_default()
+
+    def _current_record_has_default(self) -> bool:
+        """True when the focused record's id exists in the defaults bank."""
+        if self._defaults_bank is None:
+            return False
+        if self._record_count() == 0:
+            return False
+        record = self._records()[self._state.record_index]
+        record_id = getattr(record, "id", None)
+        if record_id is None:
+            return False
+        return any(
+            getattr(default_record, "id", None) == record_id
+            for default_record in getattr(self._defaults_bank, self._state.section.value)
+        )
+
+    def _reset_opened_payload(self, scope: ResetScope) -> dict[str, Any]:
+        """Shape the SETTINGS_RESET_OPENED payload for the given scope."""
+        payload: dict[str, Any] = {
+            "scope": scope.value,
+            "section": self._state.section.value,
+            "target_count": self._reset_target_count(scope),
+        }
+        if scope in (ResetScope.FIELD, ResetScope.RECORD):
+            record = self._records()[self._state.record_index]
+            payload["record_id"] = getattr(record, "id", "")
+            if scope == ResetScope.FIELD:
+                payload["field"] = self._current_field_name()
+        return payload
+
+    def _reset_target_count(self, scope: ResetScope) -> int:
+        """Number of records a reset at `scope` would touch."""
+        if scope == ResetScope.BANK:
+            assert self._defaults_bank is not None
+            return sum(
+                len(getattr(self._defaults_bank, section.value))
+                for section in SECTION_ORDER
+            )
+        if scope == ResetScope.SECTION:
+            assert self._defaults_bank is not None
+            return len(getattr(self._defaults_bank, self._state.section.value))
+        return 1
+
+    def _compute_reset_bank(self, scope: ResetScope) -> SoundBank:
+        """Build the post-reset bank for the given scope.
+
+        Returns `self._bank` unchanged when the targeted slice already
+        matches defaults — the caller treats identity equality as "no
+        change" to skip the history entry and narrate accordingly.
+        """
+        assert self._defaults_bank is not None
+        if scope == ResetScope.BANK:
+            if self._bank == self._defaults_bank:
+                return self._bank
+            return self._defaults_bank
+        if scope == ResetScope.SECTION:
+            section = self._state.section
+            default_records = getattr(self._defaults_bank, section.value)
+            current_records = getattr(self._bank, section.value)
+            if current_records == default_records:
+                return self._bank
+            return self._swap_section(section, list(default_records))
+        # FIELD / RECORD share the default-record lookup
+        record = self._records()[self._state.record_index]
+        record_id = getattr(record, "id", "")
+        default_record = self._find_default_record(record_id)
+        assert default_record is not None
+        if scope == ResetScope.RECORD:
+            if record == default_record:
+                return self._bank
+            new_records = list(self._records())
+            new_records[self._state.record_index] = default_record
+            return self._swap_section(self._state.section, new_records)
+        # FIELD
+        field_name = self._current_field_name()
+        default_value = getattr(default_record, field_name)
+        if getattr(record, field_name) == default_value:
+            return self._bank
+        new_record = replace(record, **{field_name: default_value})
+        new_records = list(self._records())
+        new_records[self._state.record_index] = new_record
+        return self._swap_section(self._state.section, new_records)
+
+    def _find_default_record(self, record_id: str) -> Optional[Any]:
+        """Return the defaults record with matching id, or None."""
+        if self._defaults_bank is None or not record_id:
+            return None
+        for record in getattr(self._defaults_bank, self._state.section.value):
+            if getattr(record, "id", None) == record_id:
+                return record
+        return None
+
+    def _swap_section(
+        self, section: Section, new_records: list[Any]
+    ) -> SoundBank:
+        """Return a new bank with `section` replaced by `new_records`."""
+        if section == Section.VOICES:
+            return self._bank.with_replaced(voices=new_records)
+        if section == Section.SOUNDS:
+            return self._bank.with_replaced(sounds=new_records)
+        return self._bank.with_replaced(bindings=new_records)
 
     def _is_bank_empty(self) -> bool:
         """True when every section is empty — nothing to search across."""

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -215,6 +215,8 @@ Producer: `asat.settings_editor.SettingsEditor`
 | `SETTINGS_SEARCH_OPENED`   | `origin_level`, `origin_section`, `origin_record_index`, `origin_field_index` |
 | `SETTINGS_SEARCH_UPDATED`  | `query`, `match_count`, (optional, when matched) `section`, `record_index`, `record_id` |
 | `SETTINGS_SEARCH_CLOSED`   | `query`, `match_count`, `committed`                                 |
+| `SETTINGS_RESET_OPENED`    | `scope` (`field`/`record`/`section`/`bank`), `section`, `target_count`, (when scope ∈ {`field`, `record`}) `record_id`, (when scope=`field`) `field` |
+| `SETTINGS_RESET_CLOSED`    | `scope`, `committed`, `changed`, `outcome` (`applied`/`already_default`/`cancelled`) |
 
 The `SETTINGS_SEARCH_*` family fires from the `/` search overlay
 described in [USER_MANUAL.md § Searching the bank](USER_MANUAL.md#searching-the-bank).
@@ -222,6 +224,19 @@ described in [USER_MANUAL.md § Searching the bank](USER_MANUAL.md#searching-the
 zero-match queries (so narration can announce "0 matches").
 `SETTINGS_SEARCH_CLOSED` carries `committed=True` on Enter and
 `committed=False` on Escape / ascend cancel.
+
+The `SETTINGS_RESET_*` family fires from the Ctrl+R / `:reset`
+confirmation sub-mode described in
+[USER_MANUAL.md § Resetting to defaults](USER_MANUAL.md#resetting-to-defaults).
+`target_count` on `SETTINGS_RESET_OPENED` is the number of records
+the confirmation would touch (1 for field/record scope, the section
+length for section scope, and the total record count across every
+section for bank scope). `SETTINGS_RESET_CLOSED`'s `outcome` key
+discriminates the three end states so each can fire its own
+single-clause predicate binding: `applied` when the reset mutated
+the bank, `already_default` when the targeted slice already matched
+defaults (no history entry is pushed), and `cancelled` when the
+user escaped out of the confirmation.
 
 ## Help surface
 

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -501,8 +501,8 @@ re-onboarding scenarios.
 
 ## F21 — Settings: undo, search, and reset
 
-**Status.** In progress. Undo/redo and `/` search shipped; `:reset`
-still pending.
+**Status.** Shipped. Undo/redo, `/` search, and `:reset` / Ctrl+R
+reset-to-defaults are all live.
 
 **Gap.** The settings editor has no undo, no search, and no "reset
 this field / record / whole bank to defaults". A user who mistypes
@@ -558,8 +558,43 @@ exposes `begin_search` / `extend_search` / `backspace_search` /
 `redo()` all refuse while the search sub-mode is active.
 `InputRouter` binds `/` to open, `n` / `N` to cycle, and routes
 every key through a dedicated dispatch while searching so motion
-keys do not leak into the editor. Reset is the remaining F21
-sub-feature.
+keys do not leak into the editor.
+
+**Sketch (shipped — `:reset` / Ctrl+R reset-to-defaults).** The
+editor now takes an optional `defaults_bank` on construction and
+exposes a reset confirmation sub-mode at four scopes: `field`,
+`record`, `section`, `bank`. `begin_reset(scope)` publishes
+`SETTINGS_RESET_OPENED` (with `scope`, `section`, `target_count`,
+and — for field/record scope — `record_id` / `field`) so the
+default bank narrates "reset foo? press enter to confirm, escape
+to cancel". `confirm_reset()` swaps the targeted slice with its
+default, pushes one polymorphic `_EditRecord` (scope-aware) onto
+the undo stack so Ctrl+Z puts the edits back in one step, and
+publishes `SETTINGS_RESET_CLOSED` with an `outcome` of `applied`
+or (when the slice already matched defaults) `already_default`.
+`cancel_reset()` publishes `outcome="cancelled"`. `_apply_history_cursor`
+parks the cursor at the coarsest level that still frames the
+change on undo/redo of a wider-scope reset, and `undo`/`redo` only
+re-publish `SETTINGS_VALUE_EDITED` for field-scope records so
+broader resets don't pretend to be a field edit. `SettingsController`
+threads `defaults_bank` through on `open()`, exposes `begin_reset`
+/ `confirm_reset` / `cancel_reset` / `resetting` / `reset_scope`,
+defaults the scope to the cursor's current level when called with
+`None`, refuses while searching, cancels any mid-edit first, and
+extends `ascend()` / `undo()` / `redo()` / `begin_edit()` /
+`begin_search()` to refuse during the reset sub-mode.
+`InputRouter` binds **Ctrl+R** to `settings_reset_begin` inside
+SETTINGS mode; while the confirmation is active Enter confirms,
+Escape cancels, and every other key is swallowed. From INPUT
+mode, `:reset bank` (alias `:reset all`) opens SETTINGS and walks
+straight into a bank-level confirmation; any other argument
+(`:reset section`, a bare `:reset`, …) surfaces a HELP_REQUESTED
+hint that directs the user to Ctrl+R inside SETTINGS so the
+cursor gives the reset a specific target. The default bank binds
+`SETTINGS_RESET_OPENED` (alert voice + settings chime) and three
+single-clause predicate branches on `SETTINGS_RESET_CLOSED`
+(`outcome == applied`, `outcome == already_default`, `outcome ==
+cancelled`) so the user hears the right feedback every time.
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -402,6 +402,32 @@ edit. After committing, `n` and `N` cycle forward and backward
 through the remaining matches (wrapping at the ends). A zero-match
 query still narrates the count so you know the overlay heard you.
 
+### Resetting to defaults
+
+If a field, record, or whole section has drifted from the stock
+bank and you want to start over, press **Ctrl+R** to open the
+reset confirmation. The scope follows your cursor:
+
+* At **field** level, only the focused field is restored.
+* At **record** level, the whole record goes back to its default.
+* At **section** level, every record in the section is replaced.
+
+Press **Enter** to confirm the reset or **Escape** to cancel — no
+other key is accepted while the confirmation is open, so a stray
+motion key can't accidentally wipe a record. Every reset is a
+single undoable step, so Ctrl+Z afterwards puts your edits back.
+
+From **INPUT** mode you can also type `:reset bank` (or the alias
+`:reset all`) to reset the entire bank at once; this opens the
+settings editor and walks straight into the confirmation. Finer-
+grained scopes (`:reset section`, `:reset record`, `:reset field`)
+are deliberately not accepted from INPUT — use Ctrl+R inside the
+editor where the cursor gives the reset a specific target.
+
+If the targeted slice is already at defaults, the confirmation
+still opens but pressing Enter narrates "already at defaults" and
+leaves the bank untouched (nothing to undo).
+
 ### What the fields mean
 
 For a full reference of every field and how the audio pipeline
@@ -456,6 +482,7 @@ Every key you need, one table.
 | INPUT      | `:duplicate`⏎     | Duplicate focused cell                |
 | INPUT      | `:pwd`⏎           | Announce working directory            |
 | INPUT      | `:commands`⏎      | List every meta-command               |
+| INPUT      | `:reset bank`⏎    | Reset the whole bank to defaults      |
 | OUTPUT     | Up / Down         | Prev / next line                      |
 | OUTPUT     | PageUp / PageDown | Jump a page                           |
 | OUTPUT     | Home / End        | First / last line                     |
@@ -474,6 +501,7 @@ Every key you need, one table.
 | SETTINGS   | `/`               | Search (live), Enter commits, Escape restores |
 | SETTINGS   | `n` / `N`         | Next / previous search match          |
 | SETTINGS   | Ctrl+Z / Ctrl+Y   | Undo / redo field edit                |
+| SETTINGS   | Ctrl+R            | Reset to defaults at cursor scope (Enter confirms, Escape cancels) |
 | SETTINGS   | Ctrl+S            | Save bank                             |
 | SETTINGS   | Ctrl+Q            | Close editor                          |
 

--- a/tests/test_default_bank.py
+++ b/tests/test_default_bank.py
@@ -118,6 +118,17 @@ SAMPLE_PAYLOADS: dict[EventType, dict[str, object]] = {
         "match_count": 1,
         "committed": True,
     },
+    EventType.SETTINGS_RESET_OPENED: {
+        "scope": "section",
+        "section": "voices",
+        "target_count": 3,
+    },
+    EventType.SETTINGS_RESET_CLOSED: {
+        "scope": "section",
+        "committed": True,
+        "changed": True,
+        "outcome": "applied",
+    },
     EventType.HELP_REQUESTED: {"lines": ["help"]},
     EventType.PROMPT_REFRESH: {
         "last_exit_code": 1,
@@ -262,6 +273,42 @@ class DefaultBankSmokeTests(unittest.TestCase):
                 "command_completed_nonzero",
                 "command_failed_timeout",
                 "command_failed_generic",
+            ],
+        )
+
+    def test_settings_reset_outcome_branches_each_pick_a_binding(self) -> None:
+        """F21c: applied / already_default / cancelled each map to a
+        distinct binding so the user hears the right feedback."""
+        bus = EventBus()
+        sink = MemorySink()
+        engine = SoundEngine(bus, default_sound_bank(), sink, sample_rate=8000)
+        self.addCleanup(engine.close)
+
+        spoken_labels: list[str] = []
+        bus.subscribe(
+            EventType.AUDIO_SPOKEN,
+            lambda event: spoken_labels.append(event.payload["binding_id"]),
+        )
+
+        for outcome in ("applied", "already_default", "cancelled"):
+            publish_event(
+                bus,
+                EventType.SETTINGS_RESET_CLOSED,
+                {
+                    "scope": "section",
+                    "committed": outcome != "cancelled",
+                    "changed": outcome == "applied",
+                    "outcome": outcome,
+                },
+                source="test",
+            )
+
+        self.assertEqual(
+            spoken_labels,
+            [
+                "settings_reset_applied",
+                "settings_reset_already_default",
+                "settings_reset_cancelled",
             ],
         )
 

--- a/tests/test_input_router.py
+++ b/tests/test_input_router.py
@@ -1241,5 +1241,267 @@ class CellLifecycleBindingTests(unittest.TestCase):
         self.assertIn(":duplicate", joined)
 
 
+def _defaults_bank() -> SoundBank:
+    """Defaults bank paired with `_settings_bank` so reset has somewhere to go."""
+    return SoundBank(
+        voices=(Voice(id="v1", rate=1.0),),
+        sounds=(SoundRecipe(id="s1", kind="tone", params={"frequency": 440.0}),),
+        bindings=(
+            EventBinding(
+                id="b1",
+                event_type="cell.created",
+                voice_id="v1",
+                say_template="hello",
+            ),
+        ),
+    )
+
+
+def _build_with_reset(
+    commands: list[str],
+) -> tuple[EventBus, NotebookCursor, InputRouter, SettingsController]:
+    """Router + controller wired with a defaults bank so Ctrl+R can fire."""
+    bus = EventBus()
+    session = Session.new()
+    for command in commands:
+        session.add_cell(Cell.new(command))
+    cursor = NotebookCursor(session, bus)
+    # Use a mutated working bank so reset has a visible change to apply.
+    working = SoundBank(
+        voices=(Voice(id="v1", rate=9.0),),
+        sounds=(SoundRecipe(id="s1", kind="tone", params={"frequency": 100.0}),),
+        bindings=_defaults_bank().bindings,
+    )
+    controller = SettingsController(bus, working, defaults_bank=_defaults_bank())
+    router = InputRouter(cursor, bus, settings_controller=controller)
+    return bus, cursor, router, controller
+
+
+class SettingsResetBindingTests(unittest.TestCase):
+    """F21c: Ctrl+R and reset-confirm key handling inside SETTINGS mode."""
+
+    def test_ctrl_r_opens_reset_confirmation_at_cursor_scope(self) -> None:
+        _, _, router, controller = _build_with_reset(["echo"])
+        router.handle_key(Key.combo(",", Modifier.CTRL))
+        result = router.handle_key(Key.combo("r", Modifier.CTRL))
+        self.assertEqual(result, "settings_reset_begin")
+        self.assertTrue(controller.resetting)
+        # Cursor is at SECTION level → scope defaults to SECTION.
+        self.assertEqual(controller.reset_scope.value, "section")
+
+    def test_enter_confirms_the_pending_reset(self) -> None:
+        _, _, router, controller = _build_with_reset(["echo"])
+        router.handle_key(Key.combo(",", Modifier.CTRL))
+        router.handle_key(Key.combo("r", Modifier.CTRL))
+        result = router.handle_key(ENTER)
+        self.assertEqual(result, "settings_reset_confirm")
+        self.assertFalse(controller.resetting)
+        # Reset applied: voices[0].rate back to 1.0.
+        self.assertAlmostEqual(controller.bank.voices[0].rate, 1.0)
+
+    def test_escape_cancels_the_pending_reset(self) -> None:
+        _, _, router, controller = _build_with_reset(["echo"])
+        router.handle_key(Key.combo(",", Modifier.CTRL))
+        router.handle_key(Key.combo("r", Modifier.CTRL))
+        result = router.handle_key(ESCAPE)
+        self.assertEqual(result, "settings_reset_cancel")
+        self.assertFalse(controller.resetting)
+        # No change: the mutated bank survives.
+        self.assertAlmostEqual(controller.bank.voices[0].rate, 9.0)
+
+    def test_arrow_keys_swallowed_while_reset_is_pending(self) -> None:
+        """Stray arrow keys must not move the cursor while a confirmation
+        is open — acknowledging the reset has to be deliberate."""
+        _, _, router, controller = _build_with_reset(["echo"])
+        router.handle_key(Key.combo(",", Modifier.CTRL))
+        router.handle_key(Key.combo("r", Modifier.CTRL))
+        section_before = controller.editor.state.section
+        self.assertIsNone(router.handle_key(UP))
+        self.assertIsNone(router.handle_key(DOWN))
+        self.assertTrue(controller.resetting)
+        self.assertEqual(controller.editor.state.section, section_before)
+
+    def test_reset_begin_payload_reports_scope(self) -> None:
+        bus, _, router, _ = _build_with_reset(["echo"])
+        recorder = _Recorder(bus)
+        router.handle_key(Key.combo(",", Modifier.CTRL))
+        router.handle_key(Key.combo("r", Modifier.CTRL))
+        begins = [
+            e for e in recorder.types_of(EventType.ACTION_INVOKED)
+            if e.payload.get("action") == "settings_reset_begin"
+        ]
+        self.assertEqual(len(begins), 1)
+        self.assertEqual(begins[0].payload["scope"], "section")
+        self.assertTrue(begins[0].payload["opened"])
+
+    def test_reset_confirm_payload_reports_scope_and_applied(self) -> None:
+        bus, _, router, _ = _build_with_reset(["echo"])
+        recorder = _Recorder(bus)
+        router.handle_key(Key.combo(",", Modifier.CTRL))
+        router.handle_key(Key.combo("r", Modifier.CTRL))
+        router.handle_key(ENTER)
+        confirms = [
+            e for e in recorder.types_of(EventType.ACTION_INVOKED)
+            if e.payload.get("action") == "settings_reset_confirm"
+        ]
+        self.assertEqual(len(confirms), 1)
+        self.assertEqual(confirms[0].payload["scope"], "section")
+        self.assertTrue(confirms[0].payload["applied"])
+
+    def test_ctrl_r_without_controller_is_safe_noop(self) -> None:
+        """A router without a settings_controller must not crash on Ctrl+R."""
+        bus = EventBus()
+        session = Session.new()
+        session.add_cell(Cell.new("echo"))
+        cursor = NotebookCursor(session, bus)
+        cursor.enter_settings_mode()  # simulate SETTINGS focus
+        router = InputRouter(cursor, bus)
+        self.assertEqual(
+            router.handle_key(Key.combo("r", Modifier.CTRL)),
+            "settings_reset_begin",
+        )
+
+    def test_ctrl_r_while_searching_is_refused(self) -> None:
+        """While a `/` composer is open the `r` key flows into the query;
+        since `r` in Modifier.CTRL isn't a printable, the begin-reset
+        handler runs but the controller refuses because searching."""
+        _, _, router, controller = _build_with_reset(["echo"])
+        router.handle_key(Key.combo(",", Modifier.CTRL))
+        router.handle_key(Key.printable("/"))
+        self.assertTrue(controller.searching)
+        # The Ctrl+R binding isn't dispatched (we're in the search
+        # composer sub-mode), so controller.resetting stays False.
+        router.handle_key(Key.combo("r", Modifier.CTRL))
+        self.assertFalse(controller.resetting)
+
+    def test_ctrl_r_while_editing_cancels_edit_then_opens_reset(self) -> None:
+        _, _, router, controller = _build_with_reset(["echo"])
+        router.handle_key(Key.combo(",", Modifier.CTRL))
+        router.handle_key(ENTER)
+        router.handle_key(ENTER)  # FIELD
+        router.handle_key(Key.printable("e"))
+        router.handle_key(Key.printable("x"))
+        # Ctrl+R in edit sub-mode is swallowed (not printable), so
+        # the binding map doesn't see it — reset stays unopened.
+        self.assertIsNone(router.handle_key(Key.combo("r", Modifier.CTRL)))
+        self.assertTrue(controller.editing)
+        self.assertFalse(controller.resetting)
+
+    def test_help_mentions_ctrl_r_reset(self) -> None:
+        from asat.input_router import HELP_LINES
+        joined = "\n".join(HELP_LINES).lower()
+        self.assertIn("ctrl+r", joined)
+        self.assertIn("reset", joined)
+
+    def test_help_mentions_meta_reset(self) -> None:
+        from asat.input_router import HELP_LINES
+        joined = "\n".join(HELP_LINES)
+        self.assertIn(":reset", joined)
+
+
+class MetaResetCommandTests(unittest.TestCase):
+    """F21c: `:reset` meta-command from INPUT mode."""
+
+    def _submit_meta(
+        self, router: InputRouter, cursor: NotebookCursor, text: str
+    ) -> None:
+        """Type `text` in INPUT mode and submit."""
+        cursor.enter_input_mode()
+        cursor.reset_input_buffer()
+        for ch in text:
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+
+    def test_colon_reset_bank_opens_settings_and_begins_bank_reset(self) -> None:
+        _, cursor, router, controller = _build_with_reset([""])
+        self._submit_meta(router, cursor, ":reset bank")
+        self.assertEqual(cursor.focus.mode, FocusMode.SETTINGS)
+        self.assertTrue(controller.is_open)
+        self.assertTrue(controller.resetting)
+        self.assertEqual(controller.reset_scope.value, "bank")
+
+    def test_colon_reset_all_is_alias_for_bank(self) -> None:
+        _, cursor, router, controller = _build_with_reset([""])
+        self._submit_meta(router, cursor, ":reset all")
+        self.assertEqual(controller.reset_scope.value, "bank")
+
+    def test_colon_reset_without_argument_emits_help(self) -> None:
+        bus, cursor, router, controller = _build_with_reset([""])
+        recorder = _Recorder(bus)
+        self._submit_meta(router, cursor, ":reset")
+        self.assertFalse(controller.resetting)
+        # The cursor does not change modes for a help-only meta.
+        help_events = recorder.types_of(EventType.HELP_REQUESTED)
+        self.assertGreaterEqual(len(help_events), 1)
+        lines = help_events[-1].payload["lines"]
+        joined = "\n".join(lines).lower()
+        self.assertIn("ctrl+r", joined)
+
+    def test_colon_reset_section_is_refused_from_input(self) -> None:
+        """Finer-grained scopes require Ctrl+R inside SETTINGS — from
+        INPUT we deliberately refuse them so a user cannot reset the
+        wrong slice without cursor context."""
+        bus, cursor, router, controller = _build_with_reset([""])
+        recorder = _Recorder(bus)
+        self._submit_meta(router, cursor, ":reset section")
+        self.assertFalse(controller.resetting)
+        help_events = recorder.types_of(EventType.HELP_REQUESTED)
+        self.assertGreaterEqual(len(help_events), 1)
+
+    def test_colon_reset_is_case_insensitive(self) -> None:
+        _, cursor, router, controller = _build_with_reset([""])
+        self._submit_meta(router, cursor, ":RESET BANK")
+        self.assertTrue(controller.resetting)
+        self.assertEqual(controller.reset_scope.value, "bank")
+
+    def test_meta_reset_payload_carries_command_and_argument(self) -> None:
+        bus, cursor, router, _ = _build_with_reset([""])
+        recorder = _Recorder(bus)
+        self._submit_meta(router, cursor, ":reset bank")
+        submit = [
+            e for e in recorder.types_of(EventType.ACTION_INVOKED)
+            if e.payload.get("action") == "submit"
+        ]
+        self.assertGreaterEqual(len(submit), 1)
+        self.assertEqual(submit[-1].payload["meta_command"], "reset")
+        self.assertEqual(submit[-1].payload["meta_argument"], "bank")
+
+    def test_meta_reset_listed_in_meta_commands(self) -> None:
+        from asat.input_router import META_COMMANDS
+        self.assertIn("reset", META_COMMANDS)
+
+
+class ParseResetScopeTests(unittest.TestCase):
+    """F21c: the module-level `:reset <arg>` argument parser."""
+
+    def test_parse_reset_scope_recognises_bank_and_all(self) -> None:
+        from asat.input_router import _parse_reset_scope
+        from asat.settings_editor import ResetScope
+        self.assertEqual(_parse_reset_scope("bank"), ResetScope.BANK)
+        self.assertEqual(_parse_reset_scope("all"), ResetScope.BANK)
+
+    def test_parse_reset_scope_recognises_each_grain(self) -> None:
+        from asat.input_router import _parse_reset_scope
+        from asat.settings_editor import ResetScope
+        self.assertEqual(_parse_reset_scope("section"), ResetScope.SECTION)
+        self.assertEqual(_parse_reset_scope("record"), ResetScope.RECORD)
+        self.assertEqual(_parse_reset_scope("field"), ResetScope.FIELD)
+
+    def test_parse_reset_scope_empty_returns_none(self) -> None:
+        from asat.input_router import _parse_reset_scope
+        self.assertIsNone(_parse_reset_scope(""))
+        self.assertIsNone(_parse_reset_scope("   "))
+
+    def test_parse_reset_scope_is_case_insensitive(self) -> None:
+        from asat.input_router import _parse_reset_scope
+        from asat.settings_editor import ResetScope
+        self.assertEqual(_parse_reset_scope("BANK"), ResetScope.BANK)
+        self.assertEqual(_parse_reset_scope("Record"), ResetScope.RECORD)
+
+    def test_parse_reset_scope_unknown_returns_none(self) -> None:
+        from asat.input_router import _parse_reset_scope
+        self.assertIsNone(_parse_reset_scope("everything"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_settings_controller.py
+++ b/tests/test_settings_controller.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from asat.event_bus import EventBus
 from asat.events import EventType
 from asat.settings_controller import SettingsController, SettingsControllerError
-from asat.settings_editor import Level, SettingsEditorError
+from asat.settings_editor import Level, ResetScope, SettingsEditorError
 from asat.sound_bank import EventBinding, SoundBank, SoundRecipe, Voice
 
 
@@ -399,6 +399,187 @@ class SaveTests(unittest.TestCase):
         controller.open()
         with self.assertRaises(SettingsControllerError):
             controller.save()
+
+
+class ResetTests(unittest.TestCase):
+    """F21c: reset confirmation sub-mode wiring at the controller layer."""
+
+    def _defaults(self) -> SoundBank:
+        return SoundBank(
+            voices=(Voice(id="v1", rate=1.0), Voice(id="v2", rate=1.2)),
+            sounds=(SoundRecipe(id="s1", kind="tone", params={"frequency": 440.0}),),
+            bindings=(
+                EventBinding(
+                    id="b1",
+                    event_type="cell.created",
+                    voice_id="v1",
+                    say_template="hello",
+                ),
+            ),
+        )
+
+    def test_controller_without_defaults_refuses_begin_reset(self) -> None:
+        controller = SettingsController(EventBus(), _bank())
+        controller.open()
+        self.assertFalse(controller.begin_reset(ResetScope.BANK))
+        self.assertFalse(controller.resetting)
+
+    def test_begin_reset_defaults_to_cursor_level_scope(self) -> None:
+        controller = SettingsController(
+            EventBus(), _bank(), defaults_bank=self._defaults()
+        )
+        controller.open()
+        self.assertTrue(controller.begin_reset())  # scope=None → SECTION at top
+        self.assertEqual(controller.reset_scope, ResetScope.SECTION)
+
+    def test_begin_reset_without_open_session_returns_false(self) -> None:
+        controller = SettingsController(
+            EventBus(), _bank(), defaults_bank=self._defaults()
+        )
+        self.assertFalse(controller.begin_reset(ResetScope.BANK))
+
+    def test_begin_reset_while_searching_is_refused(self) -> None:
+        controller = SettingsController(
+            EventBus(), _bank(), defaults_bank=self._defaults()
+        )
+        controller.open()
+        controller.begin_search()
+        self.assertTrue(controller.searching)
+        self.assertFalse(controller.begin_reset(ResetScope.BANK))
+        self.assertFalse(controller.resetting)
+
+    def test_begin_reset_while_editing_cancels_edit(self) -> None:
+        controller = SettingsController(
+            EventBus(), _bank(), defaults_bank=self._defaults()
+        )
+        controller.open()
+        controller.descend()
+        controller.descend()
+        controller.next()  # engine field
+        controller.begin_edit()
+        controller.extend_edit("s")
+        self.assertTrue(controller.editing)
+        self.assertTrue(controller.begin_reset(ResetScope.FIELD))
+        self.assertFalse(controller.editing)
+        self.assertTrue(controller.resetting)
+
+    def test_confirm_reset_applies_change_and_closes(self) -> None:
+        controller = SettingsController(
+            EventBus(), _bank(), defaults_bank=self._defaults()
+        )
+        controller.open()
+        # Stage a difference at voices[0].engine so the reset has something to do.
+        controller.descend()
+        controller.descend()
+        controller.next()  # engine
+        controller.begin_edit()
+        for ch in "sapi":
+            controller.extend_edit(ch)
+        controller.commit_edit()
+        controller.ascend()  # RECORD
+        self.assertTrue(controller.begin_reset(ResetScope.RECORD))
+        self.assertTrue(controller.confirm_reset())
+        self.assertFalse(controller.resetting)
+        self.assertEqual(controller.bank.voices[0].engine, "")
+
+    def test_cancel_reset_leaves_bank_untouched(self) -> None:
+        controller = SettingsController(
+            EventBus(), _bank(), defaults_bank=self._defaults()
+        )
+        controller.open()
+        controller.descend()
+        controller.descend()
+        controller.next()
+        controller.begin_edit()
+        for ch in "sapi":
+            controller.extend_edit(ch)
+        controller.commit_edit()
+        controller.ascend()
+        self.assertTrue(controller.begin_reset(ResetScope.RECORD))
+        self.assertTrue(controller.cancel_reset())
+        self.assertFalse(controller.resetting)
+        self.assertEqual(controller.bank.voices[0].engine, "sapi")
+
+    def test_ascend_cancels_a_pending_reset_and_returns_true(self) -> None:
+        controller = SettingsController(
+            EventBus(), _bank(), defaults_bank=self._defaults()
+        )
+        controller.open()
+        controller.begin_reset(ResetScope.BANK)
+        self.assertTrue(controller.resetting)
+        still_open = controller.ascend()
+        self.assertTrue(still_open)
+        self.assertFalse(controller.resetting)
+
+    def test_undo_is_refused_while_reset_is_pending(self) -> None:
+        controller = SettingsController(
+            EventBus(), _bank(), defaults_bank=self._defaults()
+        )
+        controller.open()
+        # Stage an edit so undo would have something to revert otherwise.
+        controller.descend()
+        controller.descend()
+        controller.next()  # engine
+        controller.begin_edit()
+        for ch in "sapi":
+            controller.extend_edit(ch)
+        controller.commit_edit()
+        controller.ascend()
+        controller.ascend()
+        controller.begin_reset(ResetScope.SECTION)
+        self.assertFalse(controller.undo())
+        self.assertEqual(controller.bank.voices[0].engine, "sapi")
+
+    def test_begin_edit_refused_while_reset_is_pending(self) -> None:
+        controller = SettingsController(
+            EventBus(), _bank(), defaults_bank=self._defaults()
+        )
+        controller.open()
+        controller.descend()
+        controller.descend()
+        controller.next()
+        controller.begin_reset(ResetScope.FIELD)
+        with self.assertRaises(SettingsControllerError):
+            controller.begin_edit()
+
+    def test_begin_search_refused_while_reset_is_pending(self) -> None:
+        controller = SettingsController(
+            EventBus(), _bank(), defaults_bank=self._defaults()
+        )
+        controller.open()
+        controller.begin_reset(ResetScope.BANK)
+        self.assertFalse(controller.begin_search())
+        self.assertFalse(controller.searching)
+
+    def test_confirm_reset_without_pending_returns_false(self) -> None:
+        controller = SettingsController(
+            EventBus(), _bank(), defaults_bank=self._defaults()
+        )
+        controller.open()
+        self.assertFalse(controller.confirm_reset())
+
+    def test_cancel_reset_without_pending_returns_false(self) -> None:
+        controller = SettingsController(
+            EventBus(), _bank(), defaults_bank=self._defaults()
+        )
+        controller.open()
+        self.assertFalse(controller.cancel_reset())
+
+    def test_default_reset_scope_matches_editor_cursor(self) -> None:
+        controller = SettingsController(
+            EventBus(), _bank(), defaults_bank=self._defaults()
+        )
+        controller.open()
+        self.assertEqual(controller.default_reset_scope(), ResetScope.SECTION)
+        controller.descend()
+        self.assertEqual(controller.default_reset_scope(), ResetScope.RECORD)
+
+    def test_reset_scope_property_is_none_when_not_resetting(self) -> None:
+        controller = SettingsController(
+            EventBus(), _bank(), defaults_bank=self._defaults()
+        )
+        controller.open()
+        self.assertIsNone(controller.reset_scope)
 
 
 if __name__ == "__main__":

--- a/tests/test_settings_editor.py
+++ b/tests/test_settings_editor.py
@@ -12,6 +12,7 @@ from asat.events import Event, EventType
 from asat.settings_editor import (
     BINDING_FIELDS,
     Level,
+    ResetScope,
     SECTION_ORDER,
     SOUND_FIELDS,
     Section,
@@ -742,6 +743,297 @@ class DefaultBankIntegrationTests(unittest.TestCase):
             editor.save(path)
             reopened = SoundBank.load(path)
         self.assertEqual(reopened, default_sound_bank())
+
+
+class ResetToDefaultsTests(unittest.TestCase):
+    """F21c: reset-to-defaults sub-mode at field/record/section/bank scope."""
+
+    def _defaults(self) -> SoundBank:
+        """A stable defaults bank with predictable fields to reset from."""
+        return SoundBank(
+            voices=(Voice(id="v1", rate=1.0, pitch=1.0), Voice(id="v2", rate=1.1)),
+            sounds=(
+                SoundRecipe(id="s1", kind="tone", params={"frequency": 440.0}),
+                SoundRecipe(id="s2", kind="silence", params={"duration": 0.1}),
+            ),
+            bindings=(
+                EventBinding(
+                    id="b1",
+                    event_type="cell.created",
+                    voice_id="v1",
+                    say_template="hello",
+                ),
+            ),
+        )
+
+    def _field_editor(self, section: Section, record_index: int, field_name: str) -> SettingsEditor:
+        """Editor parked at FIELD level on the given (section, record, field)."""
+        editor = SettingsEditor(EventBus(), _bank(), defaults_bank=self._defaults())
+        for _ in range(SECTION_ORDER.index(section)):
+            editor.next()
+        editor.enter()
+        for _ in range(record_index):
+            editor.next()
+        editor.enter()
+        fields = (
+            VOICE_FIELDS
+            if section == Section.VOICES
+            else SOUND_FIELDS
+            if section == Section.SOUNDS
+            else BINDING_FIELDS
+        )
+        for _ in range(fields.index(field_name)):
+            editor.next()
+        return editor
+
+    def test_begin_reset_without_defaults_returns_false(self) -> None:
+        editor = SettingsEditor(EventBus(), _bank())
+        self.assertFalse(editor.begin_reset(ResetScope.BANK))
+        self.assertFalse(editor.resetting)
+
+    def test_begin_reset_publishes_opened_with_scope_and_target_count(self) -> None:
+        bus = EventBus()
+        opened = _Recorder(bus, EventType.SETTINGS_RESET_OPENED)
+        editor = SettingsEditor(bus, _bank(), defaults_bank=self._defaults())
+        self.assertTrue(editor.begin_reset(ResetScope.SECTION))
+        self.assertEqual(len(opened.events), 1)
+        payload = opened.events[0].payload
+        self.assertEqual(payload["scope"], "section")
+        self.assertEqual(payload["section"], "voices")
+        self.assertEqual(payload["target_count"], 2)
+
+    def test_begin_reset_section_is_applicable_from_section_level(self) -> None:
+        editor = SettingsEditor(EventBus(), _bank(), defaults_bank=self._defaults())
+        self.assertTrue(editor.begin_reset(ResetScope.SECTION))
+
+    def test_begin_reset_field_from_section_level_refused(self) -> None:
+        editor = SettingsEditor(EventBus(), _bank(), defaults_bank=self._defaults())
+        self.assertFalse(editor.begin_reset(ResetScope.FIELD))
+
+    def test_begin_reset_record_from_section_level_refused(self) -> None:
+        editor = SettingsEditor(EventBus(), _bank(), defaults_bank=self._defaults())
+        self.assertFalse(editor.begin_reset(ResetScope.RECORD))
+
+    def test_begin_reset_record_without_default_match_refused(self) -> None:
+        # Defaults have only v1/v2; current bank adds v3 which has no peer.
+        working = SoundBank(
+            voices=(
+                Voice(id="v1", rate=1.0, pitch=1.0),
+                Voice(id="v2", rate=1.1),
+                Voice(id="v3", rate=2.0),
+            ),
+            sounds=self._defaults().sounds,
+            bindings=self._defaults().bindings,
+        )
+        editor = SettingsEditor(EventBus(), working, defaults_bank=self._defaults())
+        editor.enter()
+        editor.next()
+        editor.next()  # voices[2] = v3 — no default
+        self.assertFalse(editor.begin_reset(ResetScope.RECORD))
+
+    def test_begin_reset_while_already_open_is_noop(self) -> None:
+        editor = SettingsEditor(EventBus(), _bank(), defaults_bank=self._defaults())
+        self.assertTrue(editor.begin_reset(ResetScope.SECTION))
+        self.assertTrue(editor.begin_reset(ResetScope.BANK))  # retap
+        # First-captured scope wins.
+        self.assertEqual(editor.reset_scope, ResetScope.SECTION)
+
+    def test_confirm_reset_field_restores_default_value(self) -> None:
+        editor = self._field_editor(Section.VOICES, 0, "rate")
+        editor.edit("1.9")
+        self.assertAlmostEqual(editor.bank.voices[0].rate, 1.9)
+        self.assertTrue(editor.begin_reset(ResetScope.FIELD))
+        self.assertTrue(editor.confirm_reset())
+        self.assertAlmostEqual(editor.bank.voices[0].rate, 1.0)
+        self.assertFalse(editor.resetting)
+
+    def test_confirm_reset_record_restores_whole_record(self) -> None:
+        editor = self._field_editor(Section.VOICES, 0, "rate")
+        editor.edit("1.9")
+        editor.back()  # RECORD level for record-scope reset
+        self.assertTrue(editor.begin_reset(ResetScope.RECORD))
+        self.assertTrue(editor.confirm_reset())
+        self.assertEqual(editor.bank.voices[0], self._defaults().voices[0])
+
+    def test_confirm_reset_section_replaces_all_records_in_section(self) -> None:
+        editor = SettingsEditor(EventBus(), _bank(), defaults_bank=self._defaults())
+        editor.enter()
+        editor.enter()
+        editor.next()  # voices[0].engine
+        editor.edit("sapi")
+        editor.back()
+        editor.back()  # SECTION level
+        self.assertTrue(editor.begin_reset(ResetScope.SECTION))
+        self.assertTrue(editor.confirm_reset())
+        self.assertEqual(editor.bank.voices, self._defaults().voices)
+
+    def test_confirm_reset_bank_swaps_every_section(self) -> None:
+        # Mutate something in every section so the reset proves it did work.
+        working = SoundBank(
+            voices=(Voice(id="v1", rate=9.0),),
+            sounds=(SoundRecipe(id="s1", kind="tone", params={"frequency": 100.0}),),
+            bindings=(
+                EventBinding(
+                    id="b1",
+                    event_type="cell.created",
+                    voice_id="v1",
+                    say_template="custom",
+                ),
+            ),
+        )
+        editor = SettingsEditor(EventBus(), working, defaults_bank=self._defaults())
+        self.assertTrue(editor.begin_reset(ResetScope.BANK))
+        self.assertTrue(editor.confirm_reset())
+        self.assertEqual(editor.bank, self._defaults())
+
+    def test_confirm_reset_without_begin_returns_false(self) -> None:
+        editor = SettingsEditor(EventBus(), _bank(), defaults_bank=self._defaults())
+        self.assertFalse(editor.confirm_reset())
+
+    def test_cancel_reset_without_begin_returns_false(self) -> None:
+        editor = SettingsEditor(EventBus(), _bank(), defaults_bank=self._defaults())
+        self.assertFalse(editor.cancel_reset())
+
+    def test_cancel_reset_publishes_closed_with_cancelled_outcome(self) -> None:
+        bus = EventBus()
+        closed = _Recorder(bus, EventType.SETTINGS_RESET_CLOSED)
+        editor = SettingsEditor(bus, _bank(), defaults_bank=self._defaults())
+        editor.begin_reset(ResetScope.SECTION)
+        self.assertTrue(editor.cancel_reset())
+        self.assertEqual(len(closed.events), 1)
+        payload = closed.events[0].payload
+        self.assertEqual(payload["outcome"], "cancelled")
+        self.assertFalse(payload["changed"])
+
+    def test_confirm_reset_when_already_default_has_no_op_outcome(self) -> None:
+        bus = EventBus()
+        closed = _Recorder(bus, EventType.SETTINGS_RESET_CLOSED)
+        # Current bank identical to defaults → reset is a no-op.
+        editor = SettingsEditor(bus, self._defaults(), defaults_bank=self._defaults())
+        editor.begin_reset(ResetScope.BANK)
+        self.assertTrue(editor.confirm_reset())
+        self.assertEqual(closed.events[-1].payload["outcome"], "already_default")
+        self.assertFalse(closed.events[-1].payload["changed"])
+        self.assertFalse(editor.can_undo)
+
+    def test_confirm_reset_applied_outcome_and_history_entry(self) -> None:
+        bus = EventBus()
+        closed = _Recorder(bus, EventType.SETTINGS_RESET_CLOSED)
+        editor = SettingsEditor(bus, _bank(), defaults_bank=self._defaults())
+        editor.enter()
+        editor.enter()
+        editor.next()
+        editor.edit("sapi")
+        editor.back()
+        editor.back()
+        editor.begin_reset(ResetScope.SECTION)
+        self.assertTrue(editor.confirm_reset())
+        self.assertEqual(closed.events[-1].payload["outcome"], "applied")
+        self.assertTrue(closed.events[-1].payload["changed"])
+        self.assertTrue(editor.can_undo)
+
+    def test_undo_after_bank_reset_restores_prior_bank(self) -> None:
+        editor = self._field_editor(Section.VOICES, 0, "rate")
+        editor.edit("1.9")
+        editor.back()
+        editor.back()  # back to SECTION
+        editor.begin_reset(ResetScope.BANK)
+        editor.confirm_reset()
+        self.assertAlmostEqual(editor.bank.voices[0].rate, 1.0)
+        self.assertTrue(editor.undo())
+        self.assertAlmostEqual(editor.bank.voices[0].rate, 1.9)
+
+    def test_undo_after_section_reset_parks_cursor_at_section_level(self) -> None:
+        editor = self._field_editor(Section.VOICES, 0, "rate")
+        editor.edit("1.9")
+        editor.back()
+        editor.back()  # SECTION
+        editor.begin_reset(ResetScope.SECTION)
+        editor.confirm_reset()
+        # Navigate away then undo to check the cursor is re-parked.
+        editor.next()  # section → sounds
+        editor.undo()
+        self.assertEqual(editor.state.level, Level.SECTION)
+        self.assertEqual(editor.state.section, Section.VOICES)
+
+    def test_undo_after_record_reset_parks_cursor_at_record_level(self) -> None:
+        editor = self._field_editor(Section.VOICES, 0, "rate")
+        editor.edit("1.9")
+        editor.back()  # RECORD
+        editor.begin_reset(ResetScope.RECORD)
+        editor.confirm_reset()
+        editor.undo()
+        self.assertEqual(editor.state.level, Level.RECORD)
+        self.assertEqual(editor.state.section, Section.VOICES)
+        self.assertEqual(editor.state.record_index, 0)
+
+    def test_undo_after_field_reset_parks_cursor_on_the_field(self) -> None:
+        editor = self._field_editor(Section.VOICES, 0, "rate")
+        editor.edit("1.9")
+        editor.begin_reset(ResetScope.FIELD)
+        editor.confirm_reset()
+        editor.undo()
+        self.assertEqual(editor.state.level, Level.FIELD)
+        self.assertEqual(editor.current_field_name(), "rate")
+
+    def test_undo_of_non_field_reset_does_not_publish_value_edited(self) -> None:
+        bus = EventBus()
+        edited = _Recorder(bus, EventType.SETTINGS_VALUE_EDITED)
+        editor = SettingsEditor(bus, _bank(), defaults_bank=self._defaults())
+        editor.enter()
+        editor.enter()
+        editor.next()
+        editor.edit("sapi")
+        editor.back()
+        editor.back()
+        editor.begin_reset(ResetScope.SECTION)
+        editor.confirm_reset()
+        edited.events.clear()
+        editor.undo()
+        self.assertEqual(len(edited.events), 0)
+
+    def test_redo_after_undo_of_reset_reapplies_default_bank(self) -> None:
+        editor = self._field_editor(Section.VOICES, 0, "rate")
+        editor.edit("1.9")
+        editor.back()
+        editor.back()
+        editor.begin_reset(ResetScope.BANK)
+        editor.confirm_reset()
+        editor.undo()
+        self.assertAlmostEqual(editor.bank.voices[0].rate, 1.9)
+        self.assertTrue(editor.redo())
+        self.assertAlmostEqual(editor.bank.voices[0].rate, 1.0)
+
+    def test_default_reset_scope_follows_cursor_level(self) -> None:
+        editor = SettingsEditor(EventBus(), _bank(), defaults_bank=self._defaults())
+        self.assertEqual(editor.default_reset_scope(), ResetScope.SECTION)
+        editor.enter()
+        self.assertEqual(editor.default_reset_scope(), ResetScope.RECORD)
+        editor.enter()
+        self.assertEqual(editor.default_reset_scope(), ResetScope.FIELD)
+
+    def test_reset_opened_payload_for_field_includes_record_id_and_field(self) -> None:
+        bus = EventBus()
+        opened = _Recorder(bus, EventType.SETTINGS_RESET_OPENED)
+        editor = SettingsEditor(bus, _bank(), defaults_bank=self._defaults())
+        editor.enter()
+        editor.enter()
+        editor.next()  # engine
+        editor.begin_reset(ResetScope.FIELD)
+        payload = opened.events[-1].payload
+        self.assertEqual(payload["scope"], "field")
+        self.assertEqual(payload["record_id"], "v1")
+        self.assertEqual(payload["field"], "engine")
+        self.assertEqual(payload["target_count"], 1)
+
+    def test_reset_opened_payload_for_bank_includes_total_record_count(self) -> None:
+        bus = EventBus()
+        opened = _Recorder(bus, EventType.SETTINGS_RESET_OPENED)
+        editor = SettingsEditor(bus, _bank(), defaults_bank=self._defaults())
+        editor.begin_reset(ResetScope.BANK)
+        payload = opened.events[-1].payload
+        # 2 voices + 2 sounds + 1 binding = 5
+        self.assertEqual(payload["target_count"], 5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Ships F21c — the final sub-feature of F21 (Settings: undo, search, reset). The settings editor can now reload built-in defaults for the focused field, record, section, or the whole bank, behind a confirmation step that's part of the undo stack.
- **Ctrl+R** inside SETTINGS opens a reset confirmation at the cursor's current scope (field/record/section); Enter confirms, Escape cancels, every other key is swallowed so a stray motion can't accidentally wipe a record.
- **`:reset bank`** (alias `:reset all`) from INPUT mode walks straight into a whole-bank confirmation. Finer-grained scopes (`:reset section`, etc.) are deliberately refused from INPUT with a HELP_REQUESTED hint pointing the user to Ctrl+R, since INPUT has no cursor context.
- New events `SETTINGS_RESET_OPENED` and `SETTINGS_RESET_CLOSED` narrate the confirmation; the closing event carries an `outcome` field (`applied` / `already_default` / `cancelled`) so each state gets its own single-clause predicate binding.
- `_EditRecord` grew a polymorphic `scope` field so a reset is one undoable step regardless of grain. `_apply_history_cursor` parks the cursor at the coarsest level that still frames the change; undo/redo only re-publishes `SETTINGS_VALUE_EDITED` for field-scope records.
- Default bank adds four bindings (one for OPENED, three for CLOSED outcomes). Docs updated: `EVENTS.md`, `USER_MANUAL.md` gets a new "Resetting to defaults" subsection and cheat-sheet rows, `FEATURE_REQUESTS.md` marks F21 shipped, `HANDOFF.md` refreshed with next-PR suggestion (F22 diagnostic log).
- Test count: **696 → 760** (64 new).

## Test plan

- [x] `python -m unittest discover -s tests -t .` — 760 passing
- [x] `tests/test_settings_editor.py::ResetToDefaultsTests` — 22 tests covering scope applicability, confirm/cancel, undo/redo cursor parking, already-default no-op, opened payload shape
- [x] `tests/test_settings_controller.py::ResetTests` — defaults_bank threading, refuse-during-other-submodes, ascend-cancels-reset, scope-defaults-to-cursor-level
- [x] `tests/test_input_router.py::{SettingsResetBindingTests,MetaResetCommandTests,ParseResetScopeTests}` — Ctrl+R dispatch, Enter/Escape while resetting, arrow-keys swallowed, `:reset bank`/`all`/`section`/empty variants, case-insensitivity
- [x] `tests/test_default_bank.py` — new SAMPLE_PAYLOADS entries plus `test_settings_reset_outcome_branches_each_pick_a_binding` verifying all three predicates

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS