### PR TITLE
F60 (PR B): thread ShellBackend through kernel/app, default on, doc flips

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ and is bound to a spoken phrase or a spatialised tone. Keyboard
 only, standard library only, no mouse, no screen coordinates.
 
 > **Status.** Pre-1.0 (current `pyproject.toml` says `0.7.0`). The
-> Windows audio path and the notebook surface are usable end-to-end;
-> the POSIX live audio sink, a persistent computational backend, and
-> cell hierarchy are tracked as feature requests (see "What is not
-> here yet" below).
+> Windows audio path, the notebook surface, and the POSIX shared-shell
+> backend are usable end-to-end; the POSIX live audio sink and cell
+> hierarchy are tracked as feature requests (see "What is not here
+> yet" below).
 
 ## Who this is for
 
@@ -28,6 +28,12 @@ stdout that mirrors what the audio is saying.
 - A **session of editable cells**, each with its own command,
   captured stdout/stderr, and exit code; saved as JSON via
   `--session file.json` and resumable.
+- **A persistent shell backend** (POSIX with bash). Every cell flows
+  through one long-lived shell, so `cd`, `export`, function defs,
+  and shell options carry between cells exactly as they would at a
+  real prompt — `cd src` in cell 1, `ls` in cell 2 lists `src/`.
+  Pass `--no-shared-shell` to opt out (each cell back to a fresh
+  subprocess); Windows still uses per-cell subprocesses today.
 - **Four focus modes** — NOTEBOOK (walk cells), INPUT (type a
   command), OUTPUT (step line-by-line through one cell's captured
   output, with `/` search and `g` goto), SETTINGS (live editor for
@@ -44,9 +50,6 @@ stdout that mirrors what the audio is saying.
 
 What is **not** here yet, with the docs grounding the gap:
 
-- No persistent computational backend across cells (each cell is a
-  fresh subprocess) —
-  [F60](docs/FEATURE_REQUESTS.md#f60--persistent-computational-backend-shared-shell--repl).
 - No cell hierarchy / sections / folds —
   [F61](docs/FEATURE_REQUESTS.md#f61--cell-hierarchy-sections-folds-and-grouping).
 - No PTY inside a cell, so `vim` / `less` / curses programs do not
@@ -137,6 +140,7 @@ engine voices it.
 | `cell.py`                  | The Cell value object: command, captured outputs, status, exit code.      |
 | `kernel.py`                | `ExecutionKernel`: routes a cell to the runner and publishes lifecycle.   |
 | `runner.py`                | Thin `subprocess.Popen` wrapper with line-streamed stdout/stderr.         |
+| `shell_backend.py`         | F60 persistent shell: one long-lived bash per session via sentinel-framed I/O. |
 | `execution.py`             | `ExecutionRequest` / `ExecutionResult` value types.                       |
 | `output_buffer.py`         | `OutputRecorder` + `OutputBuffer`: per-cell line capture from events.     |
 | `output_cursor.py`         | OUTPUT-mode line cursor: navigation, search, goto.                        |

--- a/asat/__main__.py
+++ b/asat/__main__.py
@@ -40,7 +40,9 @@ from asat.audio_sink import (
 from asat.jsonl_logger import JsonlEventLogger
 from asat.keyboard import KeyboardNotAvailable, KeyboardReader, pick_default
 from asat.onboarding import OnboardingCoordinator
+from asat.runner import ProcessRunner
 from asat.session import Session
+from asat.shell_backend import shell_backend_or_none
 from asat.sound_bank import SoundBank
 
 
@@ -86,6 +88,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         quiet=args.quiet, check=args.check, has_live_audio=has_live_audio
     )
     log_factory = _log_factory(args.log)
+    runner = _pick_runner(no_shared_shell=args.no_shared_shell, quiet=args.quiet)
     app = Application.build(
         sink=sink,
         bank=bank,
@@ -96,6 +99,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         clipboard_factory=SystemClipboard,
         onboarding_factory=onboarding_factory,
         log_factory=log_factory,
+        runner=runner,
     )
     if args.check:
         _print_check_report(app, args)
@@ -126,6 +130,7 @@ def _print_check_report(app: Application, args: argparse.Namespace) -> None:
         f"platform       {sys.platform}",
         f"stdin tty      {sys.stdin.isatty()}",
         f"sink           {type(app.sink).__name__}",
+        f"runner         {type(app.runner).__name__}",
         f"bank path      {args.bank if args.bank is not None else '(built-in default)'}",
         f"session path   {args.session if args.session is not None else '(fresh)'}",
         f"session id     {app.session.session_id}",
@@ -215,6 +220,16 @@ def _parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
             "and a maintainer can replay it locally."
         ),
     )
+    parser.add_argument(
+        "--no-shared-shell",
+        action="store_true",
+        help=(
+            "Disable the persistent shell backend (F60). Each cell "
+            "spawns its own one-shot subprocess as in pre-0.8 ASAT. "
+            "Use this when state-leakage between cells is undesirable, "
+            "or when bash is missing and the fallback would be silent."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -296,6 +311,30 @@ def _log_factory(path: Optional[Path]):
         return JsonlEventLogger(bus, path)
 
     return _factory
+
+
+def _pick_runner(*, no_shared_shell: bool, quiet: bool):
+    """Return the execution runner the kernel should use.
+
+    Defaults to a `ShellBackend` (F60) so cells share state. Falls back
+    to `ProcessRunner` (the per-cell-Popen model) when bash is missing,
+    on Windows, or when `--no-shared-shell` was requested. A one-line
+    stderr note explains the fallback so the user is never surprised
+    by silently per-cell behaviour.
+    """
+    if no_shared_shell:
+        return ProcessRunner()
+    backend = shell_backend_or_none()
+    if backend is not None:
+        return backend
+    if not quiet:
+        print(
+            "[asat] persistent shell backend unavailable on this host; "
+            "falling back to per-cell subprocesses. State will not "
+            "carry between cells. Pass --no-shared-shell to silence.",
+            file=sys.stderr,
+        )
+    return ProcessRunner()
 
 
 def _load_session(path: Optional[Path]) -> Optional[Session]:

--- a/asat/app.py
+++ b/asat/app.py
@@ -41,6 +41,7 @@ from asat.input_router import InputRouter, default_bindings
 from asat.jsonl_logger import JsonlEventLogger
 from asat.kernel import ExecutionKernel
 from asat.keys import Key
+from asat.runner import ProcessRunner
 from asat.notebook import FocusMode, NotebookCursor
 from asat.onboarding import OnboardingCoordinator
 from asat.output_buffer import OutputRecorder
@@ -68,6 +69,7 @@ class Application:
     session: Session
     cursor: NotebookCursor
     kernel: ExecutionKernel
+    runner: object  # ProcessRunner or ShellBackend; both expose `.run(...)`.
     router: InputRouter
     recorder: OutputRecorder
     output_cursor: OutputCursor
@@ -109,6 +111,7 @@ class Application:
         log_factory: Optional[
             "Callable[[EventBus], JsonlEventLogger]"
         ] = None,
+        runner: Optional[object] = None,
     ) -> "Application":
         """Wire every collaborator with sensible defaults.
 
@@ -147,6 +150,14 @@ class Application:
         startup event fires so the diagnostic log captures the full
         session including `SESSION_CREATED` and the initial
         `FOCUS_CHANGED`. Tests and default invocations leave it unset.
+
+        `runner` is the execution backend the kernel routes every cell
+        through. `None` (the default) builds a fresh `ProcessRunner` —
+        the per-cell `subprocess.Popen` model. Pass a `ShellBackend`
+        instance to give the whole session one long-lived shell so
+        `cd`, `export`, function definitions, and shell options carry
+        between cells (F60). The Application owns the lifecycle either
+        way and calls `runner.close()` (when present) from `close()`.
         """
         bus = EventBus()
         # Attach the diagnostic logger FIRST so SESSION_CREATED and the
@@ -155,7 +166,8 @@ class Application:
         seeded = session is None
         resolved_session = session if session is not None else Session.new()
         cursor = NotebookCursor(resolved_session, bus)
-        kernel = ExecutionKernel(bus)
+        resolved_runner = runner if runner is not None else ProcessRunner()
+        kernel = ExecutionKernel(bus, runner=resolved_runner)
         recorder = OutputRecorder(bus)
         output_cursor = OutputCursor(bus)
         resolved_bank = bank if bank is not None else default_sound_bank()
@@ -210,6 +222,7 @@ class Application:
             session=resolved_session,
             cursor=cursor,
             kernel=kernel,
+            runner=resolved_runner,
             router=router,
             recorder=recorder,
             output_cursor=output_cursor,
@@ -284,6 +297,11 @@ class Application:
                 source="app",
             )
         self.sink.close()
+        # `ShellBackend` owns a long-lived process; `ProcessRunner` has
+        # nothing to clean up and so doesn't define `close`.
+        runner_close = getattr(self.runner, "close", None)
+        if callable(runner_close):
+            runner_close()
         if self.event_logger is not None:
             self.event_logger.close()
 

--- a/asat/kernel.py
+++ b/asat/kernel.py
@@ -32,10 +32,16 @@ from asat.event_bus import EventBus, publish_event
 from asat.events import EventType
 from asat.execution import ExecutionMode, ExecutionRequest, ExecutionResult
 from asat.runner import ProcessRunner
+from asat.shell_backend import ShellBackendError
 
 
 EXIT_CODE_NOT_FOUND = 127
 EXIT_CODE_PARSE_ERROR = 2
+# Bash convention: 125 is the "command itself failed to launch" rung
+# below "127 not found" and "126 not executable". We reuse it for the
+# persistent shell crashing mid-command — distinct from any exit code
+# the user's command could plausibly emit.
+EXIT_CODE_BACKEND_ERROR = 125
 
 
 class ExecutionKernel:
@@ -98,6 +104,13 @@ class ExecutionKernel:
             return self._fail_before_launch(cell, exc, EXIT_CODE_NOT_FOUND)
         except ValueError as exc:
             return self._fail_before_launch(cell, exc, EXIT_CODE_PARSE_ERROR)
+        except ShellBackendError as exc:
+            # The persistent shell crashed mid-command (or was already
+            # dead). Surface as a launch-time failure so the user gets
+            # the same audio cue and stderr-tail narration they'd get
+            # for any other failed command. Restart of the backend is
+            # the caller's job; the kernel just records what happened.
+            return self._fail_before_launch(cell, exc, EXIT_CODE_BACKEND_ERROR)
 
         cell.mark_completed(
             stdout=result.stdout,

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -3254,55 +3254,47 @@ user files a concrete motivator.
 
 ## F60 — Persistent computational backend (shared shell / REPL)
 
-**Gap.** Each cell launches its own one-shot `subprocess.Popen` via
-`asat/runner.py:48`. There is no carried state between cells: an
-`export X=hi` in cell 1 is gone by cell 2, `cd /tmp` does not change
-the cwd of any later cell, and there is no persistent Python / Node
-/ shell process the user can build state inside (no Jupyter-style
-kernel, no `tmux send-keys` model). Every cell is effectively a
-fresh `bash -c "<command>"` with the inherited environment of the
-ASAT process and nothing else.
+**Sketch (shipped).** POSIX hosts now launch one long-lived
+`bash --norc --noprofile` at session start and route every cell's
+command through it via stdin (`asat/shell_backend.py`). Sentinel
+framing on both pipes preserves the stdout/stderr split (no PTY
+needed), so ASAT's spatial L/R audio routing keeps working. State
+carries between cells exactly as a human at a real prompt would
+expect: `cd`, `export`, function definitions, shell options. A
+timer-driven `os.killpg(SIGINT)` interrupts a stuck command without
+killing the shell — the shell's own `trap : INT` catches SIGINT,
+while `exec` resets the disposition for the foreground child so it
+exits with 130. The CLI flips this on by default and falls back to
+the per-cell `ProcessRunner` when bash is missing, on Windows, or
+when the user passes `--no-shared-shell` (`asat/__main__.py
+:_pick_runner`). The kernel surfaces a crashed shell as the
+dedicated `EXIT_CODE_BACKEND_ERROR=125` so callers can distinguish
+it from any user-command failure. End-to-end coverage in
+`tests/test_shell_backend.py` (state persistence, timeout-without-
+killing-the-shell, sentinel-prefix-mid-line) and
+`tests/test_app.py::ApplicationSharedShellTests`.
 
-**Where it surfaces.** A blind developer who reasonably expects a
-"notebook of terminal cells" to behave like a single shell session
-runs `cd src` in cell 1, then `ls` in cell 2, and gets the
-launch-time cwd back instead of `src/`. Same with virtualenv
-activation, `source ~/.profile`, in-flight Python state, etc. Today
-USER_MANUAL.md does not state the limitation; the new
-"What a cell *is* (and is not) today" section calls it out and
-links here.
+**Open follow-ups.**
 
-**Sketch.** Give `Session` an optional `backend` (a long-lived
-subprocess) that cells route their command through instead of each
-spawning their own. The simplest first cut is a dedicated shell
-process (`bash -i` / `cmd /K`) addressed by writing to its stdin
-and framing output with sentinel markers (printf a known UUID
-before/after each command so the runner knows when output ends and
-can read the exit code). A richer second cut wraps the
-Jupyter-kernel protocol so non-shell kernels (IPython, Node, etc.)
-work the same way. Either way, the kernel is per-Session, restarts
-explicitly on `:restart` or when corrupted, and old transcripts
-remain valid because each cell still records its captured output
-and exit code.
-
-**Forward-looking notes.**
-
-- **Backend is a session-level setting.** A user might want
-  `bash` here and `ipython` there; record the chosen backend in
-  the Session JSON so resumes pick the same one back up.
+- **Per-session backend choice.** Today the backend is bash or
+  nothing. Record `backend = "bash" | "ipython" | …` in the
+  Session JSON so resumes pick the same one back up.
 - **Per-cell override.** A `:backend none` meta-command (or a
-  cell-level flag) keeps the existing fresh-subprocess behaviour
-  for one-off invocations like `git status` where shared state
-  is irrelevant or actively unwanted.
-- **Restart semantics.** Crashed kernels need a clear narration
+  cell-level flag) for one-off invocations like `git status` where
+  shared state is irrelevant or actively unwanted.
+- **Restart semantics.** A `:restart` meta-command + audio cue
   ("backend exited code N — press Ctrl+R to restart") and a
   way to mark every downstream cell as "ran against a different
   process" so a future re-run does not silently inherit different
   state.
-- **Security.** A long-lived shell amplifies the blast radius of
-  whatever the user types. Document it; never auto-run cells from
-  a loaded session against the new backend without an explicit
-  prompt.
+- **Windows backend.** Mirror the same protocol against `cmd /K`
+  (or `pwsh -NoProfile -NoExit`), reusing the sentinel framing.
+- **Non-shell kernels.** Wrap the Jupyter-kernel protocol so
+  IPython, Node, etc. work the same way.
+- **Security.** A long-lived shell amplifies blast radius. Today
+  `--no-shared-shell` is the only escape valve; never auto-run
+  cells from a loaded session against the new backend without an
+  explicit prompt.
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -155,15 +155,19 @@ duplicate, and delete cells without leaving the keyboard.
 
 It is **not** Jupyter. Two limits to be aware of from day one:
 
-1. **Each cell runs in a fresh subprocess.** `export FOO=bar` in
-   cell 1 is gone by cell 2. `cd /tmp` does not change the cwd of
-   any later cell. There is no persistent Python REPL or shared
-   shell sitting behind the cells — every command you submit
-   launches its own `subprocess.Popen`, inherits the ASAT process's
-   environment, and exits. If you need shared state today, fold it
-   into a single cell (e.g. `cd src && python script.py`). A
-   persistent computational backend is tracked as
-   [F60](FEATURE_REQUESTS.md#f60--persistent-computational-backend-shared-shell--repl).
+1. **All cells share one shell.** On POSIX hosts ASAT launches a
+   single long-lived bash at session start and routes every cell's
+   command through it. So `cd /tmp` in cell 1 *does* change the cwd
+   of cell 2, `export FOO=bar` in cell 1 is visible in cell 2, and
+   shell options (`set -o pipefail`, `shopt -s nullglob`) carry
+   forward — exactly as they would at a real prompt. If you would
+   rather isolate each cell in its own one-shot subprocess, launch
+   with `--no-shared-shell`. A long-lived shell amplifies blast
+   radius (a stuck `read`, a `set -e` exit) — when bash is missing
+   or you opt out, ASAT silently falls back to per-cell subprocesses
+   and prints a one-line stderr note. Windows currently always uses
+   per-cell subprocesses; a Windows persistent backend is tracked
+   alongside [F60](FEATURE_REQUESTS.md#f60--persistent-computational-backend-shared-shell--repl).
 2. **Cells are not interactive terminals (no PTY).** A cell is a
    command string plus its captured output and exit code. Programs
    that take over the screen — `vim`, `less`, `top`, `python`

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -100,6 +100,37 @@ class ApplicationBuildTests(unittest.TestCase):
         app = Application.build()
         self.assertIsNone(app.onboarding)
 
+    def test_default_runner_is_process_runner(self) -> None:
+        # Tests don't pass `runner=`, so the default keeps the
+        # historical per-cell-Popen behaviour. The CLI is the only
+        # place that opportunistically swaps in a ShellBackend.
+        from asat.runner import ProcessRunner
+
+        app = Application.build()
+        self.assertIsInstance(app.runner, ProcessRunner)
+        self.assertIs(app.kernel._runner, app.runner)
+
+    def test_supplied_runner_is_threaded_through_to_kernel(self) -> None:
+        runner = StubRunner()
+        app = Application.build(runner=runner)
+        self.assertIs(app.runner, runner)
+        self.assertIs(app.kernel._runner, runner)
+
+    def test_close_invokes_runner_close_when_present(self) -> None:
+        # ShellBackend defines `close`; ProcessRunner does not. The
+        # Application must call it when present so a long-lived shell
+        # is shut down at exit.
+        closed: list[bool] = []
+
+        class _ClosableRunner(StubRunner):
+            def close(self) -> None:
+                closed.append(True)
+
+        app = Application.build(runner=_ClosableRunner())
+        app.close()
+        self.assertEqual(closed, [True])
+
+
     def test_onboarding_factory_runs_after_session_created(self) -> None:
         """F20: when a coordinator is installed, `.run()` must fire
         during `Application.build` so the welcome event reaches any
@@ -128,6 +159,43 @@ class ApplicationBuildTests(unittest.TestCase):
             welcome_idx = seen.index(EventType.FIRST_RUN_DETECTED)
             self.assertLess(session_idx, welcome_idx)
             self.assertTrue(sentinel.exists())
+
+
+class ApplicationSharedShellTests(unittest.TestCase):
+    """End-to-end check that two cells submitted through one
+    `ShellBackend` (the F60 PR-B headline feature) actually share
+    shell state — `cd` in cell 1 changes the cwd seen by cell 2.
+    """
+
+    def test_cd_in_one_cell_carries_to_the_next(self) -> None:
+        import os
+        import shutil
+        from asat.shell_backend import ShellBackend
+
+        if os.name == "nt" or shutil.which("bash") is None:
+            self.skipTest("requires bash on a POSIX host")
+
+        backend = ShellBackend()
+        self.addCleanup(backend.close)
+        app = Application.build(runner=backend)
+        self.addCleanup(app.close)
+
+        # Cell 1: `cd /tmp`
+        _type(app, "cd /tmp")
+        app.handle_key(kc.ENTER)
+        for cid in app.drain_pending():
+            app.execute(cid)
+
+        # Cell 2: `pwd`
+        _type(app, "pwd")
+        app.handle_key(kc.ENTER)
+        second_pending = app.drain_pending()
+        self.assertEqual(len(second_pending), 1)
+        app.execute(second_pending[0])
+
+        second_cell = app.session.get_cell(second_pending[0])
+        self.assertEqual(second_cell.stdout.strip(), "/tmp")
+        self.assertEqual(second_cell.exit_code, 0)
 
 
 class ApplicationSubmissionTests(unittest.TestCase):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,7 +100,20 @@ class CheckFlagTests(_AsatHomeIsolated):
         self.assertIn("asat", report)
         self.assertIn("platform", report)
         self.assertIn("sink", report)
+        self.assertIn("runner", report)
         self.assertIn("bindings", report)
+
+    def test_no_shared_shell_falls_back_to_process_runner(self) -> None:
+        # `--no-shared-shell` opts out of the F60 persistent backend
+        # so each cell runs in its own one-shot subprocess. The runner
+        # line in `--check` is the user-visible signal that the flag
+        # took effect.
+        out = io.StringIO()
+        with mock.patch("asat.__main__.pick_default", side_effect=AssertionError), \
+             mock.patch("sys.stdout", out):
+            rc = cli.main(["--check", "--no-shared-shell"])
+        self.assertEqual(rc, 0)
+        self.assertIn("runner         ProcessRunner", out.getvalue())
 
 
 class NonTTYTests(_AsatHomeIsolated):

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -15,8 +15,14 @@ from asat.cell import Cell, CellStatus
 from asat.event_bus import EventBus
 from asat.events import Event, EventType
 from asat.execution import ExecutionMode, ExecutionRequest, ExecutionResult
-from asat.kernel import EXIT_CODE_NOT_FOUND, EXIT_CODE_PARSE_ERROR, ExecutionKernel
+from asat.kernel import (
+    EXIT_CODE_BACKEND_ERROR,
+    EXIT_CODE_NOT_FOUND,
+    EXIT_CODE_PARSE_ERROR,
+    ExecutionKernel,
+)
 from asat.runner import ProcessRunner
+from asat.shell_backend import ShellBackendError
 
 
 class StubRunner:
@@ -178,6 +184,23 @@ class KernelFailureTests(unittest.TestCase):
         kernel = ExecutionKernel(bus, runner=runner)
         kernel.execute(Cell.new("nope"))
         self.assertNotIn(EventType.ERROR_CHUNK, recorder.types())
+
+    def test_shell_backend_crash_surfaces_as_command_failed(self) -> None:
+        # When the persistent shell backend (F60) raises mid-command,
+        # the kernel must convert it into the same launch-failure
+        # path FileNotFoundError uses so the audio cue + stderr-tail
+        # pipeline narrates it. The exit code is the dedicated 125
+        # so callers can distinguish it from user-command failures.
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        runner = StubRunner(raises=ShellBackendError("shell exited mid-command"))
+        kernel = ExecutionKernel(bus, runner=runner)
+        result = kernel.execute(Cell.new("ls"))
+        self.assertEqual(result.exit_code, EXIT_CODE_BACKEND_ERROR)
+        failed = [e for e in recorder.events if e.event_type == EventType.COMMAND_FAILED]
+        self.assertEqual(len(failed), 1)
+        self.assertEqual(failed[0].payload["error_type"], "ShellBackendError")
+        self.assertIn(EventType.ERROR_CHUNK, recorder.types())
 
     def test_parse_error_fails_gracefully(self) -> None:
         bus = EventBus()


### PR DESCRIPTION
## Summary

Wires the `ShellBackend` shipped in #63 into the live pipeline. POSIX hosts now get **one long-lived bash per session by default** — `cd`, `export`, function definitions, and shell options carry between cells exactly as at a real prompt. Pass `--no-shared-shell` (or sit on Windows, or have no bash on PATH) to fall back to the per-cell `ProcessRunner` model.

- `Application.build` accepts `runner=`; default stays `ProcessRunner` so existing tests keep their isolation. `__main__._pick_runner` opportunistically constructs a `ShellBackend` and reports the choice in the `--check` report (new `runner` line).
- `ExecutionKernel` now catches `ShellBackendError` and routes it through `_fail_before_launch` with the dedicated `EXIT_CODE_BACKEND_ERROR=125`, so a crashed shell narrates through the existing audio cue + stderr-tail pipeline.
- `Application.close` calls `runner.close()` when present, shutting the long-lived shell down cleanly at exit.
- README promotes the shared shell to a delivered bullet (and drops it from "What is not here yet"); USER_MANUAL rewrites the cell-semantics section; FEATURE_REQUESTS marks F60 as `Sketch (shipped)` with the open follow-ups (Windows backend, `:restart`, per-cell override, non-shell kernels) called out.

## Test plan

- [x] `python -m unittest discover -s tests -t .` — 870 tests, all green
- [x] New: `tests/test_app.py::ApplicationSharedShellTests::test_cd_in_one_cell_carries_to_the_next` — real bash, two cells, second cell's `pwd` returns `/tmp` after first cell's `cd /tmp`
- [x] New: `tests/test_kernel.py::test_shell_backend_crash_surfaces_as_command_failed` — confirms `ShellBackendError` becomes `COMMAND_FAILED` with `error_type="ShellBackendError"` and `EXIT_CODE_BACKEND_ERROR`
- [x] New: `tests/test_app.py::ApplicationBuildTests::test_close_invokes_runner_close_when_present` — confirms long-lived runners are closed
- [x] New: `tests/test_cli.py::CheckFlagTests::test_no_shared_shell_falls_back_to_process_runner` — confirms the flag flips the `--check` runner line

## Manual verification (POSIX)

After this lands you should be able to:

```
$ python -m asat --check
asat 0.7.0
platform       linux
stdin tty      …
sink           MemorySink
runner         ShellBackend
…

$ python -m asat --check --no-shared-shell
…
runner         ProcessRunner
…
```

And in a live session, `cd src` in cell 1 followed by `pwd` in cell 2 now reports the new cwd.

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS