### PR TITLE
F60 (PR A): ShellBackend — persistent shell runner module

### DIFF
--- a/asat/shell_backend.py
+++ b/asat/shell_backend.py
@@ -1,0 +1,408 @@
+"""Persistent shell backend: one long-lived shell per session.
+
+ASAT's `ProcessRunner` spawns a fresh `subprocess.Popen` per cell, so
+state never carries: `cd /tmp` in cell 1 does not change the cwd of
+cell 2, `export X=1` in cell 1 leaves cell 2 with no `$X`. This module
+introduces an alternative runner — `ShellBackend` — that holds one
+long-lived shell process for the whole session and threads each cell's
+command through it via the shell's own stdin. The shell sees a single
+session of commands, exactly as a human typing into a terminal would,
+so all the state a real shell maintains (cwd, exported variables,
+function definitions, set options, alias definitions) carries between
+cells naturally.
+
+The backend mirrors `ProcessRunner.run`'s contract — same arguments,
+same `ExecutionResult` return — so the kernel can swap one for the
+other without further changes. The trade-off is that a long-lived
+shell amplifies blast radius: a `set -e`, a stuck `read`, or a
+runaway `while true` cannot be killed by waiting for the next
+command's `subprocess.wait()` to return; the backend handles those
+cases by enforcing the request's `timeout_seconds` and, on timeout,
+sending SIGINT into the shell to break the running command without
+killing the shell itself.
+
+Sentinel framing
+----------------
+Each command submission writes three lines to the shell's stdin:
+
+    <command>
+    printf "\\n__ASAT_SHELL_END_<uuid>__:%d\\n" "$?"
+    printf "__ASAT_SHELL_ERR_<uuid>__\\n" >&2
+
+The reader threads (one per stream) push lines into queues until they
+see the sentinel for their stream, then signal an event. `run()`
+collects everything that arrived on stdout / stderr before the
+sentinel, returns it as a single `ExecutionResult`, and the next
+command starts cleanly. Sentinels never reach the caller — they are
+stripped at the reader-thread layer.
+
+POSIX only in this first cut. A `ShellBackend(shell="cmd")` Windows
+adapter is a separate follow-up (the sentinel approach works the
+same way; only the framing strings change).
+"""
+
+from __future__ import annotations
+
+import os
+import queue
+import shutil
+import signal
+import subprocess
+import threading
+import uuid
+from io import StringIO
+from typing import Optional
+
+from asat.execution import ExecutionMode, ExecutionRequest, ExecutionResult
+from asat.runner import LineHandler
+
+
+_SENTINEL_OUT_PREFIX = "__ASAT_SHELL_END_"
+_SENTINEL_ERR_PREFIX = "__ASAT_SHELL_ERR_"
+
+
+class ShellBackendError(RuntimeError):
+    """Raised when the backing shell process is unusable.
+
+    Two distinct conditions raise this: (1) the shell exits between
+    commands, leaving the backend with no process to dispatch the
+    next request to; (2) the shell crashes mid-command, before both
+    sentinel markers have arrived. Callers above the kernel should
+    catch this and decide whether to surface a `BACKEND_EXITED`
+    event and restart, or to give up.
+    """
+
+
+class ShellBackend:
+    """A long-lived shell that ASAT routes every cell command through.
+
+    Construction launches the shell. Every subsequent `run()` call
+    writes one command to the shell's stdin, waits for the sentinel
+    pair, and returns the captured stdout / stderr / exit code.
+    `close()` exits the shell cleanly. The backend serialises
+    submissions internally — concurrent `run()` calls block on a
+    lock — because a single shell can only execute one command at a
+    time anyway.
+    """
+
+    SHELL_DEFAULT_ARGV = ("bash", "--norc", "--noprofile")
+
+    def __init__(
+        self,
+        shell: Optional[tuple[str, ...]] = None,
+        env: Optional[dict[str, str]] = None,
+        cwd: Optional[str] = None,
+    ) -> None:
+        """Spawn the backing shell process.
+
+        `shell` is the argv tuple used to launch the shell. Defaults
+        to `bash --norc --noprofile` so the user's dotfiles do not
+        interfere with the sentinel protocol. `env` and `cwd` are
+        passed through to `subprocess.Popen`; pass `None` to inherit
+        the parent's environment / working directory.
+
+        The shell is launched in its own session (`start_new_session
+        =True`) so SIGINT during a timeout reaches the running
+        foreground child via `killpg`, and `trap : INT` is set on
+        the shell itself so the same SIGINT runs a no-op handler in
+        bash (which therefore survives) but resets to the default
+        disposition in any child process across `exec` — so the
+        running command exits with 130, exactly like Ctrl+C at a
+        real prompt. (We use a `:` handler rather than `trap ''
+        INT`; the latter would set SIG_IGN, which `exec` *preserves*
+        in children, so the running command would also ignore the
+        signal.)
+
+        Raises `ShellBackendError` if the named shell is not on PATH
+        — the fallback chain (bash → sh) is the caller's
+        responsibility, not the backend's.
+        """
+        argv = list(shell) if shell is not None else list(self.SHELL_DEFAULT_ARGV)
+        if shutil.which(argv[0]) is None:
+            raise ShellBackendError(f"shell {argv[0]!r} not found on PATH")
+        self._argv = tuple(argv)
+        self._proc = subprocess.Popen(
+            argv,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            cwd=cwd,
+            text=True,
+            bufsize=1,
+            start_new_session=True,
+        )
+        self._lock = threading.Lock()
+        self._stdout_queue: queue.Queue[Optional[tuple[str, str]]] = queue.Queue()
+        self._stderr_queue: queue.Queue[Optional[tuple[str, str]]] = queue.Queue()
+        self._stdout_thread = threading.Thread(
+            target=self._pump,
+            args=(self._proc.stdout, self._stdout_queue, _SENTINEL_OUT_PREFIX),
+            daemon=True,
+        )
+        self._stderr_thread = threading.Thread(
+            target=self._pump,
+            args=(self._proc.stderr, self._stderr_queue, _SENTINEL_ERR_PREFIX),
+            daemon=True,
+        )
+        self._stdout_thread.start()
+        self._stderr_thread.start()
+        # Install a no-op SIGINT handler in the shell so it survives a
+        # timeout-driven killpg(SIGINT). `exec` in the foreground child
+        # resets the handler to SIG_DFL, so the child still takes the
+        # signal and exits 130 as expected.
+        try:
+            assert self._proc.stdin is not None
+            self._proc.stdin.write("trap : INT\n")
+            self._proc.stdin.flush()
+        except (BrokenPipeError, ValueError) as exc:
+            raise ShellBackendError("shell backend stdin closed at startup") from exc
+
+    @property
+    def argv(self) -> tuple[str, ...]:
+        """The argv used to launch the backing shell, for diagnostics."""
+        return self._argv
+
+    def is_alive(self) -> bool:
+        """Return True if the backing shell process is still running."""
+        return self._proc.poll() is None
+
+    def run(
+        self,
+        request: ExecutionRequest,
+        stdout_handler: Optional[LineHandler] = None,
+        stderr_handler: Optional[LineHandler] = None,
+    ) -> ExecutionResult:
+        """Execute one command in the persistent shell.
+
+        Mirrors `ProcessRunner.run`'s signature so the kernel can
+        treat `ShellBackend` as a drop-in replacement. `request.mode`
+        is ignored — the backend is intrinsically a shell, so every
+        command is shell-evaluated. `request.cwd` and `request.env`
+        are also ignored on a per-call basis: the shell carries its
+        own cwd and env across calls (that is the whole point), and
+        per-call overrides would defeat the persistence model. Use
+        `cd` and `export` inside the cell to change them.
+
+        `request.timeout_seconds`, when set, fires SIGINT into the
+        shell after the deadline — interrupting the running command
+        without killing the shell, exactly like Ctrl+C at a real
+        prompt. The sentinel still arrives once the interrupted
+        command's wrapper code runs.
+        """
+        if not request.command.strip():
+            raise ValueError("Command is empty")
+        if not self.is_alive():
+            raise ShellBackendError("shell backend is not running")
+        with self._lock:
+            return self._run_locked(request, stdout_handler, stderr_handler)
+
+    def close(self) -> None:
+        """Exit the shell cleanly; force-terminate after a short grace."""
+        if self._proc.poll() is None:
+            try:
+                assert self._proc.stdin is not None
+                self._proc.stdin.write("exit\n")
+                self._proc.stdin.flush()
+            except (BrokenPipeError, ValueError):
+                pass
+            try:
+                self._proc.wait(timeout=2.0)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+                self._proc.wait()
+        # Always close the pipe handles even when the shell has
+        # already exited on its own — otherwise the still-open stdin
+        # FD trips ResourceWarning under unittest.
+        for stream in (self._proc.stdin, self._proc.stdout, self._proc.stderr):
+            if stream is not None:
+                try:
+                    stream.close()
+                except Exception:
+                    pass
+        # Reader threads exit on EOF; join briefly so tests are clean.
+        self._stdout_thread.join(timeout=1.0)
+        self._stderr_thread.join(timeout=1.0)
+
+    def _run_locked(
+        self,
+        request: ExecutionRequest,
+        stdout_handler: Optional[LineHandler],
+        stderr_handler: Optional[LineHandler],
+    ) -> ExecutionResult:
+        """Inner run loop; caller holds `self._lock`."""
+        token = uuid.uuid4().hex
+        sentinel_out = f"{_SENTINEL_OUT_PREFIX}{token}__"
+        sentinel_err = f"{_SENTINEL_ERR_PREFIX}{token}__"
+        framed = (
+            f"{request.command}\n"
+            f'printf "\\n{sentinel_out}:%d\\n" "$?"\n'
+            f'printf "{sentinel_err}\\n" >&2\n'
+        )
+        assert self._proc.stdin is not None
+        try:
+            self._proc.stdin.write(framed)
+            self._proc.stdin.flush()
+        except (BrokenPipeError, ValueError) as exc:
+            raise ShellBackendError("shell backend stdin closed") from exc
+
+        stdout_buf = StringIO()
+        stderr_buf = StringIO()
+        timed_out = False
+        deadline_thread: Optional[threading.Thread] = None
+        if request.timeout_seconds is not None:
+            timer = threading.Timer(
+                request.timeout_seconds, self._interrupt_running_command
+            )
+            timer.daemon = True
+            timer.start()
+            deadline_thread = timer
+
+        exit_code = self._collect(
+            self._stdout_queue,
+            sentinel_out,
+            stdout_buf,
+            stdout_handler,
+            expect_exit_code=True,
+        )
+        self._collect(
+            self._stderr_queue,
+            sentinel_err,
+            stderr_buf,
+            stderr_handler,
+            expect_exit_code=False,
+        )
+
+        if deadline_thread is not None:
+            deadline_thread.cancel()
+            # An interrupted command exits with 130 (128 + SIGINT) on bash;
+            # surface that as timed_out=True so the caller's audio routing
+            # matches the existing ProcessRunner timeout contract.
+            if exit_code == 130:
+                timed_out = True
+
+        return ExecutionResult(
+            stdout=stdout_buf.getvalue(),
+            stderr=stderr_buf.getvalue(),
+            exit_code=exit_code,
+            timed_out=timed_out,
+        )
+
+    def _collect(
+        self,
+        source: "queue.Queue[Optional[tuple[str, str]]]",
+        sentinel: str,
+        buffer: StringIO,
+        handler: Optional[LineHandler],
+        *,
+        expect_exit_code: bool,
+    ) -> int:
+        """Drain a stream queue until the sentinel arrives.
+
+        Returns the parsed exit code when `expect_exit_code` is True
+        (stdout sentinel carries `:<n>` after it). For the stderr
+        path the value is meaningless and 0 is returned.
+        """
+        while True:
+            item = source.get()
+            if item is None:
+                raise ShellBackendError(
+                    "shell backend stream closed before command completed"
+                )
+            kind, line = item
+            if kind == "sentinel":
+                if expect_exit_code:
+                    try:
+                        return int(line.split(":", 1)[1])
+                    except (IndexError, ValueError) as exc:
+                        raise ShellBackendError(
+                            f"malformed sentinel: {line!r}"
+                        ) from exc
+                return 0
+            buffer.write(line)
+            if handler is not None:
+                handler(line)
+
+    def _interrupt_running_command(self) -> None:
+        """Send SIGINT to the shell's process group so the foreground child gets Ctrl+C.
+
+        The shell was started with `start_new_session=True`, so its
+        pid is the leader of its own process group. `killpg` reaches
+        the shell *and* its current foreground child. The shell has
+        `trap '' INT` set, so it ignores the signal; the child runs
+        with the default disposition and exits with 130. The shell
+        survives, ready for the next command.
+        """
+        if not self.is_alive():
+            return
+        try:
+            os.killpg(self._proc.pid, signal.SIGINT)
+        except (ProcessLookupError, OSError):
+            pass
+
+    @staticmethod
+    def _pump(
+        stream,
+        sink: "queue.Queue[Optional[tuple[str, str]]]",
+        sentinel_prefix: str,
+    ) -> None:
+        """Read one stream until EOF, tagging sentinel lines for the collector.
+
+        Lines whose first token starts with `sentinel_prefix` are
+        forwarded as `("sentinel", <full-line-without-newline>)`.
+        Every other line is forwarded as `("line", <line>)` with
+        its trailing newline preserved. EOF emits a single `None`
+        so the collector can detect the shell crashing.
+
+        One previous line is buffered so we can drop the single
+        framing newline that precedes every sentinel — `printf
+        "\\n<sentinel>..."` writes that `\\n` so the sentinel is
+        guaranteed to start at column 0 even when the user command
+        ended without a trailing newline. Without the buffer that
+        framing `\\n` would surface to callers as a phantom empty
+        line at the end of every command's output.
+        """
+        if stream is None:
+            sink.put(None)
+            return
+        pending: Optional[str] = None
+        try:
+            for raw in stream:
+                stripped = raw.rstrip("\n")
+                if stripped.startswith(sentinel_prefix):
+                    if pending is not None and pending != "\n":
+                        sink.put(("line", pending))
+                    pending = None
+                    sink.put(("sentinel", stripped))
+                    continue
+                if pending is not None:
+                    sink.put(("line", pending))
+                pending = raw
+        finally:
+            if pending is not None:
+                sink.put(("line", pending))
+            sink.put(None)
+            try:
+                stream.close()
+            except Exception:
+                pass
+
+
+def shell_backend_or_none(
+    shell: Optional[tuple[str, ...]] = None,
+    env: Optional[dict[str, str]] = None,
+    cwd: Optional[str] = None,
+) -> Optional[ShellBackend]:
+    """Try to construct a ShellBackend; return None if not feasible.
+
+    Used by the CLI / `Application.build` to opportunistically enable
+    persistent-shell mode without crashing on systems where bash is
+    missing (Windows out of the box, stripped containers). Falls back
+    to the per-cell `ProcessRunner` model when None is returned.
+    """
+    if os.name == "nt":
+        return None
+    try:
+        return ShellBackend(shell=shell, env=env, cwd=cwd)
+    except ShellBackendError:
+        return None

--- a/tests/test_shell_backend.py
+++ b/tests/test_shell_backend.py
@@ -1,0 +1,195 @@
+"""Tests for ShellBackend — the persistent-shell runner for F60.
+
+These tests exercise the real `bash` on the host. Skipped on Windows
+or when bash is missing so the suite stays green in those environments.
+The ProcessRunner-equivalent contract (line streaming, exit codes,
+empty-command rejection) is verified, plus the F60-specific
+guarantees: state carries between calls (cd, export, function
+definition), sentinels never leak to the caller, malformed shell
+output surfaces as `ShellBackendError`, and a timed-out command
+interrupts without killing the shell.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import unittest
+
+from asat.execution import ExecutionRequest
+from asat.shell_backend import (
+    ShellBackend,
+    ShellBackendError,
+    shell_backend_or_none,
+)
+
+
+_BASH = shutil.which("bash")
+_REQUIRES_BASH = unittest.skipUnless(
+    _BASH is not None and os.name != "nt",
+    "ShellBackend tests require bash on a POSIX host",
+)
+
+
+@_REQUIRES_BASH
+class ShellBackendBasicTests(unittest.TestCase):
+    """Round-trip: a single command, line streaming, exit codes."""
+
+    def setUp(self) -> None:
+        self.backend = ShellBackend()
+        self.addCleanup(self.backend.close)
+
+    def test_echo_returns_stdout_with_zero_exit(self) -> None:
+        result = self.backend.run(ExecutionRequest(command="echo hello"))
+        self.assertEqual(result.stdout.strip(), "hello")
+        self.assertEqual(result.stderr, "")
+        self.assertEqual(result.exit_code, 0)
+        self.assertFalse(result.timed_out)
+
+    def test_nonzero_exit_propagates(self) -> None:
+        result = self.backend.run(ExecutionRequest(command="false"))
+        self.assertEqual(result.exit_code, 1)
+        self.assertFalse(result.timed_out)
+
+    def test_stderr_separated_from_stdout(self) -> None:
+        result = self.backend.run(
+            ExecutionRequest(command="echo out; echo err >&2")
+        )
+        self.assertEqual(result.stdout.strip(), "out")
+        self.assertEqual(result.stderr.strip(), "err")
+
+    def test_line_handlers_receive_each_line(self) -> None:
+        out_lines: list[str] = []
+        err_lines: list[str] = []
+        self.backend.run(
+            ExecutionRequest(command="printf 'a\\nb\\nc\\n'; printf 'x\\n' >&2"),
+            stdout_handler=out_lines.append,
+            stderr_handler=err_lines.append,
+        )
+        self.assertEqual([line.rstrip("\n") for line in out_lines], ["a", "b", "c"])
+        self.assertEqual([line.rstrip("\n") for line in err_lines], ["x"])
+
+    def test_empty_command_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            self.backend.run(ExecutionRequest(command="   "))
+
+    def test_sentinel_prefix_in_user_output_is_not_truncated(self) -> None:
+        # A user-supplied line that *contains* the sentinel prefix
+        # mid-line must still flow through verbatim — only lines that
+        # *start* with the prefix are sentinel framing.
+        leak_attempt = "echo 'leading __ASAT_SHELL_END_xxx__:0'"
+        result = self.backend.run(ExecutionRequest(command=leak_attempt))
+        self.assertIn("leading __ASAT_SHELL_END_xxx__:0", result.stdout)
+        self.assertEqual(result.exit_code, 0)
+
+
+@_REQUIRES_BASH
+class ShellBackendStatePersistenceTests(unittest.TestCase):
+    """The headline F60 guarantee: state carries between cells."""
+
+    def setUp(self) -> None:
+        self.backend = ShellBackend()
+        self.addCleanup(self.backend.close)
+
+    def test_cd_persists_across_commands(self) -> None:
+        self.backend.run(ExecutionRequest(command="cd /tmp"))
+        result = self.backend.run(ExecutionRequest(command="pwd"))
+        self.assertEqual(result.stdout.strip(), "/tmp")
+
+    def test_export_persists_across_commands(self) -> None:
+        self.backend.run(ExecutionRequest(command="export ASAT_F60_TEST=hello"))
+        result = self.backend.run(ExecutionRequest(command="echo $ASAT_F60_TEST"))
+        self.assertEqual(result.stdout.strip(), "hello")
+
+    def test_function_definition_persists_across_commands(self) -> None:
+        self.backend.run(
+            ExecutionRequest(command="greet() { echo hi-from-func; }")
+        )
+        result = self.backend.run(ExecutionRequest(command="greet"))
+        self.assertEqual(result.stdout.strip(), "hi-from-func")
+
+    def test_shell_option_persists_across_commands(self) -> None:
+        # `set -o pipefail` is the safest cross-call shell-option test:
+        # `set -u` and `set -e` cause non-interactive bash to exit on
+        # the *next* offending command, which would tear down the
+        # backend itself. `pipefail` only changes the pipeline exit
+        # code, leaving the shell alive.
+        self.backend.run(ExecutionRequest(command="set -o pipefail"))
+        result = self.backend.run(ExecutionRequest(command="false | true"))
+        # Without pipefail this is 0; with pipefail it propagates the
+        # `false` from earlier in the pipeline.
+        self.assertNotEqual(result.exit_code, 0)
+
+
+@_REQUIRES_BASH
+class ShellBackendTimeoutTests(unittest.TestCase):
+    """A timeout interrupts the command but keeps the shell alive."""
+
+    def setUp(self) -> None:
+        self.backend = ShellBackend()
+        self.addCleanup(self.backend.close)
+
+    def test_timeout_marks_result_and_keeps_shell_running(self) -> None:
+        result = self.backend.run(
+            ExecutionRequest(command="sleep 5", timeout_seconds=0.3)
+        )
+        self.assertTrue(result.timed_out)
+        self.assertTrue(self.backend.is_alive())
+        # The shell survived; the next command runs normally.
+        followup = self.backend.run(ExecutionRequest(command="echo after"))
+        self.assertEqual(followup.stdout.strip(), "after")
+        self.assertEqual(followup.exit_code, 0)
+
+
+@_REQUIRES_BASH
+class ShellBackendLifecycleTests(unittest.TestCase):
+    """Start-up, shutdown, and crash detection."""
+
+    def test_close_terminates_the_shell(self) -> None:
+        backend = ShellBackend()
+        self.assertTrue(backend.is_alive())
+        backend.close()
+        self.assertFalse(backend.is_alive())
+
+    def test_run_after_close_raises(self) -> None:
+        backend = ShellBackend()
+        backend.close()
+        with self.assertRaises(ShellBackendError):
+            backend.run(ExecutionRequest(command="echo nope"))
+
+    def test_unknown_shell_raises(self) -> None:
+        with self.assertRaises(ShellBackendError):
+            ShellBackend(shell=("definitely-not-a-shell-12345",))
+
+    def test_explicit_exit_inside_command_marks_shell_dead(self) -> None:
+        backend = ShellBackend()
+        self.addCleanup(backend.close)
+        # Asking the shell itself to exit closes both pipes mid-command.
+        # The collector detects EOF on stdout before the sentinel and
+        # raises ShellBackendError.
+        with self.assertRaises(ShellBackendError):
+            backend.run(ExecutionRequest(command="exit 7"))
+        self.assertFalse(backend.is_alive())
+
+
+class ShellBackendOptionalConstructorTests(unittest.TestCase):
+    """`shell_backend_or_none` returns None instead of raising."""
+
+    def test_returns_none_on_windows(self) -> None:
+        # Smoke check: on POSIX with bash present we get an instance,
+        # on Windows we get None. We only need to assert the
+        # documented contract holds for whichever platform we're on.
+        backend = shell_backend_or_none()
+        if os.name == "nt":
+            self.assertIsNone(backend)
+        else:
+            if _BASH is None:
+                self.assertIsNone(backend)
+            else:
+                self.assertIsNotNone(backend)
+                assert backend is not None  # appease the type checker
+                backend.close()
+
+    def test_returns_none_on_missing_shell(self) -> None:
+        result = shell_backend_or_none(shell=("definitely-not-a-shell-12345",))
+        self.assertIsNone(result)


### PR DESCRIPTION
## Summary

PR A of two for **F60 — persistent computational backend (shared shell)**. This one adds the module and its tests; nothing in the kernel or app graph is wired to it yet so the change is fully additive.

- New `asat/shell_backend.py`: a long-lived shell process (default `bash --norc --noprofile`) that every cell can submit commands to. State carries between calls — `cd`, `export`, function definitions, shell options — exactly as it would at a real prompt.
- Sentinel-framed I/O on both pipes keeps stdout and stderr separate (no PTY needed), so ASAT's spatial L/R audio routing keeps working when PR B flips the kernel over.
- Timeouts work without killing the shell: `trap : INT` (handler, not `''` SIG_IGN — the latter would propagate through `exec` to children) plus `start_new_session=True` and `os.killpg(SIGINT)` interrupt only the running foreground command.

## Test plan

- [x] `python -m unittest tests.test_shell_backend -v` — 17 tests, all pass
- [x] `python -W error::ResourceWarning -m unittest tests.test_shell_backend` — clean (no leaked FDs)
- [x] `python -m unittest discover -s tests -t .` — full suite green (864 tests)
- [x] State persistence covered: `cd`, `export`, function defs, `set -o pipefail`
- [x] Timeout test asserts both `result.timed_out` and `backend.is_alive()` after the timeout fires
- [x] Sentinel-prefix-mid-line test guards against framing leaking into user output

PR B will thread `ShellBackend` through `ExecutionKernel` and default it on in `Application.build`, with a `--no-shared-shell` opt-out and the doc flips that close out F60 in `FEATURE_REQUESTS.md`.

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS