### PR TITLE
F49 hygiene: factor None-guards + name composer modes

### DIFF
--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -26,6 +26,7 @@ care about output navigation.
 from __future__ import annotations
 
 import difflib
+import functools
 import os
 import re
 from typing import Callable, Optional
@@ -44,6 +45,26 @@ from asat.settings_editor import ResetScope, SettingsEditorError
 
 BindingMap = dict[FocusMode, dict[Key, str]]
 ActionHandler = Callable[[], Optional[dict[str, object]]]
+
+
+def _requires_settings_controller(method: Callable[..., object]) -> Callable[..., object]:
+    """Skip the wrapped method when no SettingsController is configured.
+
+    The router is constructed without a controller when a session has
+    no settings UI wired up. Most `_settings_*` helpers exist only to
+    delegate one or two calls to that controller, so each one used to
+    repeat `if self._settings_controller is None: return`. This
+    decorator removes the noise: it short-circuits to None when the
+    controller is missing, otherwise calls through.
+    """
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if self._settings_controller is None:
+            return None
+        return method(self, *args, **kwargs)
+
+    return wrapper
 
 
 def _void(fn: Callable[..., object]) -> ActionHandler:
@@ -717,112 +738,106 @@ class InputRouter:
             source=self.SOURCE,
         )
 
+    @_requires_settings_controller
     def _open_settings(self) -> None:
         """Enter SETTINGS mode and open a controller session if available."""
-        if self._settings_controller is None:
-            return
         self._settings_controller.open()
         self._cursor.enter_settings_mode()
 
+    @_requires_settings_controller
     def _close_settings(self) -> None:
         """Close the controller and return to NOTEBOOK mode."""
-        if self._settings_controller is None:
-            return
         self._settings_controller.close()
         self._cursor.exit_settings_mode()
 
+    @_requires_settings_controller
     def _save_settings(self) -> None:
         """Persist the in-progress bank; no-op without a save path."""
-        if self._settings_controller is None:
-            return
         if self._settings_controller.save_path is None:
             return
         self._settings_controller.save()
 
+    @_requires_settings_controller
     def _settings_prev(self) -> None:
         """Move the settings cursor one step backward."""
-        if self._settings_controller is not None:
-            self._settings_controller.prev()
+        self._settings_controller.prev()
 
+    @_requires_settings_controller
     def _settings_next(self) -> None:
         """Move the settings cursor one step forward."""
-        if self._settings_controller is not None:
-            self._settings_controller.next()
+        self._settings_controller.next()
 
+    @_requires_settings_controller
     def _settings_descend(self) -> None:
         """Drop one level deeper into the settings hierarchy."""
-        if self._settings_controller is not None:
-            self._settings_controller.descend()
+        self._settings_controller.descend()
 
+    @_requires_settings_controller
     def _settings_ascend(self) -> None:
         """Rise one level; at the top, close the editor."""
-        if self._settings_controller is None:
-            return
         if not self._settings_controller.ascend():
             self._close_settings()
 
+    @_requires_settings_controller
     def _settings_begin_edit(self) -> None:
         """Start composing a replacement value for the focused field."""
-        if self._settings_controller is not None:
-            self._settings_controller.begin_edit()
+        self._settings_controller.begin_edit()
 
+    @_requires_settings_controller
     def _settings_edit_commit(self) -> Optional[dict[str, object]]:
         """Apply the in-progress edit buffer; surface errors in the payload."""
-        if self._settings_controller is None:
-            return None
         try:
             self._settings_controller.commit_edit()
             return {"ok": True}
         except SettingsEditorError as exc:
             return {"ok": False, "error": str(exc)}
 
+    @_requires_settings_controller
     def _settings_edit_cancel(self) -> None:
         """Discard the in-progress edit buffer."""
-        if self._settings_controller is not None:
-            self._settings_controller.cancel_edit()
+        self._settings_controller.cancel_edit()
 
+    @_requires_settings_controller
     def _settings_edit_backspace(self) -> None:
         """Remove the last character from the edit buffer."""
-        if self._settings_controller is not None:
-            self._settings_controller.backspace_edit()
+        self._settings_controller.backspace_edit()
 
+    @_requires_settings_controller
     def _settings_undo(self) -> None:
         """Revert the most recent edit via the settings controller."""
-        if self._settings_controller is not None:
-            self._settings_controller.undo()
+        self._settings_controller.undo()
 
+    @_requires_settings_controller
     def _settings_redo(self) -> None:
         """Re-apply the most recently undone edit via the settings controller."""
-        if self._settings_controller is not None:
-            self._settings_controller.redo()
+        self._settings_controller.redo()
 
+    @_requires_settings_controller
     def _settings_search_begin(self) -> Optional[dict[str, object]]:
         """Open the `/` search overlay; report whether it started."""
-        if self._settings_controller is None:
-            return None
         started = self._settings_controller.begin_search()
         return {"opened": started}
 
+    @_requires_settings_controller
     def _settings_search_commit(self) -> Optional[dict[str, object]]:
         """Apply the in-progress search; surface the query + match count."""
-        if self._settings_controller is None:
-            return None
         editor = self._settings_controller.editor
         query = editor.search_buffer
         match_count = editor.search_match_count
         self._settings_controller.commit_search()
         return {"query": query, "match_count": match_count}
 
+    @_requires_settings_controller
     def _settings_search_cancel(self) -> None:
         """Discard the in-progress search and restore the cursor."""
-        if self._settings_controller is not None:
-            self._settings_controller.cancel_search()
+        self._settings_controller.cancel_search()
 
+    @_requires_settings_controller
     def _settings_search_backspace(self) -> None:
         """Trim the last character from the search buffer."""
-        if self._settings_controller is not None:
-            self._settings_controller.backspace_search()
+        self._settings_controller.backspace_search()
 
+    @_requires_settings_controller
     def _settings_reset_begin(
         self, scope: Optional[ResetScope] = None
     ) -> Optional[dict[str, object]]:
@@ -834,8 +849,6 @@ class InputRouter:
         explicit scope arguments (`:reset record`, `:reset bank`, …)
         the caller passes the parsed enum value through.
         """
-        if self._settings_controller is None:
-            return None
         started = self._settings_controller.begin_reset(scope)
         payload: dict[str, object] = {"opened": started}
         active_scope = self._settings_controller.reset_scope
@@ -845,10 +858,9 @@ class InputRouter:
             payload["scope"] = scope.value
         return payload
 
+    @_requires_settings_controller
     def _settings_reset_confirm(self) -> Optional[dict[str, object]]:
         """Confirm the pending reset; report whether the bank changed."""
-        if self._settings_controller is None:
-            return None
         scope = self._settings_controller.reset_scope
         applied = self._settings_controller.confirm_reset()
         payload: dict[str, object] = {"applied": applied}
@@ -856,23 +868,21 @@ class InputRouter:
             payload["scope"] = scope.value
         return payload
 
+    @_requires_settings_controller
     def _settings_reset_cancel(self) -> None:
         """Cancel the pending reset; leave the bank untouched."""
-        if self._settings_controller is not None:
-            self._settings_controller.cancel_reset()
+        self._settings_controller.cancel_reset()
 
+    @_requires_settings_controller
     def _settings_search_next(self) -> Optional[dict[str, object]]:
         """Cycle to the next match; no-op without prior results."""
-        if self._settings_controller is None:
-            return None
         editor = self._settings_controller.editor
         matched = editor.next_search_match()
         return {"matched": matched}
 
+    @_requires_settings_controller
     def _settings_search_prev(self) -> Optional[dict[str, object]]:
         """Cycle to the previous match; no-op without prior results."""
-        if self._settings_controller is None:
-            return None
         editor = self._settings_controller.editor
         matched = editor.prev_search_match()
         return {"matched": matched}

--- a/asat/output_cursor.py
+++ b/asat/output_cursor.py
@@ -19,6 +19,7 @@ call move_to_start() to jump to the top of the output.
 
 from __future__ import annotations
 
+from enum import Enum
 from typing import Optional
 
 from asat.event_bus import EventBus, publish_event
@@ -27,6 +28,18 @@ from asat.output_buffer import OutputBuffer, OutputLine
 
 
 DEFAULT_PAGE_SIZE = 10
+
+
+class ComposerMode(str, Enum):
+    """Which overlay the OUTPUT-mode composer is currently driving.
+
+    Subclasses `str` so historic call sites (and tests) that compare
+    against the literals "search" / "goto" keep working without
+    needing to import the enum.
+    """
+
+    SEARCH = "search"
+    GOTO = "goto"
 
 
 class OutputCursor:
@@ -58,7 +71,7 @@ class OutputCursor:
         # persists after commit so `next_match` / `prev_match` can keep
         # cycling through hits until the user searches again or
         # detaches the cursor.
-        self._composer_mode: Optional[str] = None
+        self._composer_mode: Optional[ComposerMode] = None
         self._composer_buffer: str = ""
         self._search_matches: tuple[int, ...] = ()
         self._search_position: int = -1
@@ -140,8 +153,12 @@ class OutputCursor:
         return self._seek(len(self._buffer) - 1)
 
     @property
-    def composer_mode(self) -> Optional[str]:
-        """Return "search", "goto", or None when no composer is active."""
+    def composer_mode(self) -> Optional[ComposerMode]:
+        """Return ComposerMode.SEARCH, .GOTO, or None when idle.
+
+        Members compare equal to the legacy strings ("search", "goto")
+        for back-compat with callers and tests written before F49.
+        """
         return self._composer_mode
 
     @property
@@ -152,7 +169,11 @@ class OutputCursor:
     @property
     def search_query(self) -> str:
         """Return the query used by the most recent search (empty if none)."""
-        return self._composer_buffer if self._composer_mode == "search" else self._last_search_query
+        return (
+            self._composer_buffer
+            if self._composer_mode is ComposerMode.SEARCH
+            else self._last_search_query
+        )
 
     @property
     def search_match_count(self) -> int:
@@ -161,11 +182,11 @@ class OutputCursor:
 
     def begin_search(self) -> bool:
         """Enter SEARCH composer mode; returns False when no buffer lines."""
-        return self._begin_composer("search")
+        return self._begin_composer(ComposerMode.SEARCH)
 
     def begin_goto(self) -> bool:
         """Enter GOTO-LINE composer mode; returns False when no buffer lines."""
-        return self._begin_composer("goto")
+        return self._begin_composer(ComposerMode.GOTO)
 
     def extend_composer(self, char: str) -> None:
         """Append a character to the composer buffer.
@@ -180,10 +201,10 @@ class OutputCursor:
             return
         if len(char) != 1:
             raise ValueError("extend_composer expects exactly one character")
-        if self._composer_mode == "goto" and not char.isdigit():
+        if self._composer_mode is ComposerMode.GOTO and not char.isdigit():
             return
         self._composer_buffer += char
-        if self._composer_mode == "search":
+        if self._composer_mode is ComposerMode.SEARCH:
             self._recompute_matches(jump_to_first=True)
 
     def backspace_composer(self) -> None:
@@ -191,7 +212,7 @@ class OutputCursor:
         if self._composer_mode is None or not self._composer_buffer:
             return
         self._composer_buffer = self._composer_buffer[:-1]
-        if self._composer_mode == "search":
+        if self._composer_mode is ComposerMode.SEARCH:
             self._recompute_matches(jump_to_first=True)
 
     def commit_composer(self) -> Optional[OutputLine]:
@@ -208,7 +229,7 @@ class OutputCursor:
             return None
         buffer_text = self._composer_buffer
         self._composer_mode = None
-        if mode == "search":
+        if mode is ComposerMode.SEARCH:
             self._composer_buffer = ""
             self._last_search_query = buffer_text
             return self.current_line()
@@ -249,14 +270,14 @@ class OutputCursor:
         """Focus the given zero-based line number (clamped to the buffer)."""
         return self._seek(line_number)
 
-    def _begin_composer(self, mode: str) -> bool:
+    def _begin_composer(self, mode: ComposerMode) -> bool:
         """Shared entry point for `begin_search` and `begin_goto`."""
         if self._buffer is None or len(self._buffer) == 0:
             return False
         self._composer_mode = mode
         self._composer_buffer = ""
         self._composer_origin = self._index
-        if mode == "search":
+        if mode is ComposerMode.SEARCH:
             self._search_matches = ()
             self._search_position = -1
         return True

--- a/tests/test_output_cursor.py
+++ b/tests/test_output_cursor.py
@@ -7,7 +7,7 @@ import unittest
 from asat.event_bus import EventBus
 from asat.events import Event, EventType
 from asat.output_buffer import OutputBuffer, STDERR, STDOUT
-from asat.output_cursor import OutputCursor
+from asat.output_cursor import ComposerMode, OutputCursor
 
 
 class _Recorder:
@@ -171,6 +171,13 @@ class SearchComposerTests(unittest.TestCase):
         cursor.attach(OutputBuffer("empty"))
         self.assertFalse(cursor.begin_search())
         self.assertIsNone(cursor.composer_mode)
+
+    def test_composer_mode_is_composermode_enum(self) -> None:
+        """F49: composer_mode returns a ComposerMode (str-equatable)."""
+        self.cursor.begin_search()
+        self.assertIs(self.cursor.composer_mode, ComposerMode.SEARCH)
+        # Back-compat: the enum still compares equal to the legacy literal.
+        self.assertEqual(self.cursor.composer_mode, "search")
 
     def test_extend_jumps_to_first_match_live(self) -> None:
         self.cursor.begin_search()


### PR DESCRIPTION
## Summary
Two F49 hygiene bullets, both no-behaviour-change refactors:

- **`_requires_settings_controller` decorator** in `asat/input_router.py` replaces the repeated `if self._settings_controller is None: return` boilerplate across ~17 `_settings_*` delegate methods.
- **`ComposerMode(str, Enum)`** in `asat/output_cursor.py` replaces the `"search"` / `"goto"` magic strings. Subclassing `str` keeps every existing equality comparison (in code and tests) working unchanged.

## Test plan
- [x] `python -m unittest discover -s tests -t .` → 825 passing
- [x] New regression test asserts `composer_mode` returns the enum identity and still equals the legacy string
- [x] All existing settings-controller tests pass without modification (decorator preserves call semantics)

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS