### PR TITLE
Foundations refactor: naming, Protocol intent, docs drift guard

### DIFF
--- a/asat/actions.py
+++ b/asat/actions.py
@@ -73,7 +73,13 @@ ActionProvider = Callable[[ActionContext], tuple[MenuItem, ...]]
 
 
 class Clipboard(Protocol):
-    """Minimal contract for a clipboard backend."""
+    """Minimal contract for a clipboard backend.
+
+    Implementations in-tree: ``MemoryClipboard`` (default / tests),
+    ``SystemClipboard`` (wraps the OS ``pbcopy`` / ``xclip`` /
+    PowerShell helpers). Pluggable: install a custom adapter via
+    ``Application.build(clipboard_factory=...)``.
+    """
 
     def set_text(self, text: str) -> None:
         """Replace the clipboard contents with the given text."""

--- a/asat/audio_sink.py
+++ b/asat/audio_sink.py
@@ -39,7 +39,13 @@ from asat.audio import AudioBuffer, ChannelLayout
 
 
 class AudioSink(Protocol):
-    """Final stage of the audio pipeline."""
+    """Final stage of the audio pipeline.
+
+    Implementations in-tree: ``MemorySink`` (tests), ``WavFileSink``
+    (``--wav-dir`` CLI mode), ``WindowsLiveAudioSink`` (``--live`` on
+    Windows). Pluggable: add a new sink by implementing ``play`` and
+    ``close`` with the same signatures.
+    """
 
     def play(self, buffer: AudioBuffer) -> None:
         """Deliver a fully-rendered audio buffer to the sink."""

--- a/asat/keyboard.py
+++ b/asat/keyboard.py
@@ -77,7 +77,14 @@ _WINDOWS_SPECIAL: dict[int, Key] = {
 
 
 class KeyboardReader(Protocol):
-    """Produces one `Key` value per real keystroke."""
+    """Produces one `Key` value per real keystroke.
+
+    Implementations in-tree: ``PosixKeyboard`` (termios raw mode),
+    ``WindowsKeyboard`` (``msvcrt.getwch``), ``ScriptedKeyboard``
+    (test fixture that replays a pre-recorded list). Pluggable: any
+    driver that yields ``Key`` values one at a time via ``read_key``
+    satisfies the shape.
+    """
 
     def read_key(self) -> Optional[Key]:
         """Block until a keystroke arrives and return the decoded Key."""

--- a/asat/settings_editor.py
+++ b/asat/settings_editor.py
@@ -50,9 +50,6 @@ from asat.sound_bank import (
 )
 
 
-SOURCE = "settings_editor"
-
-
 MAX_HISTORY = 64
 
 
@@ -156,6 +153,8 @@ class SettingsEditor:
     SoundEngine can narrate in real time.
     """
 
+    SOURCE = "settings_editor"
+
     def __init__(
         self,
         bus: EventBus,
@@ -200,7 +199,7 @@ class SettingsEditor:
             bus,
             EventType.SETTINGS_OPENED,
             {"section": self._state.section.value, "record_count": self._record_count()},
-            source=SOURCE,
+            source=self.SOURCE,
         )
         self._publish_focus()
 
@@ -220,7 +219,7 @@ class SettingsEditor:
             self._bus,
             EventType.SETTINGS_CLOSED,
             {"dirty": self._state.dirty},
-            source=SOURCE,
+            source=self.SOURCE,
         )
 
     def next(self) -> None:
@@ -318,7 +317,7 @@ class SettingsEditor:
                 "old_value": _jsonable(old_value),
                 "new_value": _jsonable(parsed),
             },
-            source=SOURCE,
+            source=self.SOURCE,
         )
 
     @property
@@ -357,7 +356,7 @@ class SettingsEditor:
                     "old_value": _jsonable(record.new_value),
                     "new_value": _jsonable(record.old_value),
                 },
-                source=SOURCE,
+                source=self.SOURCE,
             )
         self._publish_focus()
         return True
@@ -385,7 +384,7 @@ class SettingsEditor:
                     "old_value": _jsonable(record.old_value),
                     "new_value": _jsonable(record.new_value),
                 },
-                source=SOURCE,
+                source=self.SOURCE,
             )
         self._publish_focus()
         return True
@@ -517,7 +516,7 @@ class SettingsEditor:
                 "origin_record_index": self._state.record_index,
                 "origin_field_index": self._state.field_index,
             },
-            source=SOURCE,
+            source=self.SOURCE,
         )
         return True
 
@@ -564,7 +563,7 @@ class SettingsEditor:
                 "match_count": match_count,
                 "committed": True,
             },
-            source=SOURCE,
+            source=self.SOURCE,
         )
         return True
 
@@ -597,7 +596,7 @@ class SettingsEditor:
                 "match_count": 0,
                 "committed": False,
             },
-            source=SOURCE,
+            source=self.SOURCE,
         )
         return True
 
@@ -667,7 +666,7 @@ class SettingsEditor:
             self._bus,
             EventType.SETTINGS_RESET_OPENED,
             self._reset_opened_payload(scope),
-            source=SOURCE,
+            source=self.SOURCE,
         )
         return True
 
@@ -717,7 +716,7 @@ class SettingsEditor:
                 "changed": changed,
                 "outcome": "applied" if changed else "already_default",
             },
-            source=SOURCE,
+            source=self.SOURCE,
         )
         return True
 
@@ -737,7 +736,7 @@ class SettingsEditor:
                 "changed": False,
                 "outcome": "cancelled",
             },
-            source=SOURCE,
+            source=self.SOURCE,
         )
         return True
 
@@ -922,7 +921,7 @@ class SettingsEditor:
             self._bus,
             EventType.SETTINGS_SEARCH_UPDATED,
             payload,
-            source=SOURCE,
+            source=self.SOURCE,
         )
 
     def save(self, path: Path | str) -> None:
@@ -940,7 +939,7 @@ class SettingsEditor:
             self._bus,
             EventType.SETTINGS_SAVED,
             {"path": str(path)},
-            source=SOURCE,
+            source=self.SOURCE,
         )
 
     def _move(self, delta: int) -> None:
@@ -983,7 +982,7 @@ class SettingsEditor:
             payload["value"] = _jsonable(
                 getattr(self._records()[self._state.record_index], field_name)
             )
-        publish_event(self._bus, EventType.SETTINGS_FOCUSED, payload, source=SOURCE)
+        publish_event(self._bus, EventType.SETTINGS_FOCUSED, payload, source=self.SOURCE)
 
     def _records(self) -> tuple[Any, ...]:
         """Return the current section's record tuple from the bank."""

--- a/asat/sound_engine.py
+++ b/asat/sound_engine.py
@@ -52,8 +52,6 @@ from asat.sound_generators import SoundGeneratorRegistry
 from asat.tts import TTSEngine, ToneTTSEngine
 
 
-SOURCE_NAME = "sound_engine"
-
 NARRATION_HISTORY_CAPACITY = 20
 
 
@@ -73,7 +71,14 @@ class NarrationHistoryEntry(NamedTuple):
 
 
 class PredicateEvaluator(Protocol):
-    """Anything that decides whether a binding applies to a payload."""
+    """Anything that decides whether a binding applies to a payload.
+
+    Single in-tree implementation today: ``DefaultPredicateEvaluator``
+    (handles the tiny ``key == literal`` / ``key != literal`` /
+    ``key in [...]`` grammar documented at module top). Pluggable:
+    swap in a richer evaluator via ``SoundEngine(..., predicate=...)``
+    if a bank needs a different predicate language.
+    """
 
     def matches(self, expression: str, payload: dict[str, Any]) -> bool:
         """Return True when the expression matches against payload."""
@@ -112,6 +117,8 @@ class SoundEngineError(ValueError):
 
 class SoundEngine:
     """Drive audio output from a SoundBank by subscribing to events."""
+
+    SOURCE = "sound_engine"
 
     def __init__(
         self,
@@ -177,7 +184,7 @@ class SoundEngine:
                 "text": entry.text,
                 "voice_id": entry.voice_id,
             },
-            source=SOURCE_NAME,
+            source=self.SOURCE,
         )
         return entry
 
@@ -216,7 +223,7 @@ class SoundEngine:
 
     def _dispatch(self, event: Event) -> None:
         """Render every matching binding and play the result."""
-        if event.source == SOURCE_NAME:
+        if event.source == self.SOURCE:
             return
         bindings = self._bank.bindings_for(event.event_type.value)
         for binding in bindings:
@@ -263,7 +270,7 @@ class SoundEngine:
                 "voice_id": binding.voice_id,
                 "sound_id": binding.sound_id,
             },
-            source=SOURCE_NAME,
+            source=self.SOURCE,
         )
 
     def _resolve_voice(self, binding: EventBinding) -> Optional[Voice]:

--- a/asat/sound_generators.py
+++ b/asat/sound_generators.py
@@ -50,7 +50,13 @@ class SoundGeneratorError(ValueError):
 
 
 class SoundGenerator(Protocol):
-    """Anything that can turn one recipe into a mono AudioBuffer."""
+    """Anything that can turn one recipe into a mono AudioBuffer.
+
+    Implementations in-tree: ``ToneGenerator``, ``ChordGenerator``,
+    ``SampleGenerator``, ``SilenceGenerator`` — one per ``kind`` the
+    default bank uses. Pluggable: register a new generator on a
+    ``SoundGeneratorRegistry`` to add a ``kind="..."`` recipe type.
+    """
 
     def generate(self, recipe: SoundRecipe, *, sample_rate: int) -> AudioBuffer:
         """Render the recipe into a mono AudioBuffer at sample_rate."""

--- a/asat/tts.py
+++ b/asat/tts.py
@@ -26,7 +26,14 @@ from asat.audio import AudioBuffer, DEFAULT_SAMPLE_RATE, VoiceProfile
 
 
 class TTSEngine(Protocol):
-    """Synthesizes a line of text into a mono AudioBuffer."""
+    """Synthesizes a line of text into a mono AudioBuffer.
+
+    Single in-tree implementation today: ``ToneTTSEngine`` (a
+    deterministic tone-based stand-in). Pluggable: real TTS
+    backends (Windows SAPI, macOS NSSpeechSynthesizer, Piper, etc.)
+    can be swapped in via ``SoundEngine(..., tts=...)`` without
+    touching the rest of the pipeline.
+    """
 
     def synthesize(self, text: str, voice: VoiceProfile) -> AudioBuffer:
         """Return a mono AudioBuffer containing the rendered speech."""

--- a/docs/AUDIO.md
+++ b/docs/AUDIO.md
@@ -181,7 +181,7 @@ own registry (`SoundGeneratorRegistry(...)`) and passing it to
 `asat/sound_engine.py` subscribes to every `EventType` that the
 active bank's enabled bindings mention. Per event:
 
-1. Skip if `event.source == SOURCE_NAME` (prevents feedback loops:
+1. Skip if `event.source == SoundEngine.SOURCE` (prevents feedback loops:
    `AUDIO_SPOKEN` is itself an event, and a binding that matched it
    would loop forever).
 2. Look up every binding for `event.event_type`, sorted by

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -21,6 +21,18 @@ When designing a new subscriber, key off `event_type` only. `source`
 is informational (useful for debug logs or filtering) and can change
 over time.
 
+### Source convention
+
+Every class that publishes events exposes a `SOURCE` class attribute
+holding the string it passes as the `source=` keyword on
+`publish_event`. Examples: `ExecutionKernel.SOURCE == "kernel"`,
+`NotebookCursor.SOURCE == "notebook"`, `SoundEngine.SOURCE ==
+"sound_engine"`. Keep the name short and matching the module slug so
+a log reader can locate the publisher from the string alone. New
+event-publishing classes should follow this convention so cross-cutting
+tools (the JSONL logger, future filters, the event log viewer) can
+present a consistent vocabulary.
+
 ---
 
 ## Session lifecycle
@@ -264,12 +276,44 @@ fired when the user submits the `:help` meta-command.
 |------------------|--------------------------------------------------|
 | `HELP_REQUESTED` | `lines` (list of str: the cheat-sheet lines from `asat.input_router.HELP_LINES`) |
 
+## Prompt context
+
+Producer: `asat.prompt_context.PromptContext` (`source="prompt_context"`).
+`PROMPT_REFRESH` fires every time focus transitions into INPUT mode
+(and after each completed command) so renderers can redraw a
+bash-style prompt line with the last exit code and CWD.
+
+| EventType        | Payload keys                                                                  |
+|------------------|-------------------------------------------------------------------------------|
+| `PROMPT_REFRESH` | `last_exit_code`, `last_cell_id`, `last_timed_out`, `cwd`                     |
+
+Suppressed until at least one command has completed — `PromptContext`
+returns early if `last_exit_code is None`, so the very first input
+cell doesn't narrate a stale prompt.
+
+## Onboarding
+
+Producer: `asat.onboarding.OnboardingCoordinator` (`source="onboarding"`).
+`FIRST_RUN_DETECTED` fires once per machine (gated by a sentinel
+file) when ASAT launches for the first time, and again on demand via
+the `:welcome` meta-command with `replay=True`.
+
+| EventType            | Payload keys                                         |
+|----------------------|------------------------------------------------------|
+| `FIRST_RUN_DETECTED` | `lines`, `sentinel_path`, `replay`                   |
+
+`replay` is `True` when the event is a `:welcome` re-invocation and
+`False` on the genuine first run; a binding that wants to sound
+different on replay can key off it.
+
 ---
 
 ## Adding a new event
 
 1. Add the member to the `EventType` enum in `asat/events.py`.
 2. Document the payload in this file under the appropriate section.
+   `tests/test_events_docs_sync.py` fails the build if you skip this
+   step, so add the row at the same time as the enum member.
 3. Publish it via `publish_event(bus, EventType.X, payload, source=...)`
    from the producing module. Never hand-roll `Event(...)` — the
    helper keeps construction uniform for future audit/correlation

--- a/tests/test_events_docs_sync.py
+++ b/tests/test_events_docs_sync.py
@@ -1,0 +1,41 @@
+"""Regression guard: every EventType is mentioned in docs/EVENTS.md.
+
+Adding a new ``EventType`` without documenting its payload is a silent
+contract leak: subscribers outside this repo will not know the event
+exists, and no error will ever surface until someone searches the docs
+and comes up empty. This test fails the build until every new category
+lands in the reference, so the docs cannot drift behind the code.
+
+The check is deliberately loose — it only asserts the enum member
+name (e.g. ``SESSION_CREATED``) appears somewhere in EVENTS.md
+(inside a table cell, a prose line, or a code fence). Where and how
+you document the event is up to you; that you document it at all is
+non-negotiable.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from asat.events import EventType
+
+
+_DOCS_PATH = Path(__file__).resolve().parent.parent / "docs" / "EVENTS.md"
+
+
+class EventsDocsSyncTests(unittest.TestCase):
+    def test_every_event_type_is_documented(self) -> None:
+        text = _DOCS_PATH.read_text(encoding="utf-8")
+        missing = [event.name for event in EventType if event.name not in text]
+        self.assertEqual(
+            missing,
+            [],
+            "EventType names missing from docs/EVENTS.md — add rows "
+            "describing payload and producer before merging: "
+            f"{missing}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sound_engine.py
+++ b/tests/test_sound_engine.py
@@ -11,7 +11,6 @@ from asat.events import EventType
 from asat.sound_bank import EventBinding, SoundBank, SoundRecipe, Voice
 from asat.sound_engine import (
     DefaultPredicateEvaluator,
-    SOURCE_NAME,
     SoundEngine,
     SoundEngineError,
 )
@@ -526,7 +525,7 @@ class SourceFilteringTests(unittest.TestCase):
         engine = SoundEngine(bus, bank, sink, sample_rate=8000)
         self.addCleanup(engine.close)
 
-        publish_event(bus, EventType.CELL_CREATED, {}, source=SOURCE_NAME)
+        publish_event(bus, EventType.CELL_CREATED, {}, source=SoundEngine.SOURCE)
         self.assertEqual(len(sink.buffers), 0)
 
 


### PR DESCRIPTION
## Summary

Small mechanical cleanups from a codebase audit. No behavioural changes,
no renamed public callables. Six items landed; three more the audit
flagged turned out to be wrong on closer reading and were dropped.

### Naming consistency
- `sound_engine.py`: `SOURCE_NAME` (module constant) → `SoundEngine.SOURCE`
  (class attribute), matching every other event-publishing class.
- `settings_editor.py`: same move — `SOURCE` promoted from module level
  to `SettingsEditor.SOURCE`.
- Callers switch to `source=self.SOURCE`. Tests and `docs/AUDIO.md` updated.

### Protocol intent
Every `Protocol` (`AudioSink`, `Clipboard`, `TTSEngine`, `KeyboardReader`,
`SoundGenerator`, `PredicateEvaluator`) gets a docstring block naming
its in-tree implementations and noting whether it's pluggable. A future
reader can now tell at a glance that `AudioSink` has three concrete
implementations but `TTSEngine` has one.

### Docs drift guard
- New `tests/test_events_docs_sync.py` asserts every `EventType` name
  appears somewhere in `docs/EVENTS.md`. Immediately caught two real
  omissions: `PROMPT_REFRESH` and `FIRST_RUN_DETECTED` were published
  in code but never documented.
- `docs/EVENTS.md` gains "Prompt context" and "Onboarding" sections
  covering those events, plus a "Source convention" note near the top
  explaining the `SOURCE` class attribute pattern. The "Adding a new
  event" checklist now points at the sync test.

### Audit items dropped after verification
- Don't drop `Optional` on `InputRouter.__init__` collaborators — ~10
  tests construct `InputRouter(cursor, bus)` without
  `settings_controller` / `output_cursor` / `action_menu`, testing that
  the router degrades gracefully. The `Optional` is a real public contract.
- Don't delete `asat/common.py:new_id()` — it's used by `session.py:47`
  and `cell.py:85`.
- Don't unify `SettingsEditorError` and `SettingsControllerError` — they
  encode distinct categories (editor: bad data / `ValueError`; controller:
  bad workflow state / `RuntimeError`).
- Don't inline `PredicateEvaluator` Protocol — `docs/AUDIO.md` lines 132
  and 382 advertise it as a documented extension point.

### Deferred (for focused future PRs)
- Splitting `input_router.py` (1145 lines) and `settings_editor.py` (1151
  lines). These deserve dedicated PRs with test-by-test migration, not a
  kitchen-sink sweep.

## Test plan

- [x] Suite: 817 passing (up from 816, +1 for the drift guard).
- [x] Drift guard was bootstrapped with the code in place, so it
  exercises the real EventType enum against the real docs file.
- [x] No behaviour tests moved or skipped.

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS