### PR TITLE
HANDOFF: replace brittle test count with a pointer

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -35,7 +35,9 @@ meta-command, and cue that ships today).
 python -m unittest discover -s tests -t .
 ```
 
-Currently **816 passing**.
+All tests live under `tests/`; run the command above to see the
+current pass count. Every PR adds or touches whatever coverage
+the change warrants — don't hand-maintain a count here.
 
 ## Suggested next PR
 


### PR DESCRIPTION
## Summary
The "Currently **816 passing**" line in HANDOFF.md drifted every time tests landed and was causing HANDOFF to churn with no information gain. Replaces it with a pointer that tells the next session to run `python -m unittest discover -s tests -t .` and look at `tests/` directly.

## Test plan
- [x] Docs-only; no code affected.

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS