### PR TITLE
fix: attach output buffer on Ctrl+O so OUTPUT-mode nav works standalone

### DIFF
--- a/asat/app.py
+++ b/asat/app.py
@@ -184,6 +184,7 @@ class Application:
             output_cursor=output_cursor,
             settings_controller=settings_controller,
             action_menu=action_menu,
+            output_recorder=recorder,
         )
         resolved_sink: AudioSink = sink if sink is not None else MemorySink()
         sound_engine = SoundEngine(bus, resolved_bank, resolved_sink)

--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -38,6 +38,7 @@ from asat.events import EventType
 from asat.help_topics import HELP_TOPICS, lookup as lookup_help_topic, topic_names
 from asat.keys import Key, Modifier
 from asat.notebook import FocusMode, NotebookCursor
+from asat.output_buffer import OutputRecorder
 from asat.output_cursor import OutputCursor
 from asat.settings_controller import SettingsController
 from asat.settings_editor import ResetScope, SettingsEditorError
@@ -282,6 +283,7 @@ class InputRouter:
         output_cursor: Optional[OutputCursor] = None,
         settings_controller: Optional[SettingsController] = None,
         action_menu: Optional[ActionMenu] = None,
+        output_recorder: Optional[OutputRecorder] = None,
     ) -> None:
         """Attach the router to a cursor, event bus, and optional cursors.
 
@@ -297,6 +299,13 @@ class InputRouter:
         focused item, and Escape closes the menu without activating.
         Without an `action_menu` the `open_action_menu` action is a
         silent no-op.
+
+        When an `output_recorder` is supplied alongside `output_cursor`,
+        the `view_output` action (Ctrl+O) attaches the cursor to the
+        focused cell's buffer on transition, so Up/Down/`/`/`g` work
+        immediately without the user having to route through the F2
+        action menu first. Without it, Ctrl+O still flips the focus
+        mode but navigation keys no-op until something else attaches.
         """
         self._cursor = cursor
         self._bus = bus
@@ -304,6 +313,7 @@ class InputRouter:
         self._output_cursor = output_cursor
         self._settings_controller = settings_controller
         self._action_menu = action_menu
+        self._output_recorder = output_recorder
 
     @property
     def bindings(self) -> BindingMap:
@@ -738,6 +748,23 @@ class InputRouter:
             source=self.SOURCE,
         )
 
+    def _view_output(self) -> None:
+        """Enter OUTPUT mode and attach the output cursor to the cell's buffer.
+
+        Captures the focused cell id BEFORE the mode transition (which
+        may clear it) so the buffer attach lands on the right cell.
+        With no output_cursor / output_recorder wired, falls back to
+        the old behaviour of simply transitioning focus.
+        """
+        cell_id = self._cursor.focus.cell_id
+        self._cursor.view_output_mode()
+        if (
+            self._output_cursor is not None
+            and self._output_recorder is not None
+            and cell_id is not None
+        ):
+            self._output_cursor.attach(self._output_recorder.buffer_for(cell_id))
+
     @_requires_settings_controller
     def _open_settings(self) -> None:
         """Enter SETTINGS mode and open a controller session if available."""
@@ -970,7 +997,7 @@ class InputRouter:
             "delete_word_left": _void(self._cursor.delete_word_left),
             "delete_to_start": _void(self._cursor.delete_to_start),
             "delete_to_end": _void(self._cursor.delete_to_end),
-            "view_output": _void(self._cursor.view_output_mode),
+            "view_output": _void(self._view_output),
             "exit_output": _void(self._cursor.exit_output_mode),
             "submit": self._submit,
             "output_line_up": lambda: self._with_output_cursor(

--- a/tests/test_smoke_scenarios.py
+++ b/tests/test_smoke_scenarios.py
@@ -280,6 +280,30 @@ class Act5OutputModeTests(unittest.TestCase):
         texts = [e.payload["text"] for e in appended]
         self.assertEqual(texts, ["line a", "line b", "line c"])
 
+    def test_ctrl_o_attaches_buffer_and_up_navigates(self) -> None:
+        """End-to-end keyboard-only path into OUTPUT mode: Ctrl+O not
+        only flips focus mode but attaches the output cursor to the
+        focused cell's buffer, so Up/Down work immediately without
+        routing through the F2 action menu. This is the behaviour
+        SMOKE_TEST.md Act 5.2 promises."""
+        fx = _ScenarioFixture(stdout="line a\nline b\nline c\n", exit_code=0)
+        fx.type_text("produce lines")
+        fx.submit()
+        fx.press(kc.ESCAPE)
+        fx.press(kc.UP)  # back to the completed cell
+        fx.press(Key.combo("o", Modifier.CTRL))
+
+        # Attach should have fired an initial OUTPUT_LINE_FOCUSED
+        # landing on the last line.
+        focused = fx.types_of(EventType.OUTPUT_LINE_FOCUSED)
+        self.assertGreaterEqual(len(focused), 1)
+        self.assertEqual(focused[-1].payload["line_number"], 2)
+
+        before = len(focused)
+        fx.press(kc.UP)
+        after = len(fx.types_of(EventType.OUTPUT_LINE_FOCUSED))
+        self.assertGreater(after, before, "Up in OUTPUT did not focus a new line")
+
 
 # -------------------------------------------------------------------
 # Act 6 — Meta-commands and discoverability


### PR DESCRIPTION
## Summary
- Ctrl+O flipped focus to OUTPUT mode but never attached the `OutputCursor` to the focused cell's buffer, so Up/Down, `/`, and `g` silently no-op'd in fresh sessions — the only path that attached the buffer went through the F2 action menu.
- This would have been the very first broken impression for any blind user following `docs/SMOKE_TEST.md` Act 5.2, which promises navigation works the moment Ctrl+O lands.
- Adds `InputRouter._view_output` that captures the focused cell id, transitions the cursor, then attaches via `OutputRecorder.buffer_for(cell_id)`. `Application.build` threads the recorder into the router so defaults wire up automatically; the parameter is optional so existing bare-router tests still pass.
- Scenario coverage: new `test_ctrl_o_attaches_buffer_and_up_navigates` drives the exact keystrokes from the smoke test.

## Test plan
- [x] `python -m unittest tests.test_smoke_scenarios` — 21/21 pass (new Ctrl+O scenario passes)
- [x] `python -m unittest discover -s tests` — 847/847 pass, no regressions
- [ ] Manual: walk through SMOKE_TEST.md Act 5.2 in a live terminal and confirm *"output, line N of N"* narration fires on Ctrl+O with no F2 detour.

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS