### PR TITLE
docs: USER_MANUAL.md cheat-sheet drift fixes + sync regression test

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -291,6 +291,7 @@ command's narration flew by and you want to re-hear line 47.
 | `/`         | Search: type a query (case-insensitive). The cursor jumps to the first match as you type. Enter commits, Escape restores your starting line. |
 | `n` / `N`   | After a committed search, cycle to the next / previous match. |
 | `g`         | Jump to line: type a 1-based line number, Enter commits. |
+| F2 / Ctrl+. | Open the actions menu.                            |
 | Escape      | Return to NOTEBOOK mode.                          |
 
 Each step plays the `focus_shift` cue and the narrator reads the
@@ -488,6 +489,7 @@ Every key you need, one table.
 | NOTEBOOK   | `d`               | Delete focused cell                   |
 | NOTEBOOK   | `y`               | Duplicate focused cell                |
 | NOTEBOOK   | Alt+Up / Alt+Down | Move focused cell up / down           |
+| NOTEBOOK   | Ctrl+R            | Repeat the most recent narration      |
 | NOTEBOOK   | F2 / Ctrl+.       | Open actions menu                     |
 | INPUT      | Enter             | Submit command                        |
 | INPUT      | Backspace         | Delete char before caret              |
@@ -499,8 +501,11 @@ Every key you need, one table.
 | INPUT      | Ctrl+U            | Delete from start of line to caret    |
 | INPUT      | Ctrl+K            | Delete from caret to end of line      |
 | INPUT      | Escape            | Leave INPUT without running           |
+| INPUT      | Ctrl+R            | Repeat the most recent narration      |
 | INPUT      | F2 / Ctrl+.       | Open actions menu                     |
 | INPUT      | `:help`⏎          | Narrate + print the cheat sheet       |
+| INPUT      | `:welcome`⏎       | Replay the first-run welcome tour     |
+| INPUT      | `:repeat`⏎        | Re-hear the most recent narration     |
 | INPUT      | `:settings`⏎      | Open settings editor                  |
 | INPUT      | `:save`⏎          | Save session                          |
 | INPUT      | `:quit`⏎          | Exit ASAT                             |

--- a/tests/test_user_manual_sync.py
+++ b/tests/test_user_manual_sync.py
@@ -1,0 +1,41 @@
+"""Regression guard: every META_COMMAND is mentioned in USER_MANUAL.md.
+
+A meta-command users can type but cannot find in the manual is
+worse than a meta-command that does not exist — the user wastes
+real time hunting for it. This test asserts that every name in
+``input_router.META_COMMANDS`` appears somewhere in
+``docs/USER_MANUAL.md`` (anywhere — table cell, prose, cheat
+sheet — author's choice; that you document it at all is the
+non-negotiable bit).
+
+Pairs with ``test_events_docs_sync.py``: same shape, different
+file. Add a sibling test for any new public-name registry that
+ships in the repo.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from asat.input_router import META_COMMANDS
+
+
+_DOCS_PATH = Path(__file__).resolve().parent.parent / "docs" / "USER_MANUAL.md"
+
+
+class UserManualSyncTests(unittest.TestCase):
+    def test_every_meta_command_is_documented(self) -> None:
+        text = _DOCS_PATH.read_text(encoding="utf-8")
+        missing = [name for name in META_COMMANDS if f":{name}" not in text]
+        self.assertEqual(
+            missing,
+            [],
+            "META_COMMANDS missing from docs/USER_MANUAL.md — add a "
+            "row in the meta-command table or the cheat sheet "
+            f"before merging: {missing}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Pre-test prep task **1 of 10**. Audits `docs/USER_MANUAL.md`
against the canonical key-binding map and meta-command tuple
in `asat/input_router.py`.

### Drift fixed in the cheat sheet

- NOTEBOOK row missing **Ctrl+R** (repeat narration) — defined
  at `input_router.py:135`.
- INPUT row missing **Ctrl+R** — defined at
  `input_router.py:153`.
- INPUT meta-command rows missing **`:welcome`** and
  **`:repeat`** — defined in `META_COMMANDS` at
  `input_router.py:194`.
- OUTPUT in-section table missing **F2 / Ctrl+.** for the
  actions menu (was already in the cheat sheet but absent
  from the per-mode walkthrough).

### Regression guard

`tests/test_user_manual_sync.py` mirrors the existing
`test_events_docs_sync` shape: asserts every name in
`META_COMMANDS` appears somewhere in `docs/USER_MANUAL.md`
(table cell, prose, cheat sheet — author's choice). Catches
future drift on the next CI run.

## Test plan

- [x] New test passes: `python -m unittest
      tests.test_user_manual_sync` — green.
- [ ] Eyeball cheat-sheet rows render in a markdown viewer.
- [ ] Confirm no missing META_COMMAND name (test passing
      already proves this).

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS