### PR TITLE
Add :state meta-command for "where am I?" snapshot

### DIFF
--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -203,6 +203,7 @@ META_COMMANDS: tuple[str, ...] = (
     "reset",
     "welcome",
     "repeat",
+    "state",
 )
 
 # "Ambient" meta-commands do their job without taking focus away from
@@ -213,7 +214,7 @@ META_COMMANDS: tuple[str, ...] = (
 # mode. Commands NOT in this set (today: `:settings`, `:quit`)
 # inherently require a mode change and go through `abandon_input_mode`.
 AMBIENT_META_COMMANDS: frozenset[str] = frozenset(
-    {"help", "save", "pwd", "commands", "welcome", "repeat"}
+    {"help", "save", "pwd", "commands", "welcome", "repeat", "state"}
 )
 
 # `:name optional-argument` — case-insensitive in the name, everything
@@ -547,6 +548,8 @@ class InputRouter:
             self._cursor.duplicate_focused_cell()
         elif command == "pwd":
             self._publish_pwd()
+        elif command == "state":
+            self._publish_state()
         elif command == "commands":
             self._publish_commands()
         elif command == "reset":
@@ -594,6 +597,41 @@ class InputRouter:
             self._bus,
             EventType.HELP_REQUESTED,
             {"lines": [f"Working directory: {os.getcwd()}"]},
+            source=self.SOURCE,
+        )
+
+    def _publish_state(self) -> None:
+        """Narrate "where am I?" — focus mode, cell index, cwd, session id.
+
+        Designed for the hands-on test loop: when the user has lost
+        track of which cell or mode they're in, `:state` answers in
+        one HELP_REQUESTED block. Always reports from the cursor's
+        perspective so the answer matches what the next keystroke
+        will act on.
+        """
+        focus = self._cursor.focus
+        session = self._cursor.session
+        cells = session.cells
+        cell_count = len(cells)
+        cell_id = focus.cell_id
+        if cell_id is not None:
+            try:
+                index = session.index_of(cell_id)
+                position = f"cell {index + 1} of {cell_count}"
+            except ValueError:
+                position = f"cell {cell_id} (not in session)"
+        else:
+            position = "no cell focused"
+        lines = [
+            f"Focus mode: {focus.mode.value}",
+            f"Position: {position}",
+            f"Session id: {session.session_id}",
+            f"Working directory: {os.getcwd()}",
+        ]
+        publish_event(
+            self._bus,
+            EventType.HELP_REQUESTED,
+            {"lines": lines},
             source=self.SOURCE,
         )
 

--- a/asat/notebook.py
+++ b/asat/notebook.py
@@ -98,6 +98,11 @@ class NotebookCursor:
         """Return the current focus state."""
         return self._state
 
+    @property
+    def session(self) -> Session:
+        """Return the underlying Session (read-only handle)."""
+        return self._session
+
     def move_up(self) -> Optional[Cell]:
         """Move to the previous cell. Returns the new cell or None."""
         return self._move(delta=-1)

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -230,6 +230,7 @@ discarded and the cell is not modified.
 | `:delete`    | Delete the focused cell (same as `d` in NOTEBOOK).   |
 | `:duplicate` | Duplicate the focused cell (same as `y` in NOTEBOOK).|
 | `:pwd`       | Announce the current working directory.              |
+| `:state`     | Narrate focus mode, cell position, session id, and cwd. |
 | `:commands`  | List every available meta-command.                   |
 | `:reset bank` | Reset the whole sound bank to the built-in defaults (also `:reset all`). |
 
@@ -507,6 +508,7 @@ Every key you need, one table.
 | INPUT      | `:delete`⏎        | Delete focused cell                   |
 | INPUT      | `:duplicate`⏎     | Duplicate focused cell                |
 | INPUT      | `:pwd`⏎           | Announce working directory            |
+| INPUT      | `:state`⏎         | Announce focus, cell position, cwd    |
 | INPUT      | `:commands`⏎      | List every meta-command               |
 | INPUT      | `:reset bank`⏎    | Reset the whole bank to defaults      |
 | OUTPUT     | Up / Down         | Prev / next line                      |

--- a/tests/test_input_router.py
+++ b/tests/test_input_router.py
@@ -784,6 +784,27 @@ class MetaCommandTests(unittest.TestCase):
         self.assertEqual(cursor.focus.mode, FocusMode.INPUT)
         self.assertEqual(cursor.focus.input_buffer, "")
 
+    def test_colon_state_reports_focus_mode_cell_position_and_cwd(self) -> None:
+        """`:state` emits a HELP_REQUESTED snapshot of "where am I?"."""
+        import os
+
+        bus, cursor, router, _controller = _build_with_settings(["", ""])
+        recorder = _Recorder(bus)
+        router.handle_key(ENTER)
+        for ch in ":state":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+        helps = recorder.types_of(EventType.HELP_REQUESTED)
+        self.assertEqual(len(helps), 1)
+        lines = helps[0].payload["lines"]
+        text = "\n".join(lines)
+        self.assertIn("Focus mode: input", text)
+        self.assertIn("cell 1 of 2", text)
+        self.assertIn(cursor.session.session_id, text)
+        self.assertIn(os.getcwd(), text)
+        self.assertEqual(cursor.focus.mode, FocusMode.INPUT)
+        self.assertEqual(cursor.focus.input_buffer, "")
+
     def test_colon_commands_lists_every_meta_command(self) -> None:
         """F17: `:commands` enumerates the full meta-command set."""
         from asat.input_router import META_COMMANDS


### PR DESCRIPTION
## Summary
- New ambient meta-command `:state` narrates focus mode, cell position (index of total), session id, and cwd in one HELP_REQUESTED block.
- Adds `NotebookCursor.session` read-only property so the router can introspect without reaching into private state.
- Documents the command in both meta-command tables in `USER_MANUAL.md`.

## Why
Hands-on test prep: when the user has lost track of which mode or cell they're in, `:state` answers the "where am I?" question in a single keystroke. Pairs with `:pwd` and `:commands`.

## Test plan
- [x] `python -m unittest discover -s tests -t .` → 818 passing
- [x] New positive case asserts focus/position/session/cwd all narrated
- [x] Existing `test_colon_commands_lists_every_meta_command` auto-asserts `:state` is listed (iterates `META_COMMANDS`)

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS