### PR TITLE
docs: clarify what a cell is + file F60 (shared backend) and F61 (hierarchy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ highlight, an ANSI event — flows through one synchronous event bus
 and can be bound to a spoken phrase or a spatialised tone. Keyboard
 only, standard-library only, no mouse, no screen coordinates.
 
+**What "notebook-style" means here.** An ordered list of editable
+cells per session, each with its own captured stdout/stderr and
+exit code, persisted to JSON. Navigate, reorder, duplicate, and
+re-run cells from the keyboard. Each cell runs as its own one-shot
+subprocess — there is no shared shell or persistent REPL across
+cells today, and cells do not host interactive (PTY) programs like
+`vim`. See [docs/USER_MANUAL.md](docs/USER_MANUAL.md#what-a-cell-is-and-is-not-today)
+for the precise contract; the persistent-backend and section /
+hierarchy gaps are tracked as
+[F60](docs/FEATURE_REQUESTS.md#f60--persistent-computational-backend-shared-shell--repl)
+and
+[F61](docs/FEATURE_REQUESTS.md#f61--cell-hierarchy-sections-folds-and-grouping).
+
 ## Install and run
 
 Requires Python 3.10 or newer. No runtime dependencies (`numpy` is an

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -3255,6 +3255,111 @@ user files a concrete motivator.
 
 ---
 
+## F60 — Persistent computational backend (shared shell / REPL)
+
+**Gap.** Each cell launches its own one-shot `subprocess.Popen` via
+`asat/runner.py:48`. There is no carried state between cells: an
+`export X=hi` in cell 1 is gone by cell 2, `cd /tmp` does not change
+the cwd of any later cell, and there is no persistent Python / Node
+/ shell process the user can build state inside (no Jupyter-style
+kernel, no `tmux send-keys` model). Every cell is effectively a
+fresh `bash -c "<command>"` with the inherited environment of the
+ASAT process and nothing else.
+
+**Where it surfaces.** A blind developer who reasonably expects a
+"notebook of terminal cells" to behave like a single shell session
+runs `cd src` in cell 1, then `ls` in cell 2, and gets the
+launch-time cwd back instead of `src/`. Same with virtualenv
+activation, `source ~/.profile`, in-flight Python state, etc. Today
+USER_MANUAL.md does not state the limitation; the new
+"What a cell *is* (and is not) today" section calls it out and
+links here.
+
+**Sketch.** Give `Session` an optional `backend` (a long-lived
+subprocess) that cells route their command through instead of each
+spawning their own. The simplest first cut is a dedicated shell
+process (`bash -i` / `cmd /K`) addressed by writing to its stdin
+and framing output with sentinel markers (printf a known UUID
+before/after each command so the runner knows when output ends and
+can read the exit code). A richer second cut wraps the
+Jupyter-kernel protocol so non-shell kernels (IPython, Node, etc.)
+work the same way. Either way, the kernel is per-Session, restarts
+explicitly on `:restart` or when corrupted, and old transcripts
+remain valid because each cell still records its captured output
+and exit code.
+
+**Forward-looking notes.**
+
+- **Backend is a session-level setting.** A user might want
+  `bash` here and `ipython` there; record the chosen backend in
+  the Session JSON so resumes pick the same one back up.
+- **Per-cell override.** A `:backend none` meta-command (or a
+  cell-level flag) keeps the existing fresh-subprocess behaviour
+  for one-off invocations like `git status` where shared state
+  is irrelevant or actively unwanted.
+- **Restart semantics.** Crashed kernels need a clear narration
+  ("backend exited code N — press Ctrl+R to restart") and a
+  way to mark every downstream cell as "ran against a different
+  process" so a future re-run does not silently inherit different
+  state.
+- **Security.** A long-lived shell amplifies the blast radius of
+  whatever the user types. Document it; never auto-run cells from
+  a loaded session against the new backend without an explicit
+  prompt.
+
+---
+
+## F61 — Cell hierarchy: sections, folds, and grouping
+
+**Gap.** `Session.cells` is a flat ordered list. There is no
+parent/child relationship, no section header that groups several
+cells together, no fold/collapse, no "this cell depends on that
+cell". The only navigation primitive is "previous / next cell
+linearly" (`asat/notebook.py:546-559`).
+
+**Where it surfaces.** A long session — say twenty exploratory
+shell commands followed by ten cells of a Python data pull —
+walks as a single flat list. A user who wants to "jump back to
+the data-pull section" has to remember roughly where it started
+and Up-arrow there. There is no "collapse the chunk I'm not
+working on", no folding for navigation by section, and no parent
+context narrated when entering a cell.
+
+**Sketch.** Two layered changes, either one shippable on its
+own.
+
+1. **Section headers (lightweight).** Add a new `CellKind`
+   discriminator on `Cell` (`SECTION` vs the existing
+   `COMMAND`). A section cell carries a title string, no
+   command, no output. NOTEBOOK navigation gains
+   "previous / next section" (Ctrl+Up / Ctrl+Down) and the
+   `:state` meta-command additionally narrates "section: <title>"
+   when the cursor is inside one. Sections do not nest in the
+   first cut.
+2. **Folding (deeper).** Each section can be collapsed; while
+   collapsed, Up/Down skips its children and the narrator says
+   "section <title>, <N> cells, collapsed". A `z` keystroke at
+   a section header toggles the fold, mirroring vim.
+
+**Forward-looking notes.**
+
+- **Nested sections.** Real-world workflows want subsections
+  (a top-level "data" section with "load" and "clean"
+  subsections). Defer to a v2 once the flat case settles —
+  nesting adds focus-restoration complexity (where does the
+  cursor land after collapsing the parent of where you were?).
+- **Cross-cell dependencies.** Once F60 ships a persistent
+  backend, sections become natural dependency boundaries (a
+  "setup" section everyone re-runs, a "scratch" section nobody
+  does). Worth recording but out of scope for a first pass.
+- **Macro interaction.** F56's `expect`/`capture` steps will
+  want a way to address "every cell in section X" — give
+  sections stable ids, not just titles.
+- **Persistence.** Bump the `Session` JSON schema_version when
+  sections land so loaders can detect old files cleanly.
+
+---
+
 ## How to add an entry
 
 Append a section using the template:

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -145,6 +145,42 @@ each step.
 
 ---
 
+## What a cell *is* (and is not) today
+
+ASAT is a notebook in the sense that you have an ordered list of
+cells per session, each cell is editable, each remembers its own
+captured stdout/stderr and exit code, and the whole list saves to
+JSON with `--session file.json`. You can navigate, reorder,
+duplicate, and delete cells without leaving the keyboard.
+
+It is **not** Jupyter. Two limits to be aware of from day one:
+
+1. **Each cell runs in a fresh subprocess.** `export FOO=bar` in
+   cell 1 is gone by cell 2. `cd /tmp` does not change the cwd of
+   any later cell. There is no persistent Python REPL or shared
+   shell sitting behind the cells — every command you submit
+   launches its own `subprocess.Popen`, inherits the ASAT process's
+   environment, and exits. If you need shared state today, fold it
+   into a single cell (e.g. `cd src && python script.py`). A
+   persistent computational backend is tracked as
+   [F60](FEATURE_REQUESTS.md#f60--persistent-computational-backend-shared-shell--repl).
+2. **Cells are not interactive terminals (no PTY).** A cell is a
+   command string plus its captured output and exit code. Programs
+   that take over the screen — `vim`, `less`, `top`, `python`
+   without `-c`, anything curses-based — will not work inside a
+   cell. Use a one-shot invocation (`python -c '...'`,
+   `git --no-pager log`) instead.
+3. **Cells are a flat ordered list.** No sections, no folding, no
+   parent/child grouping. Up / Down walks every cell linearly.
+   Sections and folds are tracked as
+   [F61](FEATURE_REQUESTS.md#f61--cell-hierarchy-sections-folds-and-grouping).
+
+Within those limits the notebook surface is real: edit a previous
+cell, re-run it, walk its captured output line by line in OUTPUT
+mode, save the session, resume it tomorrow with every cell intact.
+
+---
+
 ## Focus modes
 
 You are always in exactly one of four modes. The current mode


### PR DESCRIPTION
## Summary
Set straight expectations for the notebook surface so first-time users know what they're getting and what's still aspirational. The codebase already ships real notebook mechanics — per-session ordered cell list, per-cell captured stdout/stderr/exit code, navigate/reorder/duplicate/delete, save-and-resume. The docs glossed over two limits people implicitly expect from "notebook of terminals":

- **No persistent computational backend.** Each cell launches its own one-shot `subprocess.Popen` (`asat/runner.py:48-57`), so `cd`, `export`, virtualenv activation, and in-flight REPL state do not carry from cell to cell.
- **No hierarchy.** `Session.cells` is a flat ordered list — no sections, folds, or grouping.
- (Bonus, also called out: cells aren't PTYs, so `vim`/`less`/curses can't run inside one.)

Changes:
- **`docs/USER_MANUAL.md`** — new "What a cell *is* (and is not) today" section above Focus modes that names all three limits and links to the feature requests.
- **`README.md`** — extra paragraph after the tagline grounding "notebook-style" in concrete capabilities + the F60 / F61 trackers.
- **`docs/FEATURE_REQUESTS.md`** — adds **F60** (persistent computational backend; first cut: long-lived `bash` with sentinel framing, second cut: Jupyter kernel protocol) and **F61** (cell hierarchy; flat sections shippable on its own, folding/nesting deferred to v2).

## Test plan
- [x] `python -m unittest discover -s tests` — 847/847, no behaviour changed
- [ ] Skim the rendered USER_MANUAL.md and confirm the new section sits naturally above Focus modes

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS