### PR TITLE
F61 PR A: CellKind + heading-cell foundations (no wiring yet)

### DIFF
--- a/asat/cell.py
+++ b/asat/cell.py
@@ -51,14 +51,33 @@ class CellStatus(str, Enum):
     CANCELLED = "cancelled"
 
 
+class CellKind(str, Enum):
+    """What flavour of cell this is.
+
+    COMMAND cells are the executable input/output units the notebook
+    was originally built around. HEADING cells are structural
+    landmarks that anchor NVDA-style heading navigation (F61). Future
+    kinds (pure-input, pure-output, terminal) plug in here without
+    rewriting the session/cursor/render layers.
+    """
+
+    COMMAND = "command"
+    HEADING = "heading"
+
+
+MIN_HEADING_LEVEL = 1
+MAX_HEADING_LEVEL = 6
+
+
 @dataclass
 class Cell:
-    """A single input/output notebook cell.
+    """A single notebook cell.
 
-    Use Cell.new(command) to construct a fresh cell. Direct construction
-    is supported for deserialization but callers should prefer the
-    factory method so that identifiers and timestamps are generated
-    consistently.
+    Use Cell.new(command) for an executable command cell, or
+    Cell.new_heading(level, title) for a heading landmark. Direct
+    construction is supported for deserialization but callers should
+    prefer the factory methods so identifiers, timestamps, and kind
+    stay consistent.
     """
 
     cell_id: str
@@ -71,10 +90,30 @@ class Cell:
     status: CellStatus = CellStatus.PENDING
     parent_id: Optional[str] = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    kind: CellKind = CellKind.COMMAND
+    heading_level: Optional[int] = None
+    heading_title: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.kind is CellKind.HEADING:
+            if self.heading_level is None or not (
+                MIN_HEADING_LEVEL <= self.heading_level <= MAX_HEADING_LEVEL
+            ):
+                raise ValueError(
+                    f"heading cell requires heading_level in "
+                    f"{MIN_HEADING_LEVEL}..{MAX_HEADING_LEVEL}"
+                )
+            if self.heading_title is None or not self.heading_title.strip():
+                raise ValueError("heading cell requires a non-empty heading_title")
+        else:
+            if self.heading_level is not None or self.heading_title is not None:
+                raise ValueError(
+                    "heading_level / heading_title only apply to HEADING cells"
+                )
 
     @classmethod
     def new(cls, command: str, parent_id: Optional[str] = None) -> "Cell":
-        """Create a fresh pending cell for the given command.
+        """Create a fresh pending command cell.
 
         The parent_id is used when the user edits and re-runs a previous
         cell. It lets the session preserve the original cell as history
@@ -89,13 +128,54 @@ class Cell:
             parent_id=parent_id,
         )
 
+    @classmethod
+    def new_heading(cls, level: int, title: str) -> "Cell":
+        """Create a fresh heading landmark cell at the given level (1..6)."""
+        if not (MIN_HEADING_LEVEL <= level <= MAX_HEADING_LEVEL):
+            raise ValueError(
+                f"heading level must be {MIN_HEADING_LEVEL}..{MAX_HEADING_LEVEL}"
+            )
+        if not title.strip():
+            raise ValueError("heading title must be non-empty")
+        now = utcnow()
+        return cls(
+            cell_id=new_id(),
+            command="",
+            created_at=now,
+            updated_at=now,
+            status=CellStatus.COMPLETED,
+            kind=CellKind.HEADING,
+            heading_level=level,
+            heading_title=title,
+        )
+
+    @property
+    def is_heading(self) -> bool:
+        return self.kind is CellKind.HEADING
+
+    @property
+    def is_executable(self) -> bool:
+        """True iff this cell represents runnable work.
+
+        Headings are landmarks, not commands; the kernel and worker
+        must skip them. Future read-only cell kinds fall through here
+        too.
+        """
+        return self.kind is CellKind.COMMAND
+
+    def _require_executable(self, op: str) -> None:
+        if not self.is_executable:
+            raise ValueError(f"cannot {op} on a non-executable cell (kind={self.kind.value})")
+
     def mark_running(self) -> None:
         """Transition this cell to the RUNNING state."""
+        self._require_executable("mark_running")
         self.status = CellStatus.RUNNING
         self.updated_at = utcnow()
 
     def mark_completed(self, stdout: str, stderr: str, exit_code: int) -> None:
         """Record a completed execution and set status from the exit code."""
+        self._require_executable("mark_completed")
         self.stdout = stdout
         self.stderr = stderr
         self.exit_code = exit_code
@@ -104,6 +184,7 @@ class Cell:
 
     def mark_cancelled(self) -> None:
         """Record that the user cancelled this cell before completion."""
+        self._require_executable("mark_cancelled")
         self.status = CellStatus.CANCELLED
         self.updated_at = utcnow()
 
@@ -114,11 +195,26 @@ class Cell:
         branching. Output fields are cleared so a stale result is never
         shown alongside an unexecuted command.
         """
+        self._require_executable("update_command")
         self.command = new_command
         self.stdout = ""
         self.stderr = ""
         self.exit_code = None
         self.status = CellStatus.PENDING
+        self.updated_at = utcnow()
+
+    def update_heading(self, level: int, title: str) -> None:
+        """Edit the level/title of a heading cell in place."""
+        if not self.is_heading:
+            raise ValueError("update_heading only applies to heading cells")
+        if not (MIN_HEADING_LEVEL <= level <= MAX_HEADING_LEVEL):
+            raise ValueError(
+                f"heading level must be {MIN_HEADING_LEVEL}..{MAX_HEADING_LEVEL}"
+            )
+        if not title.strip():
+            raise ValueError("heading title must be non-empty")
+        self.heading_level = level
+        self.heading_title = title
         self.updated_at = utcnow()
 
     def snapshot(self) -> "Cell":
@@ -140,6 +236,9 @@ class Cell:
             status=self.status,
             parent_id=self.parent_id,
             metadata=dict(self.metadata),
+            kind=self.kind,
+            heading_level=self.heading_level,
+            heading_title=self.heading_title,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -148,11 +247,16 @@ class Cell:
         data["created_at"] = self.created_at.isoformat()
         data["updated_at"] = self.updated_at.isoformat()
         data["status"] = self.status.value
+        data["kind"] = self.kind.value
         return data
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "Cell":
-        """Rebuild a Cell from a dictionary previously produced by to_dict."""
+        """Rebuild a Cell from a dictionary previously produced by to_dict.
+
+        Missing `kind` / `heading_level` / `heading_title` default to a
+        COMMAND cell so sessions written before F61 load cleanly.
+        """
         return cls(
             cell_id=data["cell_id"],
             command=data["command"],
@@ -164,4 +268,7 @@ class Cell:
             status=CellStatus(data.get("status", CellStatus.PENDING.value)),
             parent_id=data.get("parent_id"),
             metadata=dict(data.get("metadata", {})),
+            kind=CellKind(data.get("kind", CellKind.COMMAND.value)),
+            heading_level=data.get("heading_level"),
+            heading_title=data.get("heading_title"),
         )

--- a/asat/notebook.py
+++ b/asat/notebook.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import Optional
 
-from asat.cell import Cell
+from asat.cell import Cell, CellKind
 from asat.event_bus import EventBus, publish_event
 from asat.events import EventType
 from asat.session import Session, SessionError
@@ -153,6 +153,76 @@ class NotebookCursor:
         )
         return cell
 
+    def new_heading_cell(self, level: int, title: str) -> Cell:
+        """Append a heading landmark, focus it, and stay in NOTEBOOK mode.
+
+        Headings are not executable, so there's no input buffer and no
+        transition into INPUT — they live alongside command cells purely
+        as structural anchors for NVDA-style heading navigation.
+        """
+        cell = Cell.new_heading(level, title)
+        self._session.add_cell(cell)
+        self._session.set_active(cell.cell_id)
+        self._publish_cell_created(cell, len(self._session.cells) - 1)
+        self._transition(
+            FocusState(
+                mode=FocusMode.NOTEBOOK,
+                cell_id=cell.cell_id,
+                input_buffer="",
+                cursor_position=0,
+            )
+        )
+        return cell
+
+    def move_to_next_heading(self, level: Optional[int] = None) -> Optional[Cell]:
+        """Jump forward to the next heading. None level = any level.
+
+        NVDA convention: always step past the current cell, so
+        repeatedly pressing the shortcut cycles through headings one
+        at a time. Returns the landed cell, or None if there is no
+        next heading matching the filter (in which case the cursor
+        does not move).
+        """
+        return self._move_to_heading(direction=+1, level=level)
+
+    def move_to_previous_heading(self, level: Optional[int] = None) -> Optional[Cell]:
+        """Jump backward to the previous heading. None level = any level."""
+        return self._move_to_heading(direction=-1, level=level)
+
+    def _move_to_heading(self, direction: int, level: Optional[int]) -> Optional[Cell]:
+        if self._state.mode != FocusMode.NOTEBOOK:
+            return None
+        cells = self._session.cells
+        if not cells:
+            return None
+        if self._state.cell_id is None:
+            start_index = -1 if direction > 0 else len(cells)
+        else:
+            start_index = self._session.index_of(self._state.cell_id)
+        index = start_index + direction
+        while 0 <= index < len(cells):
+            candidate = cells[index]
+            if candidate.kind is CellKind.HEADING and (
+                level is None or candidate.heading_level == level
+            ):
+                return self.focus_cell(candidate.cell_id)
+            index += direction
+        return None
+
+    def list_headings(self) -> list[tuple[int, int, str, str]]:
+        """Return the notebook's TOC: list of (index, level, title, cell_id).
+
+        Used by the `:toc` meta-command and any future outline view.
+        Empty when the session has no heading cells.
+        """
+        out: list[tuple[int, int, str, str]] = []
+        for i, cell in enumerate(self._session.cells):
+            if cell.kind is CellKind.HEADING:
+                assert cell.heading_level is not None
+                assert cell.heading_title is not None
+                out.append((i, cell.heading_level, cell.heading_title, cell.cell_id))
+        return out
+
     def delete_focused_cell(self) -> Optional[Cell]:
         """Remove the focused cell and land on a sensible neighbor.
 
@@ -202,7 +272,12 @@ class NotebookCursor:
         if cell_id is None:
             return None
         source = self._session.get_cell(cell_id)
-        duplicate = Cell.new(source.command)
+        if source.is_heading:
+            assert source.heading_level is not None
+            assert source.heading_title is not None
+            duplicate = Cell.new_heading(source.heading_level, source.heading_title)
+        else:
+            duplicate = Cell.new(source.command)
         target_index = self._session.index_of(cell_id) + 1
         self._session.add_cell(duplicate, position=target_index)
         self._publish_cell_created(duplicate, target_index)
@@ -256,11 +331,14 @@ class NotebookCursor:
         """Switch from notebook to input mode on the focused cell.
 
         The caret lands at the end of the existing command so typing
-        continues to append the way the user expects.
+        continues to append the way the user expects. Heading cells
+        have no command buffer, so this is a no-op on them.
         """
         if self._state.cell_id is None:
             return None
         cell = self._session.get_cell(self._state.cell_id)
+        if not cell.is_executable:
+            return None
         self._transition(
             FocusState(
                 mode=FocusMode.INPUT,

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import time
 import unittest
 
-from asat.cell import Cell, CellStatus
+from asat.cell import Cell, CellKind, CellStatus
 
 
 class CellFactoryTests(unittest.TestCase):
@@ -132,6 +132,109 @@ class CellSnapshotTests(unittest.TestCase):
         snap = cell.snapshot()
         cell.metadata["k"] = "mutated"
         self.assertEqual(snap.metadata, {"k": "v"})
+
+
+class CellKindDefaultsTests(unittest.TestCase):
+    """A Cell.new() result is a plain COMMAND cell."""
+
+    def test_default_kind_is_command(self) -> None:
+        cell = Cell.new("echo hi")
+        self.assertEqual(cell.kind, CellKind.COMMAND)
+        self.assertTrue(cell.is_executable)
+        self.assertFalse(cell.is_heading)
+        self.assertIsNone(cell.heading_level)
+        self.assertIsNone(cell.heading_title)
+
+
+class CellHeadingFactoryTests(unittest.TestCase):
+    """Cell.new_heading produces structurally valid landmarks."""
+
+    def test_new_heading_sets_kind_and_fields(self) -> None:
+        cell = Cell.new_heading(2, "Setup")
+        self.assertEqual(cell.kind, CellKind.HEADING)
+        self.assertTrue(cell.is_heading)
+        self.assertFalse(cell.is_executable)
+        self.assertEqual(cell.heading_level, 2)
+        self.assertEqual(cell.heading_title, "Setup")
+        self.assertEqual(cell.command, "")
+        # Headings are "always complete"; they carry no pending work.
+        self.assertEqual(cell.status, CellStatus.COMPLETED)
+
+    def test_new_heading_rejects_out_of_range_level(self) -> None:
+        with self.assertRaises(ValueError):
+            Cell.new_heading(0, "x")
+        with self.assertRaises(ValueError):
+            Cell.new_heading(7, "x")
+
+    def test_new_heading_rejects_blank_title(self) -> None:
+        with self.assertRaises(ValueError):
+            Cell.new_heading(1, "")
+        with self.assertRaises(ValueError):
+            Cell.new_heading(1, "   ")
+
+    def test_heading_cells_are_not_executable_and_refuse_exec_mutations(self) -> None:
+        cell = Cell.new_heading(1, "Intro")
+        with self.assertRaises(ValueError):
+            cell.mark_running()
+        with self.assertRaises(ValueError):
+            cell.mark_completed("", "", 0)
+        with self.assertRaises(ValueError):
+            cell.mark_cancelled()
+        with self.assertRaises(ValueError):
+            cell.update_command("echo")
+
+    def test_update_heading_edits_level_and_title(self) -> None:
+        cell = Cell.new_heading(1, "Old")
+        cell.update_heading(3, "New Title")
+        self.assertEqual(cell.heading_level, 3)
+        self.assertEqual(cell.heading_title, "New Title")
+
+    def test_update_heading_refuses_on_command_cell(self) -> None:
+        cell = Cell.new("echo")
+        with self.assertRaises(ValueError):
+            cell.update_heading(1, "nope")
+
+
+class CellKindSerializationTests(unittest.TestCase):
+    """Heading cells round-trip through to_dict/from_dict."""
+
+    def test_heading_round_trip(self) -> None:
+        cell = Cell.new_heading(4, "Runs")
+        restored = Cell.from_dict(cell.to_dict())
+        self.assertEqual(restored.kind, CellKind.HEADING)
+        self.assertEqual(restored.heading_level, 4)
+        self.assertEqual(restored.heading_title, "Runs")
+        self.assertEqual(restored.cell_id, cell.cell_id)
+
+    def test_command_cell_round_trip_preserves_kind(self) -> None:
+        cell = Cell.new("ls")
+        data = cell.to_dict()
+        self.assertEqual(data["kind"], "command")
+        restored = Cell.from_dict(data)
+        self.assertEqual(restored.kind, CellKind.COMMAND)
+
+    def test_legacy_dict_without_kind_defaults_to_command(self) -> None:
+        # Older session JSON (pre-F61) has no `kind` field. It must
+        # still load cleanly as a COMMAND cell.
+        cell = Cell.new("ls")
+        data = cell.to_dict()
+        data.pop("kind", None)
+        data.pop("heading_level", None)
+        data.pop("heading_title", None)
+        restored = Cell.from_dict(data)
+        self.assertEqual(restored.kind, CellKind.COMMAND)
+        self.assertIsNone(restored.heading_level)
+        self.assertIsNone(restored.heading_title)
+
+
+class CellSnapshotKindTests(unittest.TestCase):
+
+    def test_heading_snapshot_preserves_kind(self) -> None:
+        cell = Cell.new_heading(2, "Setup")
+        snap = cell.snapshot()
+        self.assertEqual(snap.kind, CellKind.HEADING)
+        self.assertEqual(snap.heading_level, 2)
+        self.assertEqual(snap.heading_title, "Setup")
 
 
 if __name__ == "__main__":

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import unittest
 
-from asat.cell import Cell, CellStatus
+from asat.cell import Cell, CellKind, CellStatus
 from asat.event_bus import EventBus
 from asat.events import Event, EventType
 from asat.notebook import FocusMode, NotebookCursor
@@ -583,6 +583,133 @@ class CellLifecycleOperationsTests(unittest.TestCase):
         self.created.clear()
         self.cursor.submit()
         self.assertEqual(len(self.created), 1)
+
+
+class HeadingNavigationTests(unittest.TestCase):
+    """F61: headings act as NVDA-style jump targets."""
+
+    def setUp(self) -> None:
+        self.bus = EventBus()
+        self.session = Session.new()
+        # Interleave headings and commands to exercise level filtering
+        # and any-level cycling.
+        #   [0] h1 "Intro"
+        #   [1] cmd "ls"
+        #   [2] h2 "Setup"
+        #   [3] cmd "install"
+        #   [4] h1 "Runs"
+        #   [5] cmd "run"
+        self.session.add_cell(Cell.new_heading(1, "Intro"))
+        self.session.add_cell(Cell.new("ls"))
+        self.session.add_cell(Cell.new_heading(2, "Setup"))
+        self.session.add_cell(Cell.new("install"))
+        self.session.add_cell(Cell.new_heading(1, "Runs"))
+        self.session.add_cell(Cell.new("run"))
+        self.cursor = NotebookCursor(self.session, self.bus)
+        # Start at the first cell; explicit for clarity.
+        self.cursor.focus_cell(self.session.cells[0].cell_id)
+
+    def test_next_any_level_skips_current_and_walks_order(self) -> None:
+        # From index 0 (h1 Intro) -> index 2 (h2 Setup)
+        landed = self.cursor.move_to_next_heading()
+        assert landed is not None
+        self.assertEqual(landed.heading_title, "Setup")
+        # Next -> index 4 (h1 Runs)
+        landed = self.cursor.move_to_next_heading()
+        assert landed is not None
+        self.assertEqual(landed.heading_title, "Runs")
+        # Next -> None (no more headings); cursor does not move
+        before = self.cursor.focus.cell_id
+        self.assertIsNone(self.cursor.move_to_next_heading())
+        self.assertEqual(self.cursor.focus.cell_id, before)
+
+    def test_prev_any_level_walks_back(self) -> None:
+        self.cursor.focus_cell(self.session.cells[-1].cell_id)
+        landed = self.cursor.move_to_previous_heading()
+        assert landed is not None
+        self.assertEqual(landed.heading_title, "Runs")
+        landed = self.cursor.move_to_previous_heading()
+        assert landed is not None
+        self.assertEqual(landed.heading_title, "Setup")
+        landed = self.cursor.move_to_previous_heading()
+        assert landed is not None
+        self.assertEqual(landed.heading_title, "Intro")
+        self.assertIsNone(self.cursor.move_to_previous_heading())
+
+    def test_level_filter_finds_matching_level_only(self) -> None:
+        # Level 1 from index 0: skip current, next match is index 4
+        landed = self.cursor.move_to_next_heading(level=1)
+        assert landed is not None
+        self.assertEqual(landed.heading_title, "Runs")
+        # No more h1 after that.
+        self.assertIsNone(self.cursor.move_to_next_heading(level=1))
+
+    def test_level_filter_no_match_leaves_cursor_alone(self) -> None:
+        # There are no h6 cells; cursor should not move.
+        before = self.cursor.focus.cell_id
+        self.assertIsNone(self.cursor.move_to_next_heading(level=6))
+        self.assertEqual(self.cursor.focus.cell_id, before)
+
+    def test_heading_nav_noop_outside_notebook_mode(self) -> None:
+        self.cursor.focus_cell(self.session.cells[1].cell_id)
+        self.cursor.enter_input_mode()
+        self.assertIsNone(self.cursor.move_to_next_heading())
+        self.assertIsNone(self.cursor.move_to_previous_heading())
+
+    def test_empty_session_heading_nav_is_safe(self) -> None:
+        bus = EventBus()
+        empty = Session.new()
+        cursor = NotebookCursor(empty, bus)
+        self.assertIsNone(cursor.move_to_next_heading())
+        self.assertIsNone(cursor.move_to_previous_heading())
+
+    def test_list_headings_returns_outline(self) -> None:
+        toc = self.cursor.list_headings()
+        self.assertEqual(
+            [(i, level, title) for i, level, title, _ in toc],
+            [(0, 1, "Intro"), (2, 2, "Setup"), (4, 1, "Runs")],
+        )
+        # cell_ids line up with the session's actual cells.
+        for i, _, _, cell_id in toc:
+            self.assertEqual(cell_id, self.session.cells[i].cell_id)
+
+
+class HeadingCreationTests(unittest.TestCase):
+    """new_heading_cell adds a landmark without entering INPUT mode."""
+
+    def setUp(self) -> None:
+        self.bus = EventBus()
+        self.session = Session.new()
+        self.cursor = NotebookCursor(self.session, self.bus)
+
+    def test_new_heading_cell_appends_and_stays_in_notebook(self) -> None:
+        cell = self.cursor.new_heading_cell(2, "Setup")
+        self.assertEqual(cell.kind, CellKind.HEADING)
+        self.assertEqual(self.cursor.focus.mode, FocusMode.NOTEBOOK)
+        self.assertEqual(self.cursor.focus.cell_id, cell.cell_id)
+        self.assertEqual(self.session.cells[-1].cell_id, cell.cell_id)
+
+    def test_new_heading_cell_publishes_cell_created(self) -> None:
+        created: list[Event] = []
+        self.bus.subscribe(EventType.CELL_CREATED, created.append)
+        cell = self.cursor.new_heading_cell(1, "Intro")
+        self.assertEqual(len(created), 1)
+        self.assertEqual(created[0].payload["cell_id"], cell.cell_id)
+
+    def test_enter_input_mode_on_heading_is_noop(self) -> None:
+        heading = self.cursor.new_heading_cell(1, "Intro")
+        result = self.cursor.enter_input_mode()
+        self.assertIsNone(result)
+        self.assertEqual(self.cursor.focus.mode, FocusMode.NOTEBOOK)
+        self.assertEqual(self.cursor.focus.cell_id, heading.cell_id)
+
+    def test_duplicate_of_heading_cell_is_also_a_heading(self) -> None:
+        self.cursor.new_heading_cell(2, "Setup")
+        dup = self.cursor.duplicate_focused_cell()
+        assert dup is not None
+        self.assertEqual(dup.kind, CellKind.HEADING)
+        self.assertEqual(dup.heading_level, 2)
+        self.assertEqual(dup.heading_title, "Setup")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds `CellKind` (`COMMAND` | `HEADING`) + `heading_level` / `heading_title` to `Cell`; new `Cell.new_heading(level, title)` factory and `is_executable` / `is_heading` predicates guard lifecycle mutations so a heading can never be mistaken for a command.
- Serialisation round-trips through `to_dict` / `from_dict`; sessions written before F61 load unchanged (missing `kind` defaults to `COMMAND`).
- `NotebookCursor` gains `new_heading_cell`, `move_to_next_heading` / `move_to_previous_heading` (NVDA-style: always step past current, optional level filter), and `list_headings()` for the upcoming `:toc` meta-command. `enter_input_mode` is a no-op on a heading; `duplicate_focused_cell` duplicates a heading as a heading.
- Intentionally additive: no router bindings, no renderer changes, no default-bank bindings, no docs flips yet. Those land in PR B.

## Test plan
- [x] `python -m unittest discover tests` — 904 passing
- [ ] Verify no regressions on PR B wiring build

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS