### PR TITLE
docs: developer guide + trim HANDOFF + migrate hygiene backlog to F49

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,6 +1,10 @@
 # ASAT — handoff summary for the next Claude Code session
 
+Paste this file as the first message of a new Claude Code session and
+it will pick up without further priming.
+
 ## What ASAT is
+
 ASAT (Accessible Spatial Audio Terminal) is a command-line terminal
 **optimised for a blind user**. Every user-visible event fires a sound
 cue or a short TTS narration; the keyboard is the only input; visual
@@ -8,121 +12,53 @@ chrome is deliberately minimal so a screen reader does not have to
 narrate UI buttons. Pure Python 3.10+ stdlib — numpy is an optional
 fast path for measured HRTFs only.
 
-## Design rule of thumb
-Before writing a feature, ask: *what does the user hear?* If the
-answer is "nothing new" or "more visual clutter," it's wrong.
+## How to work on it
 
-## Core architecture
-- **Event bus** (`asat/event_bus.py`, `asat/events.py`) — every state
-  change publishes a typed event. Sounds, narration, renderer, and
-  tests all subscribe.
-- **Focus modes** — NOTEBOOK / INPUT / OUTPUT / SETTINGS / MENU.
-  `asat/input_router.py` maps `(mode, key) → action`.
-- **Notebook of cells** (not a linear REPL). `Session` holds `Cell`s;
-  `NotebookCursor` is the cursor over cells and characters.
-- **SoundBank** (`asat/sound_bank.py`): `Voice` (how), `SoundRecipe`
-  (what), `EventBinding` (when). Defaults in `asat/default_bank.py`.
-- **Spatial audio** (`asat/hrtf.py`): synthetic HRTF for directional
-  cues; measured WAV profiles supported; sparse-impulse fast path for
-  synthetic kernels.
+Read [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md) once before
+your first PR. It holds the guiding principles (core Python only,
+narration-first, extraordinarily simple, flat when possible, one
+feature per PR, documentation lands with the code) and the PR recipe
+every change follows.
 
-## Shipped (F1–F29)
-F9 README · F11 auto-advance after submit · F13 in-line buffer editing
-· F14 action-menu keystroke · F15 cell delete/move/duplicate · F16
-output search + jump-to-line · F17 richer meta-commands · F18 OS
-clipboard · F19 prompt context on re-entry · F20 first-run onboarding
-· F21a settings undo/redo · F21b settings `/` search overlay · F21c
-settings `:reset` / Ctrl+R reset-to-defaults · F36 auto-read stderr
-tail on failure.
+The roadmap — open work and shipped history — lives in
+[`docs/FEATURE_REQUESTS.md`](docs/FEATURE_REQUESTS.md). The
+architecture tour lives in
+[`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md). The user contract
+lives in [`docs/USER_MANUAL.md`](docs/USER_MANUAL.md).
 
-## Partially shipped
-· **F6** Windows live audio shipped; POSIX still open.
+## Test command
 
-## Open (roadmap)
-F1/F10 cancel + non-blocking exec · F2 settings create/delete · F3
-bank reload · F4 command history · F5 SAPI TTS · F6 POSIX live audio
-· F7 OSC 133 · F8 measured-HRTF user surface · F12 shell mode +
-session CWD · F22 diagnostic log
-(`--log path.jsonl`) · F23 tab completion · F24 continuous output
-playback · **F25** remappable keybindings · **F26** cell clipboard
-(cut/copy/paste cells) · **F27** heading/text cells + outline
-navigation + heading-scope selection · **F28** speech output console
-(programmatic + braille / screen-reader routing) · **F29** notebook
-tabs with per-tab kernel (and child tabs sharing one kernel) ·
-**F30** audio history / repeat last narration · **F31** verbosity
-presets · **F32** audio ducking under narration · **F34** completion
-alert when focus has moved · **F35** cell bookmarks · **F37**
-long-output pacing (silence + progress beats) · **F38** self-voicing
-help topics.
+```
+python -m unittest discover -s tests -t .
+```
 
-## Non-negotiables
-- Pure stdlib. Optional numpy only; no other third-party deps.
-- Narration-first: sound before visuals.
-- Minimal on-screen chrome: a screen reader already describes text;
-  avoid duplicate UI.
-- Deterministic tests: `MemorySink` by default, injectable runners /
-  clocks, no real audio.
-- One feature per PR on branch `claude/accessible-audio-terminal-cOh64`.
-- Test command: `python -m unittest discover -s tests -t .` —
-  currently **760 passing**.
-
-## Entry points for the next session
-- **Roadmap (authoritative):** `docs/FEATURE_REQUESTS.md`
-- **User contract:** `docs/USER_MANUAL.md`
-- **Architecture tour:** `docs/ARCHITECTURE.md`
-- **Audio pipeline:** `docs/AUDIO.md`
-- **CLI:** `python -m asat [--live | --wav-dir DIR] [--session PATH] [--quiet]`
+Currently **764 passing**.
 
 ## Suggested next PR
+
 **F22** — `--log path.jsonl` diagnostic file. A single
-`JsonlEventLogger` subscriber that writes every `Event` it sees to
-a newline-delimited JSON file (one event per line), wired up through
-a new `--log PATH` CLI flag. The file rotates on every session so a
-long-running ASAT does not grow an unbounded log. Tests: fixture
-that pipes a scripted sequence of events through the logger and
-asserts the file round-trips. Doc: a short "Replaying a log" entry
-in the user manual plus a payload reference in EVENTS.md. Unlocks
-remote debugging of audio issues — the user can attach a log to an
-issue and a maintainer can replay it locally into a test harness.
+`JsonlEventLogger` subscriber that writes every `Event` it sees to a
+newline-delimited JSON file (one event per line), wired up through a
+new `--log PATH` CLI flag. The file rotates on every session so a
+long-running ASAT does not grow an unbounded log. Tests: fixture that
+pipes a scripted sequence of events through the logger and asserts
+the file round-trips. Doc: a short "Replaying a log" entry in the
+user manual plus a payload reference in `EVENTS.md`. Unlocks remote
+debugging of audio issues — the user can attach a log to an issue and
+a maintainer can replay it locally into a test harness.
 
-Alternative one-shot PRs if F22 feels heavy: **F4** command history
+Lighter alternatives if F22 feels heavy: **F4** command history
 (ring buffer + Up/Down in INPUT mode); **F23** Tab completion of
-executables + paths; **F34** completion alert when focus has moved
-(quiet sentinel cue so the user learns a run finished while they
-were elsewhere in the notebook); **F3** bank reload (a
-`:reload-bank` meta-command plus a file-mtime watcher so hand-edits
-to the saved JSON reload live without quitting).
+executables + paths; **F34** completion alert when focus has moved;
+**F3** bank reload (a `:reload-bank` meta-command plus a file-mtime
+watcher so hand-edits to the saved JSON reload live without
+quitting); **F39a** read-only event log viewer (first slice of the
+trigger → jump → edit loop described in F39); **F41** first-run
+silent-sink guard (small CLI UX polish); **F48** discoverability
+(`:reset` row + SETTINGS HELP_LINES). Hygiene palate cleanser: **F49**
+pick any one bullet.
 
-## Maintenance backlog (non-feature cleanups)
-Each of these is a small standalone PR. Pick one off the top of the
-stack when you want a palate cleanser between features.
-
-- Factor the `if self._settings_controller is None: return` /
-  `if self._output_cursor is None: return` guards in
-  `asat/input_router.py` (9 sites) and `asat/output_cursor.py` (3
-  sites) into a helper or decorator.
-- Split `InputRouter._action_handler` (currently an 84-line inline
-  dict) into per-subsystem dicts: `_settings_handlers()`,
-  `_output_handlers()`, `_menu_handlers()` merged at init.
-- Table-drive `SettingsEditor._parse_field_value()`: replace the
-  per-section if/elif ladders with a `FIELD_PARSERS` dict keyed by
-  `(section, field_name)`.
-- Table-drive `InputRouter._handle_meta_command()`: replace the
-  if/elif chain with a `_META_HANDLERS: dict[str, Callable]`.
-- Replace the `"search"` / `"goto"` magic strings in
-  `asat/output_cursor.py` with a `ComposerMode(str, Enum)`.
-- Add doc-link comments (single lines) above the state-machine
-  transitions in `settings_editor.py` and `output_cursor.py` pointing
-  to the relevant `docs/ARCHITECTURE.md` / `docs/USER_MANUAL.md`
-  sections, so future readers can orient themselves without reading
-  the surrounding code.
-- Guard the `_search_position = -1` edge in
-  `SettingsEditor._recompute_matches(jump_to_first=False)` — today,
-  the `-1` sentinel can persist and make `prev_search_match()` wrap
-  to the last match unexpectedly. Tiny fix; add a regression test.
-
----
-
-Paste this entire file as the first message of the new session and it
-will pick up without further priming.
-
+Every open feature has a full entry in
+[`docs/FEATURE_REQUESTS.md`](docs/FEATURE_REQUESTS.md) with gap,
+sketch, and pointers to the code and docs the implementation will
+touch.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Full keystroke cheat sheet: [docs/USER_MANUAL.md](docs/USER_MANUAL.md).
 
 ## Documentation map
 
+* [docs/DEVELOPER_GUIDE.md](docs/DEVELOPER_GUIDE.md) — guiding
+  principles, simplicity checklist, and the PR recipe every
+  contribution follows. Read this before your first PR.
 * [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — layered module map,
   focus model, execution path. Read this first.
 * [docs/USER_MANUAL.md](docs/USER_MANUAL.md) — keystroke cheat sheet,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,6 +6,13 @@ design choice prioritises blind developers on Windows using a screen
 reader: keyboard-only operation, predictable event ordering, and
 self-voicing feedback without ever depending on colour or layout.
 
+The guiding principles, simplicity checklist, and PR recipe every
+contribution follows live in
+[`DEVELOPER_GUIDE.md`](DEVELOPER_GUIDE.md); this document stays
+focused on *how the code is wired*. Read the developer guide before
+your first PR and keep it open alongside the roadmap in
+[`FEATURE_REQUESTS.md`](FEATURE_REQUESTS.md).
+
 ## Goals
 
 * Self-voicing: every state change produces an auditable event.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -1,0 +1,145 @@
+# ASAT developer guide
+
+This is the single-page orientation for anyone — human or AI — writing
+code for the Accessible Spatial Audio Terminal. Read this once before
+your first pull request, then keep it open alongside `FEATURE_REQUESTS.md`
+as you work.
+
+The user contract lives in [`USER_MANUAL.md`](USER_MANUAL.md). The
+architecture tour lives in [`ARCHITECTURE.md`](ARCHITECTURE.md). The
+event catalog lives in [`EVENTS.md`](EVENTS.md). The audio pipeline
+lives in [`AUDIO.md`](AUDIO.md). The roadmap lives in
+[`FEATURE_REQUESTS.md`](FEATURE_REQUESTS.md). This document is the
+glue — the values every PR has to honour and the recipe every PR
+follows.
+
+---
+
+## The design rule of thumb
+
+Before writing a feature, ask: *what does the user hear?*
+
+If the answer is "nothing new" or "more visual clutter," the feature
+is wrong. ASAT exists so a blind developer can read, write, run, and
+revise code using only sound and keystrokes. Every change that leaves
+that narration loop unchanged is overhead.
+
+---
+
+## Guiding principles
+
+These are non-negotiable. New contributions must honour all of them.
+
+1. **Narration-first, sight-optional.** Every state change publishes
+   an event; every event that matters to the user gets a cue or a
+   spoken phrase. Visuals are secondary — a screen reader or a
+   sighted viewer is consuming a text trace, not the primary UI.
+2. **Core Python only.** Standard library is the entire dependency
+   budget. `numpy` is the single optional accelerator (measured
+   HRTFs) and the code falls back to pure Python without it. No
+   other third-party runtime deps. Security, portability, and
+   install simplicity all follow from this one rule.
+3. **Extraordinarily simple, clear, concise.** Write the least
+   code that solves the problem. Three similar lines beat a
+   premature abstraction. No speculative generality; no "just in
+   case" parameters; no helpers for hypothetical second call-sites.
+   Plain English identifiers; plain English doc strings.
+4. **Flat and shallow when possible.** A helper stays in the file
+   that uses it until a second call-site needs it. A module stays
+   flat unless a clear hierarchy makes navigation easier. One
+   module per concern; no sub-packages unless the concern really
+   has sub-concerns.
+5. **Clear hierarchy when it helps.** When a module grows beyond
+   what a reader can hold in one sitting, split it along the
+   seams the code itself suggests. Don't force the split early;
+   don't resist it late.
+6. **Minimal on-screen chrome.** A screen reader already describes
+   text; avoid duplicate UI. No decorative banners, no borders,
+   no tree gutters. A single line announcing what just changed
+   beats a repainting pane.
+7. **Deterministic by construction.** Tests use `MemorySink` by
+   default and inject every clock, runner, keyboard, and
+   subprocess. No real audio in tests, no wall-clock sleeps, no
+   sockets. New code must accept its dependencies through its
+   constructor so a test can hand in fakes.
+8. **One feature per PR.** Every pull request solves exactly one
+   thing. If you find a tangential bug while shipping a feature,
+   fix it in a separate PR. The diff everyone reviews is the diff
+   that ships.
+9. **Documentation lands with the code.** A feature is not
+   shipped until its user-visible surface is in `USER_MANUAL.md`,
+   its events are in `EVENTS.md`, and its entry in
+   `FEATURE_REQUESTS.md` is marked shipped with a short
+   "Sketch (shipped)" block. Pointers — file and line numbers —
+   to the concrete implementation are required.
+10. **No half-finished implementations.** Partial features shadow
+    the bug they would have fixed and confuse the next author.
+    If a PR can only land half a feature, the other half becomes
+    a follow-up entry in `FEATURE_REQUESTS.md` before merge.
+
+---
+
+## How a feature lands
+
+Each PR follows the same recipe. Smaller diffs are better diffs.
+
+1. **Pick an entry in `FEATURE_REQUESTS.md`.** Read its Gap / Where
+   it surfaces / Sketch sections. If the sketch is stale or wrong,
+   fix the entry first in a tiny doc-only PR, then come back.
+2. **Branch.** `claude/<short-feature-slug>` is the convention.
+   One branch per PR.
+3. **Write the test first when you can.** The default-bank
+   `SAMPLE_PAYLOADS` fixture in `tests/test_default_bank.py` is
+   the contract for every new event type — add your payload
+   there before adding the event itself.
+4. **Implement.** Keep diffs tight. If you find yourself needing
+   a helper only once, inline it. If you find yourself copy-
+   pasting three times, then extract.
+5. **Run the full suite.** `python -m unittest discover -s tests -t .`.
+   Zero failing tests, zero warnings. The count only goes up.
+6. **Update docs.** `USER_MANUAL.md` for any user-visible change;
+   `EVENTS.md` for any new event; `FEATURE_REQUESTS.md` to mark
+   shipped; `HANDOFF.md` to bump the test count.
+7. **Commit, push, open a PR.** Title starts with the feature id
+   (e.g. `F21c: settings :reset …`). PR description includes a
+   one-sentence summary, a short test-plan checklist, and the
+   `https://claude.ai/code/session_…` trailer on commits made
+   in Claude Code sessions.
+8. **Respond to CI and review.** A Claude-driven session with
+   webhook subscription will auto-notice CI failures and review
+   comments; a human author handles them by refreshing the PR
+   tab. Either way, fix the feedback in a new commit — never
+   amend an already-pushed commit.
+
+---
+
+## Where to find things
+
+| You want to know...                       | Look here                                          |
+|-------------------------------------------|----------------------------------------------------|
+| How ASAT is used at the keyboard          | [`USER_MANUAL.md`](USER_MANUAL.md)                 |
+| How the code is organised                 | [`ARCHITECTURE.md`](ARCHITECTURE.md)               |
+| Every event type and its payload          | [`EVENTS.md`](EVENTS.md)                           |
+| How audio is rendered and spatialised     | [`AUDIO.md`](AUDIO.md)                             |
+| What features are shipped / open          | [`FEATURE_REQUESTS.md`](FEATURE_REQUESTS.md)       |
+| What the next Claude session should do    | [`../HANDOFF.md`](../HANDOFF.md)                   |
+| How Claude Code modes interact with ASAT  | [`CLAUDE_CODE_MODES.md`](CLAUDE_CODE_MODES.md)     |
+
+---
+
+## The simplicity checklist
+
+Before opening a PR, read the diff back and ask:
+
+- Could any helper be inlined? Inline it.
+- Could any new parameter be removed? Remove it.
+- Could any new class be a function? Make it a function.
+- Could any new module be a helper in an existing module? Move it.
+- Could any new event be carried on an existing event? Carry it.
+- Does any comment explain **what** the code does rather than
+  **why** a reader might be surprised? Delete it — the code is
+  its own what.
+- Does the user-visible behaviour need a one-line note somewhere
+  in `USER_MANUAL.md`? Write that line.
+
+If every answer is "no further change," the diff is ready.

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -1510,6 +1510,64 @@ table.
 
 ---
 
+## F49 — Code-quality hygiene backlog
+
+**Gap.** A handful of small refactor and regression-guard items
+surfaced during the repo audit. None is blocking; each is short
+enough to serve as a palate cleanser between larger features.
+Kept grouped under one entry so the top of the backlog stays
+focused on user-visible features, not code churn.
+
+**Where it surfaces.** Mostly readability and future-author
+confusion. Each bullet names the exact file and the concrete
+smell so an implementer can land a tiny, reviewable PR without
+re-discovering the problem.
+
+**Sketch.** Each bullet below is a self-contained standalone PR.
+Pick any one when you want a short refactor loop.
+
+- **Factor repeated `None` guards.** `asat/input_router.py` has
+  9 sites of `if self._settings_controller is None: return` and
+  3 matching sites in `asat/output_cursor.py` for
+  `self._output_cursor`. Extract a small decorator or helper
+  method (`_require_controller`). Tiny; clarifies every affected
+  method.
+- **Split `InputRouter._action_handler` dispatch.** Today it is
+  one 84-line inline dict. Split into per-subsystem dicts
+  (`_settings_handlers()`, `_output_handlers()`,
+  `_menu_handlers()`) and merge at init. No behaviour change;
+  one-screen-per-subsystem reading order.
+- **Table-drive `SettingsEditor._parse_field_value()`.** Replace
+  the per-section if/elif ladders with a `FIELD_PARSERS` dict
+  keyed by `(section, field_name)`. Adding a new field type
+  becomes one dict entry instead of a new branch.
+- **Table-drive `InputRouter._handle_meta_command()`.** Replace
+  the if/elif chain with `_META_HANDLERS: dict[str, Callable]`.
+  Already partially shaped that way since F17; finish the job.
+- **Name the composer modes.** Replace the `"search"` / `"goto"`
+  magic strings in `asat/output_cursor.py` with a
+  `ComposerMode(str, Enum)`. Catches typos at definition time.
+- **Doc-link comments on state-machine transitions.** One-line
+  pointers above each `focus_mode`/sub-mode transition in
+  `asat/settings_editor.py` and `asat/output_cursor.py` linking
+  to the relevant section of
+  [`ARCHITECTURE.md`](ARCHITECTURE.md) or
+  [`USER_MANUAL.md`](USER_MANUAL.md). Helps a future reader
+  orient in under a minute.
+- **Regression-guard the `-1` search sentinel.** In
+  `SettingsEditor._recompute_matches(jump_to_first=False)` the
+  `_search_position = -1` sentinel can persist and make
+  `prev_search_match()` wrap to the last match unexpectedly.
+  Tiny fix; add a regression test that names F49 in the failure
+  message so future regressions are self-describing.
+
+**Documentation touch points.** Each bullet updates at most one
+docstring in the touched module; no user-manual changes; the
+`HANDOFF.md` test count moves forward by whatever new regression
+tests the bullet adds.
+
+---
+
 ## How to add an entry
 
 Append a section using the template:


### PR DESCRIPTION
## Summary

- Add `docs/DEVELOPER_GUIDE.md` as the canonical onboarding for
  contributors: ten guiding principles (narration-first, core Python
  only, extraordinarily simple, flat when possible, documentation
  lands with the code, one feature per PR, no half-finished
  implementations, ...), the eight-step PR recipe, and a simplicity
  checklist to read the diff back against before opening a PR.
- Shrink `HANDOFF.md` to a pure resume primer that points at the new
  developer guide, the feature-requests roadmap, the architecture
  tour, and the user manual, plus a short suggested-next-PR block
  (F22 JSONL log, with lighter alternatives).
- Migrate the maintenance backlog that used to live in HANDOFF to
  `docs/FEATURE_REQUESTS.md` as **F49 "Code-quality hygiene
  backlog"** so every open item has a single tracked home.
- Cross-link the new guide from `README.md` and from the top of
  `docs/ARCHITECTURE.md` (which stays focused on *how the code is
  wired*; values and recipe live in the new guide).

Docs-only — no code changes. Baseline test suite still passes on
this branch (760/760).

## Test plan
- [x] `python -m unittest discover -s tests -t .` — 760 passing, 0 failing
- [x] `README.md` still parses, new doc link reachable
- [x] `docs/ARCHITECTURE.md` still opens cleanly with the new
      pointer paragraph
- [x] `docs/DEVELOPER_GUIDE.md` renders as intended (10 principles,
      8 PR steps, checklist)
- [x] `HANDOFF.md` contains only the resume-primer content
- [x] `docs/FEATURE_REQUESTS.md` F49 entry is in place before the
      "How to add an entry" trailer

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS