### PR TITLE
F38 + F44: self-voicing help topics + :welcome onboarding replay

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -32,7 +32,7 @@ lives in [`docs/USER_MANUAL.md`](docs/USER_MANUAL.md).
 python -m unittest discover -s tests -t .
 ```
 
-Currently **771 passing**.
+Currently **786 passing**.
 
 ## Suggested next PR
 

--- a/asat/app.py
+++ b/asat/app.py
@@ -278,6 +278,22 @@ class Application:
                 self.running = False
             elif meta == "save":
                 self._save_session()
+            elif meta == "welcome":
+                self._replay_welcome()
+
+    def _replay_welcome(self) -> None:
+        """Re-invoke the onboarding tour on `:welcome` (F44).
+
+        Re-publishes `FIRST_RUN_DETECTED` with `replay=True` through
+        the same coordinator that ran at launch, so every existing
+        subscriber (audio bank, renderer) reacts just as it did on
+        the first boot. Silently no-ops when onboarding was
+        disabled (`--quiet`, `--check`) so the meta-command stays a
+        harmless tab-completion hit in those modes.
+        """
+        if self.onboarding is None:
+            return
+        self.onboarding.run(force=True)
 
     def _save_session(self) -> None:
         """Persist the session to `session_path` if one was configured.

--- a/asat/help_topics.py
+++ b/asat/help_topics.py
@@ -1,0 +1,68 @@
+"""Self-voicing help topics (F38).
+
+`:help` with no argument narrates the full cheat sheet (HELP_LINES in
+`asat/input_router.py`). `:help <topic>` narrates a focused micro-tour
+instead — short enough to absorb in one sitting, long enough to cover
+one conceptual area. `:help topics` lists every topic name.
+
+Topics live here as plain tuples so editing or translating one is a
+one-file change. Each topic's first line is its heading — the renderer
+and the sound bank can style it separately from the body if they wish.
+
+The router treats topics as case-insensitive. Add a new topic by
+dropping it into `HELP_TOPICS`; `:help topics` will pick it up
+automatically, and the typo-suggestion path will include it for free.
+"""
+
+from __future__ import annotations
+
+
+HELP_TOPICS: dict[str, tuple[str, ...]] = {
+    "navigation": (
+        "Navigation topic.",
+        "NOTEBOOK mode is the home base. Up/Down walk between cells, Home/End jump to the ends of the session, Enter enters INPUT mode on the focused cell, Ctrl+N appends a fresh cell.",
+        "INPUT mode is where you type a command. Enter submits, Escape leaves without running. Left/Right walk the caret; Home/End jump to the line's start/end.",
+        "OUTPUT mode steps through a cell's captured output line-by-line. Ctrl+O enters it, Up/Down step, PageUp/PageDown page, Escape leaves.",
+        "Escape is always safe — from any mode it returns you one level up toward NOTEBOOK.",
+    ),
+    "cells": (
+        "Cells topic.",
+        "Each cell is one command plus the output it produced. New cells are appended with Ctrl+N; `d` in NOTEBOOK deletes the focused cell, `y` duplicates it.",
+        "Alt+Up and Alt+Down reorder the focused cell within the session.",
+        "From INPUT mode the meta-commands `:delete` and `:duplicate` do the same things for hands-that-prefer-typing.",
+    ),
+    "settings": (
+        "Settings topic.",
+        "Ctrl+, (or the `:settings` meta-command) opens the live settings editor. Up/Down walk, Right/Enter descend, Left/Escape ascend, `e` edits the focused field.",
+        "Ctrl+S saves the bank to the `--bank` path if one was given. Ctrl+Q closes without saving.",
+        "Ctrl+Z undoes your last settings edit, Ctrl+Y redoes it. Ctrl+R resets the cursor's current scope to the built-in defaults; Enter confirms, Escape cancels.",
+        "`/` opens a cross-section search; Enter commits, Escape restores, `n` and `N` cycle matches.",
+    ),
+    "audio": (
+        "Audio topic.",
+        "Every event fires a cue or a short narration. --live plays through the speaker on Windows; --wav-dir DIR captures each buffer as a numbered WAV on any platform.",
+        "Run `python -m asat --check` for a diagnostic summary. When no audio flag is given, ASAT narrates into an in-memory sink — you will not hear cues.",
+        "Open settings (Ctrl+,) to retune voices, speeds, and sound recipes live; the change takes effect on the next event without restarting.",
+    ),
+    "search": (
+        "Search topic.",
+        "In OUTPUT mode, press `/` to search the captured output of the focused cell. Type a query and press Enter to commit; `n` jumps to the next hit, `N` the previous. `g` jumps to a specific line number.",
+        "In SETTINGS mode, `/` searches across every section of the bank. Enter commits the jump; Escape restores the cursor to where it was before the search.",
+    ),
+    "meta": (
+        "Meta-commands topic.",
+        "Any INPUT line that starts with `:` is a meta-command. Names are case-insensitive; a single trailing argument is passed through to commands that use it.",
+        "Handy ones: `:help`, `:help topics`, `:settings`, `:save`, `:quit`, `:delete`, `:duplicate`, `:pwd`, `:commands`, `:reset bank`, `:welcome`.",
+        "`:commands` lists every meta-command. `:welcome` replays the first-run tour. `:help <topic>` narrates one of the topics you are listening to now.",
+    ),
+}
+
+
+def topic_names() -> tuple[str, ...]:
+    """Return topic names sorted so `:help topics` output is stable."""
+    return tuple(sorted(HELP_TOPICS))
+
+
+def lookup(topic: str) -> tuple[str, ...] | None:
+    """Return the lines for `topic` (case-insensitive), or None if unknown."""
+    return HELP_TOPICS.get(topic.lower())

--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -34,6 +34,7 @@ from asat import keys as kc
 from asat.actions import ActionContext, ActionMenu
 from asat.event_bus import EventBus, publish_event
 from asat.events import EventType
+from asat.help_topics import HELP_TOPICS, lookup as lookup_help_topic, topic_names
 from asat.keys import Key, Modifier
 from asat.notebook import FocusMode, NotebookCursor
 from asat.output_cursor import OutputCursor
@@ -197,6 +198,7 @@ META_COMMANDS: tuple[str, ...] = (
     "pwd",
     "commands",
     "reset",
+    "welcome",
 )
 
 # "Ambient" meta-commands do their job without taking focus away from
@@ -207,7 +209,7 @@ META_COMMANDS: tuple[str, ...] = (
 # mode. Commands NOT in this set (today: `:settings`, `:quit`)
 # inherently require a mode change and go through `abandon_input_mode`.
 AMBIENT_META_COMMANDS: frozenset[str] = frozenset(
-    {"help", "save", "pwd", "commands"}
+    {"help", "save", "pwd", "commands", "welcome"}
 )
 
 # `:name optional-argument` — case-insensitive in the name, everything
@@ -232,8 +234,9 @@ HELP_LINES: tuple[str, ...] = (
     "           Ctrl+Z undo, Ctrl+Y redo edits in the order you made them.",
     "           Ctrl+R resets to defaults at cursor scope (Enter confirms, Escape cancels).",
     "Menu:      F2 (or Ctrl+.) opens contextual actions; Up/Down walk, Enter invokes, Escape closes.",
-    "Meta:      :help, :settings, :save, :quit, :delete, :duplicate, :pwd, :commands, :reset.",
-    "           Meta-commands are case-insensitive and accept a trailing argument.",
+    "Meta:      :help, :settings, :save, :quit, :delete, :duplicate, :pwd, :commands, :reset, :welcome.",
+    "           `:help topics` lists focused tours; `:help <topic>` narrates one (navigation, cells, settings, audio, search, meta).",
+    "           `:welcome` replays the first-run tour. Meta-commands are case-insensitive and accept a trailing argument.",
     "Exit:      :quit, or EOF (Ctrl+D on POSIX, Ctrl+Z Enter on Windows).",
     "Docs:      docs/USER_MANUAL.md for the full keystroke reference.",
 )
@@ -532,7 +535,7 @@ class InputRouter:
         if command == "settings":
             self._open_settings()
         elif command == "help":
-            self._publish_help()
+            self._publish_help(argument)
         elif command == "delete":
             self._cursor.delete_focused_cell()
         elif command == "duplicate":
@@ -618,12 +621,53 @@ class InputRouter:
             source=self.SOURCE,
         )
 
-    def _publish_help(self) -> None:
-        """Emit HELP_REQUESTED so the renderer and audio bank can react."""
+    def _publish_help(self, argument: str = "") -> None:
+        """Emit HELP_REQUESTED with either the cheat sheet or a topic tour.
+
+        No argument → the full cheat sheet (HELP_LINES), matching the
+        pre-F38 behaviour. `:help topics` → a listing of every
+        available topic. `:help <topic>` → that topic's micro-tour.
+        Unknown topic → a typo-suggestion hint built from
+        `difflib.get_close_matches` over the topic names, so the user
+        stays in INPUT mode and can correct-and-retry.
+        """
+        topic = argument.strip().lower()
+        if not topic:
+            publish_event(
+                self._bus,
+                EventType.HELP_REQUESTED,
+                {"lines": list(HELP_LINES)},
+                source=self.SOURCE,
+            )
+            return
+        if topic == "topics":
+            lines = ["Available `:help <topic>` tours:"]
+            lines.extend(f"  :help {name}" for name in topic_names())
+            publish_event(
+                self._bus,
+                EventType.HELP_REQUESTED,
+                {"lines": lines, "help_topic": "topics"},
+                source=self.SOURCE,
+            )
+            return
+        body = lookup_help_topic(topic)
+        if body is not None:
+            publish_event(
+                self._bus,
+                EventType.HELP_REQUESTED,
+                {"lines": list(body), "help_topic": topic},
+                source=self.SOURCE,
+            )
+            return
+        lines = [f"Unknown `:help` topic `{argument.strip()}`."]
+        suggestion = difflib.get_close_matches(topic, topic_names(), n=1)
+        if suggestion:
+            lines.append(f"Did you mean `:help {suggestion[0]}`?")
+        lines.append("Type `:help topics` to list every available topic.")
         publish_event(
             self._bus,
             EventType.HELP_REQUESTED,
-            {"lines": list(HELP_LINES)},
+            {"lines": lines, "help_topic_unknown": argument.strip()},
             source=self.SOURCE,
         )
 

--- a/asat/onboarding.py
+++ b/asat/onboarding.py
@@ -93,16 +93,23 @@ class OnboardingCoordinator:
         """Return True when the sentinel is absent (no prior welcome)."""
         return not self._sentinel_path.exists()
 
-    def run(self) -> bool:
-        """Publish the tour once and create the sentinel; return True if fired.
+    def run(self, *, force: bool = False) -> bool:
+        """Publish the tour and (on a first run) create the sentinel.
 
-        Returns False on subsequent calls so the CLI can treat the
-        result as "did I just onboard a newcomer?" without re-checking
-        the filesystem itself.
+        Returns False on a non-first-run, non-forced call so the CLI
+        can treat the result as "did I just onboard a newcomer?"
+        without re-checking the filesystem itself.
+
+        `force=True` is the `:welcome` replay path (F44): it publishes
+        the same `FIRST_RUN_DETECTED` event but does NOT write the
+        sentinel, because the sentinel's meaning is "the user has
+        seen this once" and a replay must not rewind that fact. The
+        silent-sink hint (F41) is also skipped on a forced replay —
+        the user chose this; they already know whether they can hear.
         """
-        if not self.is_first_run():
+        if not force and not self.is_first_run():
             return False
-        if not self._has_live_audio:
+        if not force and not self._has_live_audio:
             print(SILENT_SINK_HINT, file=self._hint_stream)
         publish_event(
             self._bus,
@@ -110,9 +117,12 @@ class OnboardingCoordinator:
             {
                 "lines": list(self._lines),
                 "sentinel_path": str(self._sentinel_path),
+                "replay": force,
             },
             source=self.SOURCE,
         )
+        if force:
+            return True
         self._sentinel_path.parent.mkdir(parents=True, exist_ok=True)
         self._sentinel_path.write_text("first-run-done\n", encoding="utf-8")
         return True

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -1019,25 +1019,28 @@ temporal frame for long-running output.
 
 ## F38 — Self-voicing help topics
 
-**Gap.** `:help` prints the cheat sheet. A brand-new user — blind,
-with no sighted context — needs a spoken tour that explains the mode
-model, the key keystrokes, and how to discover things like `Ctrl+,`
-for settings. Today the only path is "read the USER_MANUAL in a
-screen reader".
+**Status: Shipped.**
 
-**Where it surfaces.** First-run onboarding (F20 shipped) reads a
-short welcome but doesn't cover navigation, settings, audio tuning,
-or search. A user who wants to learn more has to leave the terminal
-to do so.
+**Gap (at time of shipping).** `:help` printed the cheat sheet. A
+brand-new blind user needed a spoken tour of each mode, the key
+keystrokes, and discovery paths like `Ctrl+,` for settings — the
+only alternative was reading the USER_MANUAL in a screen reader.
 
-**Sketch.** Extend `:help` to accept a topic: `:help navigation`,
-`:help audio`, `:help settings`, `:help cells`, `:help search`,
-`:help topics` (lists the rest). Each topic narrates a 10-20 second
-tour via the `system` voice — short enough to absorb, long enough to
-be useful. Topics live as plain strings in a new
-`asat/help_topics.py` module so they're easy to edit and translate.
-`:help` with no argument keeps the current print-the-cheat-sheet
-behaviour for users who already know the layout.
+**Sketch (shipped).** New `asat/help_topics.py` holds a
+`HELP_TOPICS: dict[str, tuple[str, ...]]` with six topics:
+navigation, cells, settings, audio, search, meta. Each topic is
+a short spoken tour (heading + a handful of body lines).
+`asat/input_router.py` `_publish_help(argument)` dispatches:
+bare `:help` → `HELP_LINES` (unchanged); `:help topics` → an
+enumeration of every registered topic with a `help_topic:
+"topics"` payload key; `:help <topic>` → the topic's lines with
+`help_topic: <name>`; unknown topic → a `HELP_REQUESTED` hint
+with a `difflib.get_close_matches` suggestion and
+`help_topic_unknown` key. Topic lookup is case-insensitive.
+Tests: four new router cases (`test_colon_help_topic_*`) plus
+five in a new `tests/test_help_topics.py`. `HELP_LINES` gained a
+row pointing users at `:help topics` so the self-voicing path is
+discoverable from the cheat sheet itself.
 
 ---
 
@@ -1310,33 +1313,31 @@ mention the tour in `README.md` quick-start.
 
 ## F44 — `:welcome` meta-command to replay onboarding
 
-**Gap.** Once the first-run sentinel at `~/.asat/first-run-done`
-(`asat/__main__.py:232`) is written, there is no supported path
-to re-hear the onboarding narration. A user who missed a word,
-wants to re-learn after a long hiatus, or wants to demo ASAT to
-someone else has to manually delete the sentinel and relaunch.
+**Status: Shipped.**
 
-**Where it surfaces.** Support and teaching — every time
-someone says "wait, what were those key bindings again?" the
-only answer today is `rm ~/.asat/first-run-done && python -m asat`.
+**Gap (at time of shipping).** Once the first-run sentinel at
+`~/.asat/first-run-done` was written, there was no supported
+path to re-hear the onboarding narration. Users who missed a
+word, returned after a hiatus, or wanted to demo ASAT had to
+manually delete the sentinel and relaunch.
 
-**Sketch.** Add a `:welcome` meta-command
-(`asat/input_router.py` `_META_HANDLERS`) that re-invokes
-`OnboardingCoordinator.run(force=True)` on the live bus. The
-coordinator grows a `force: bool = False` parameter that skips
-the sentinel check but does *not* rewrite the sentinel (the
-sentinel's meaning stays "the user has seen this once"). Accepts
-an optional argument: `:welcome tour` runs the F43 guided
-first-command tour as well; bare `:welcome` replays just the
-spoken welcome.
+**Sketch (shipped).** `OnboardingCoordinator.run()` gained a
+keyword-only `force: bool = False` parameter. When
+`force=True`, the coordinator publishes `FIRST_RUN_DETECTED`
+with `replay=True` in the payload and **does not** rewrite the
+sentinel, preserving F20's once-per-machine contract. The F41
+silent-sink hint is also skipped on replays. Added `"welcome"`
+to both `META_COMMANDS` and `AMBIENT_META_COMMANDS` in
+`asat/input_router.py` so `:welcome` propagates as a
+`meta_command: "welcome"` payload on ACTION_INVOKED without
+taking focus out of INPUT mode. `Application._on_action_invoked`
+catches the meta-command and calls `onboarding.run(force=True)`;
+when `onboarding is None` (--quiet or --check) the meta-command
+is a harmless no-op. Tests: three new coordinator cases, two
+Application cases, one router case.
 
-Pairs with F38 (self-voicing help topics) — `:welcome` is the
-one fixed-script tour; `:help <topic>` covers everything else.
-
-**Documentation touch points.** New row in the meta-command
-table at `docs/USER_MANUAL.md:199-208`; mention in the
-"Your first launch" subsection so users know they can re-hear
-it; cross-reference from F38.
+F43 (guided first-command tour) follow-up: `:welcome tour` as a
+richer variant remains on the F43 entry once that lands.
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -212,6 +212,9 @@ discarded and the cell is not modified.
 | Meta-command | Effect                                               |
 |--------------|------------------------------------------------------|
 | `:help`      | Narrate + print the keystroke cheat sheet.           |
+| `:help topics` | List every focused `:help <topic>` micro-tour.     |
+| `:help <topic>` | Narrate one tour: `navigation`, `cells`, `settings`, `audio`, `search`, `meta`. |
+| `:welcome`   | Replay the first-run welcome tour (F44).             |
 | `:settings`  | Open the settings editor (same as Ctrl+,).           |
 | `:save`      | Save the current session to `--session` path (no-op without one). |
 | `:quit`      | Exit ASAT.                                           |

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -234,6 +234,49 @@ class ApplicationMetaCommandTests(unittest.TestCase):
         self.assertEqual(seen, [])
         self.assertTrue(app.running)
 
+    def test_welcome_meta_command_replays_tour_without_rewriting_sentinel(self) -> None:
+        """F44: `:welcome` re-publishes FIRST_RUN_DETECTED through the
+        same coordinator that ran at launch, without rewinding the
+        sentinel. A user who forgot the keystrokes hears the full tour
+        again; the next fresh launch still stays silent."""
+        import tempfile
+        from pathlib import Path
+
+        from asat.event_bus import EventBus
+        from asat.onboarding import OnboardingCoordinator
+
+        with tempfile.TemporaryDirectory() as td:
+            sentinel = Path(td) / "first-run-done"
+
+            def _factory(bus: EventBus) -> OnboardingCoordinator:
+                return OnboardingCoordinator(bus, sentinel)
+
+            app = Application.build(onboarding_factory=_factory)
+            # Launch fired FIRST_RUN_DETECTED once and wrote the sentinel.
+            first_mtime = sentinel.stat().st_mtime_ns
+
+            replays: list[dict] = []
+            app.bus.subscribe(
+                EventType.FIRST_RUN_DETECTED,
+                lambda e: replays.append(dict(e.payload)),
+            )
+            _type(app, ":welcome")
+            app.handle_key(kc.ENTER)
+
+            self.assertEqual(len(replays), 1)
+            self.assertTrue(replays[0]["replay"])
+            self.assertEqual(sentinel.stat().st_mtime_ns, first_mtime)
+            self.assertTrue(app.running, ":welcome must not exit the app")
+
+    def test_welcome_meta_command_is_safe_without_onboarding(self) -> None:
+        """F44: a user running `--quiet` or `--check` has `onboarding=None`.
+        `:welcome` there must be a harmless no-op, not a crash."""
+        app = Application.build()  # no onboarding_factory
+        self.assertIsNone(app.onboarding)
+        _type(app, ":welcome")
+        app.handle_key(kc.ENTER)
+        self.assertTrue(app.running)
+
 
 class ApplicationPersistenceTests(unittest.TestCase):
     def test_close_persists_session_when_path_given(self) -> None:

--- a/tests/test_help_topics.py
+++ b/tests/test_help_topics.py
@@ -1,0 +1,44 @@
+"""Unit tests for asat/help_topics.py (F38)."""
+
+from __future__ import annotations
+
+import unittest
+
+from asat.help_topics import HELP_TOPICS, lookup, topic_names
+
+
+class HelpTopicsTests(unittest.TestCase):
+    def test_every_topic_has_at_least_two_lines(self) -> None:
+        # A topic with one line is just a heading — not a tour. This
+        # keeps the module honest when someone adds a new topic.
+        for name, lines in HELP_TOPICS.items():
+            self.assertGreaterEqual(
+                len(lines),
+                2,
+                f"help topic `{name}` must have a heading plus at least one body line",
+            )
+
+    def test_topic_names_are_sorted_for_stable_listing(self) -> None:
+        names = topic_names()
+        self.assertEqual(names, tuple(sorted(HELP_TOPICS)))
+
+    def test_lookup_is_case_insensitive(self) -> None:
+        for name in HELP_TOPICS:
+            self.assertEqual(lookup(name), HELP_TOPICS[name])
+            self.assertEqual(lookup(name.upper()), HELP_TOPICS[name])
+
+    def test_lookup_returns_none_for_unknown_topic(self) -> None:
+        self.assertIsNone(lookup("no-such-topic"))
+
+    def test_meta_topic_mentions_welcome_and_help_topics(self) -> None:
+        """Discoverability regression guard: the `meta` tour names
+        both `:welcome` and `:help topics` so a user who finds their
+        way to `:help meta` learns about the two self-service
+        commands the rest of the app relies on."""
+        meta_text = "\n".join(HELP_TOPICS["meta"]).lower()
+        self.assertIn(":welcome", meta_text)
+        self.assertIn(":help topics", meta_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_input_router.py
+++ b/tests/test_input_router.py
@@ -818,6 +818,71 @@ class MetaCommandTests(unittest.TestCase):
         ]
         self.assertEqual(submits[-1].payload["meta_command"], "help")
 
+    def test_colon_help_topic_publishes_that_topics_lines(self) -> None:
+        """F38: `:help <topic>` narrates a focused micro-tour."""
+        from asat.help_topics import HELP_TOPICS
+
+        bus, _, router, _controller = _build_with_settings([""])
+        recorder = _Recorder(bus)
+        router.handle_key(ENTER)
+        for ch in ":help settings":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+        helps = recorder.types_of(EventType.HELP_REQUESTED)
+        self.assertEqual(len(helps), 1)
+        self.assertEqual(
+            tuple(helps[0].payload["lines"]),
+            HELP_TOPICS["settings"],
+        )
+        self.assertEqual(helps[0].payload["help_topic"], "settings")
+
+    def test_colon_help_topic_is_case_insensitive(self) -> None:
+        """F38: `:HELP Navigation` resolves the same as `:help navigation`."""
+        from asat.help_topics import HELP_TOPICS
+
+        bus, _, router, _controller = _build_with_settings([""])
+        recorder = _Recorder(bus)
+        router.handle_key(ENTER)
+        for ch in ":HELP Navigation":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+        helps = recorder.types_of(EventType.HELP_REQUESTED)
+        self.assertEqual(tuple(helps[0].payload["lines"]), HELP_TOPICS["navigation"])
+
+    def test_colon_help_topics_lists_every_topic_name(self) -> None:
+        """F38: `:help topics` enumerates every registered topic."""
+        from asat.help_topics import topic_names
+
+        bus, _, router, _controller = _build_with_settings([""])
+        recorder = _Recorder(bus)
+        router.handle_key(ENTER)
+        for ch in ":help topics":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+        helps = recorder.types_of(EventType.HELP_REQUESTED)
+        self.assertEqual(len(helps), 1)
+        text = "\n".join(helps[0].payload["lines"])
+        for name in topic_names():
+            self.assertIn(f":help {name}", text)
+        self.assertEqual(helps[0].payload["help_topic"], "topics")
+
+    def test_colon_help_unknown_topic_suggests_closest_match(self) -> None:
+        """F38: `:help navgation` (typo) suggests `:help navigation`."""
+        bus, _, router, _controller = _build_with_settings([""])
+        recorder = _Recorder(bus)
+        router.handle_key(ENTER)
+        for ch in ":help navgation":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+        helps = recorder.types_of(EventType.HELP_REQUESTED)
+        self.assertEqual(len(helps), 1)
+        text = "\n".join(helps[0].payload["lines"])
+        self.assertIn("Unknown", text)
+        self.assertIn(":help navigation", text)
+        self.assertEqual(
+            helps[0].payload["help_topic_unknown"], "navgation"
+        )
+
     def test_colon_help_is_ambient_leaves_user_in_input_mode(self) -> None:
         """`:help` consumes the buffer but keeps INPUT focus so the
         user can immediately continue typing their real command."""
@@ -832,6 +897,24 @@ class MetaCommandTests(unittest.TestCase):
         for ch in "echo hi":
             router.handle_key(Key.printable(ch))
         self.assertEqual(cursor.focus.input_buffer, "echo hi")
+
+    def test_colon_welcome_surfaces_meta_command_and_stays_in_input(self) -> None:
+        """F44: `:welcome` emits `meta_command: welcome` on the submit
+        action and, being ambient, keeps the user in INPUT mode so
+        they can keep typing after hearing the tour replay."""
+        bus, cursor, router, _controller = _build_with_settings([""])
+        recorder = _Recorder(bus)
+        router.handle_key(ENTER)
+        for ch in ":welcome":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+        submits = [
+            e for e in recorder.types_of(EventType.ACTION_INVOKED)
+            if e.payload.get("action") == "submit"
+        ]
+        self.assertEqual(submits[-1].payload["meta_command"], "welcome")
+        self.assertEqual(cursor.focus.mode, FocusMode.INPUT)
+        self.assertEqual(cursor.focus.input_buffer, "")
 
     def test_colon_save_is_ambient_leaves_user_in_input_mode(self) -> None:
         """Same ambient semantics for `:save` — session gets saved by

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -171,6 +171,57 @@ class OnboardingCoordinatorTests(unittest.TestCase):
         self.assertFalse(fired_again)
         self.assertEqual(stream.getvalue(), "")
 
+    def test_force_run_fires_even_when_sentinel_exists(self) -> None:
+        """F44: `.run(force=True)` replays the tour after the first
+        run. A user invoking `:welcome` must hear the same lines the
+        sentinel saved them from hearing on every launch."""
+        bus = EventBus()
+        coordinator = OnboardingCoordinator(bus, self.sentinel)
+        coordinator.run()
+        self.assertFalse(coordinator.is_first_run())
+
+        recorder = _Recorder(bus)
+        fired = coordinator.run(force=True)
+
+        self.assertTrue(fired)
+        events = recorder.of(EventType.FIRST_RUN_DETECTED)
+        self.assertEqual(len(events), 1)
+        self.assertTrue(events[0].payload["replay"])
+        self.assertEqual(
+            events[0].payload["lines"], list(DEFAULT_ONBOARDING_LINES)
+        )
+
+    def test_force_run_does_not_rewrite_sentinel(self) -> None:
+        """F44: a replay must not touch the sentinel. Its meaning
+        stays `the user has seen the tour once` — rewinding that would
+        break F20's once-per-machine contract."""
+        bus = EventBus()
+        coordinator = OnboardingCoordinator(bus, self.sentinel)
+        coordinator.run()
+        first_mtime = self.sentinel.stat().st_mtime_ns
+
+        coordinator.run(force=True)
+        coordinator.run(force=True)
+
+        self.assertEqual(self.sentinel.stat().st_mtime_ns, first_mtime)
+
+    def test_force_run_skips_silent_sink_hint(self) -> None:
+        """F44 + F41: the replay must not print the silent-sink hint.
+        The user chose to replay; they already know whether they
+        can hear. Spamming stderr on every `:welcome` would be noise."""
+        bus = EventBus()
+        stream = io.StringIO()
+        coordinator = OnboardingCoordinator(
+            bus,
+            self.sentinel,
+            has_live_audio=False,
+            hint_stream=stream,
+        )
+
+        coordinator.run(force=True)
+
+        self.assertEqual(stream.getvalue(), "")
+
     def test_default_lines_mention_help_and_quit(self) -> None:
         # Sanity check the welcome text a newcomer will actually hear
         # so a careless edit doesn't ship a tour without the two


### PR DESCRIPTION
Thematically-aligned batch: two features that both live on the meta-command dispatch path and both help a blind user learn ASAT without leaving the terminal.

## F38 — `:help <topic>` micro-tours

A new `asat/help_topics.py` module holds six focused tours — `navigation`, `cells`, `settings`, `audio`, `search`, `meta` — each a 3-6 line narration. `:help` alone still prints the existing overview; `:help topics` lists every tour; `:help <topic>` narrates one; `:help <typo>` uses `difflib.get_close_matches` for a "Did you mean?" suggestion and points the user at `:help topics`.

- `HELP_REQUESTED` gains two optional payload keys: `help_topic` (the resolved tour name) and `help_topic_unknown` (the raw argument when dispatch falls through).
- Topic lookup is case-insensitive; `topic_names()` returns a sorted tuple for stable listing.
- `HELP_LINES` now mentions `:welcome` and `:help topics` inline so the existing help surface links into the new one.

## F44 — `:welcome` replays the first-run tour

`OnboardingCoordinator.run()` takes a new keyword-only `force: bool = False`. `:welcome` routes through the existing meta-command bus pattern (router publishes `ACTION_INVOKED` with `meta_command="welcome"`; `Application._on_action_invoked` catches it and calls `self.onboarding.run(force=True)` when onboarding is attached). Force mode:

- Fires `FIRST_RUN_DETECTED` with a new `replay: bool` payload field (F20 consumers that ignore the field keep working).
- Does **not** rewrite the sentinel — its meaning stays "user has seen this once".
- Suppresses the F41 silent-sink hint, because replay is user-initiated.
- No-ops cleanly when `Application` was built without an onboarding coordinator.

`:welcome` is registered in both `META_COMMANDS` and `AMBIENT_META_COMMANDS`, so it leaves the user in INPUT mode like `:help` and `:settings`.

## Tests (771 → 786, +15)

- `tests/test_help_topics.py` (new, 5 tests): heading+body invariant, sorted listing, case-insensitive lookup, unknown-topic None, regression guard that `meta` topic mentions both `:welcome` and `:help topics`.
- `tests/test_input_router.py` (+5 tests): `:help topics`, `:help navigation`, `:help NAVIGATION` (case-insensitivity), `:help bogus` (suggestion fallback), `:welcome` ambient routing.
- `tests/test_onboarding.py` (+3 tests): `force=True` fires after sentinel exists, preserves sentinel mtime across two replays, skips silent-sink hint on replay.
- `tests/test_app.py` (+2 tests): `:welcome` end-to-end replays the tour without rewriting the sentinel; `:welcome` without onboarding is a safe no-op.

Full suite: `python -m unittest discover -s tests -t .` → **786 passing**.

## Docs

- `docs/USER_MANUAL.md` meta-command table gains three rows (`:help topics`, `:help <topic>`, `:welcome`).
- `docs/FEATURE_REQUESTS.md` F38 and F44 entries flipped to `Status: Shipped` with "Sketch (shipped)" pointers to the new module, payload keys, and test files.
- `HANDOFF.md` test count bumped to 786.

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS