### PR TITLE
F61 PR B: wire NVDA-style heading navigation end to end

### DIFF
--- a/asat/app.py
+++ b/asat/app.py
@@ -311,11 +311,18 @@ class Application:
         the caller never blocks waiting for the command to finish.
         Otherwise the call runs synchronously on the caller's thread,
         matching pre-F62 behaviour.
+
+        Non-executable cells (F61 heading landmarks, future read-only
+        kinds) are silently skipped so an accidental stray id cannot
+        crash the driver — the router paths already guard against
+        routing headings here, this is belt-and-braces.
         """
+        cell = self.session.get_cell(cell_id)
+        if not cell.is_executable:
+            return
         if self.execution_worker is not None:
             self.execution_worker.enqueue(cell_id)
             return
-        cell = self.session.get_cell(cell_id)
         self.kernel.execute(cell)
 
     def close(self) -> None:

--- a/asat/default_bank.py
+++ b/asat/default_bank.py
@@ -440,12 +440,21 @@ def _default_bindings() -> tuple[EventBinding, ...]:
             priority=110,
         ),
         EventBinding(
+            id="focus_changed_heading",
+            event_type=EventType.FOCUS_CHANGED.value,
+            voice_id="narrator",
+            sound_id="nav_blip",
+            say_template="heading level {heading_level} {heading_title}",
+            predicate="transition == cell and kind == 'heading'",
+            priority=120,
+        ),
+        EventBinding(
             id="focus_changed_cell",
             event_type=EventType.FOCUS_CHANGED.value,
             voice_id="narrator",
             sound_id="nav_blip",
             say_template="{command}",
-            predicate="transition == cell",
+            predicate="transition == cell and kind == 'command'",
             priority=100,
         ),
         EventBinding(

--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -97,6 +97,10 @@ def default_bindings() -> BindingMap:
         `d` deletes the focused cell, `y` duplicates it,
         Alt+Up / Alt+Down move the focused cell within the session,
         F2 (or Ctrl+.) opens the contextual actions menu.
+        NVDA-style heading navigation (F61):
+          `]` / `[` jump forward / backward to the next heading
+            of any level,
+          `1`..`6` jump forward to the next heading of that level.
 
     INPUT mode:
         Backspace deletes the character before the caret,
@@ -152,6 +156,14 @@ def default_bindings() -> BindingMap:
             Key.printable("y"): "duplicate_cell",
             Key.special("up", Modifier.ALT): "move_cell_up",
             Key.special("down", Modifier.ALT): "move_cell_down",
+            Key.printable("]"): "next_heading",
+            Key.printable("["): "prev_heading",
+            Key.printable("1"): "next_heading_1",
+            Key.printable("2"): "next_heading_2",
+            Key.printable("3"): "next_heading_3",
+            Key.printable("4"): "next_heading_4",
+            Key.printable("5"): "next_heading_5",
+            Key.printable("6"): "next_heading_6",
             kc.F2: "open_action_menu",
             menu_open: "open_action_menu",
             repeat_narration: "repeat_last_narration",
@@ -226,6 +238,8 @@ META_COMMANDS: tuple[str, ...] = (
     "welcome",
     "repeat",
     "state",
+    "heading",
+    "toc",
 )
 
 # "Ambient" meta-commands do their job without taking focus away from
@@ -236,7 +250,7 @@ META_COMMANDS: tuple[str, ...] = (
 # mode. Commands NOT in this set (today: `:settings`, `:quit`)
 # inherently require a mode change and go through `abandon_input_mode`.
 AMBIENT_META_COMMANDS: frozenset[str] = frozenset(
-    {"help", "save", "pwd", "commands", "welcome", "repeat", "state"}
+    {"help", "save", "pwd", "commands", "welcome", "repeat", "state", "toc"}
 )
 
 # `:name optional-argument` — case-insensitive in the name, everything
@@ -251,6 +265,7 @@ HELP_LINES: tuple[str, ...] = (
     "ASAT quick reference.",
     "NOTEBOOK:  Up/Down walk cells, Enter type, Ctrl+N new, Ctrl+O output, Ctrl+, settings.",
     "           d delete, y duplicate, Alt+Up/Down reorder.",
+    "           ] / [ next / prev heading; 1..6 next heading of that level.",
     "INPUT:     Enter submits, Escape leaves without running.",
     "           Backspace/Delete cut, Left/Right walk, Home/End jump (or Ctrl+A/E).",
     "           Ctrl+W kills word, Ctrl+U kills to start, Ctrl+K kills to end.",
@@ -261,7 +276,7 @@ HELP_LINES: tuple[str, ...] = (
     "           Ctrl+Z undo, Ctrl+Y redo edits in the order you made them.",
     "           Ctrl+R resets to defaults at cursor scope (Enter confirms, Escape cancels).",
     "Menu:      F2 (or Ctrl+.) opens contextual actions; Up/Down walk, Enter invokes, Escape closes.",
-    "Meta:      :help, :settings, :save, :quit, :delete, :duplicate, :pwd, :state, :commands, :reset, :welcome, :repeat.",
+    "Meta:      :help, :settings, :save, :quit, :delete, :duplicate, :pwd, :state, :commands, :reset, :welcome, :repeat, :heading, :toc.",
     "           `:help topics` lists focused tours; `:help <topic>` narrates one (navigation, cells, settings, audio, search, meta).",
     "           `:welcome` replays the first-run tour; `:repeat` (or Ctrl+R in notebook/input) re-speaks the last narration.",
     "           Meta-commands are case-insensitive and accept a trailing argument.",
@@ -585,9 +600,56 @@ class InputRouter:
             self._publish_commands()
         elif command == "reset":
             self._handle_meta_reset(argument)
+        elif command == "heading":
+            self._handle_meta_heading(argument)
+        elif command == "toc":
+            self._publish_toc()
         # `repeat`, `save`, `quit`, `welcome` are handled by the
         # Application via the ACTION_INVOKED payload's `meta_command`
         # key — no router-side dispatch needed here.
+
+    def _handle_meta_heading(self, argument: str) -> None:
+        """Append a heading cell from `:heading <level> <title>`.
+
+        Expects `<level>` as a single digit 1..6 followed by a
+        non-empty title. Malformed arguments surface a HELP_REQUESTED
+        hint instead of silently creating a wrong-level heading.
+        """
+        level, title = _parse_heading_argument(argument)
+        if level is None or title is None:
+            publish_event(
+                self._bus,
+                EventType.HELP_REQUESTED,
+                {
+                    "lines": [
+                        "`:heading <level> <title>` — level is 1..6, "
+                        "title is the remainder of the line.",
+                        "Example: `:heading 2 Setup`.",
+                    ],
+                },
+                source=self.SOURCE,
+            )
+            return
+        self._cursor.new_heading_cell(level, title)
+
+    def _publish_toc(self) -> None:
+        """Announce the notebook's heading outline via HELP_REQUESTED."""
+        toc = self._cursor.list_headings()
+        if not toc:
+            lines = [
+                "No headings in this notebook yet.",
+                "Add one with `:heading <level> <title>` (level 1..6).",
+            ]
+        else:
+            lines = ["Table of contents:"]
+            for index, level, title, _ in toc:
+                lines.append(f"  cell {index + 1}: H{level} — {title}")
+        publish_event(
+            self._bus,
+            EventType.HELP_REQUESTED,
+            {"lines": lines},
+            source=self.SOURCE,
+        )
 
     def _handle_meta_reset(self, argument: str) -> None:
         """Open settings mode and begin a reset confirmation.
@@ -1050,6 +1112,14 @@ class InputRouter:
             "duplicate_cell": _void(self._cursor.duplicate_focused_cell),
             "move_cell_up": _void(lambda: self._cursor.move_focused_cell(-1)),
             "move_cell_down": _void(lambda: self._cursor.move_focused_cell(+1)),
+            "next_heading": self._next_heading_action(None),
+            "prev_heading": self._prev_heading_action(None),
+            "next_heading_1": self._next_heading_action(1),
+            "next_heading_2": self._next_heading_action(2),
+            "next_heading_3": self._next_heading_action(3),
+            "next_heading_4": self._next_heading_action(4),
+            "next_heading_5": self._next_heading_action(5),
+            "next_heading_6": self._next_heading_action(6),
             "output_search_begin": self._output_search_begin,
             "output_goto_begin": self._output_goto_begin,
             "output_search_next": self._output_search_next,
@@ -1072,6 +1142,30 @@ class InputRouter:
         if self._output_cursor is None:
             return
         operation(self._output_cursor)
+
+    def _next_heading_action(self, level: Optional[int]) -> ActionHandler:
+        """Handler that reports whether a forward heading jump landed."""
+        def handler() -> Optional[dict[str, object]]:
+            cell = self._cursor.move_to_next_heading(level=level)
+            payload: dict[str, object] = {"matched": cell is not None}
+            if level is not None:
+                payload["level"] = level
+            if cell is not None:
+                payload["cell_id"] = cell.cell_id
+            return payload
+        return handler
+
+    def _prev_heading_action(self, level: Optional[int]) -> ActionHandler:
+        """Handler that reports whether a backward heading jump landed."""
+        def handler() -> Optional[dict[str, object]]:
+            cell = self._cursor.move_to_previous_heading(level=level)
+            payload: dict[str, object] = {"matched": cell is not None}
+            if level is not None:
+                payload["level"] = level
+            if cell is not None:
+                payload["cell_id"] = cell.cell_id
+            return payload
+        return handler
 
     def _output_search_begin(self) -> Optional[dict[str, object]]:
         """Open the `/` search composer on the attached output cursor."""
@@ -1198,6 +1292,31 @@ def _suggest_meta_command(name: str) -> Optional[str]:
         name.lower(), META_COMMANDS, n=1, cutoff=0.6
     )
     return matches[0] if matches else None
+
+
+def _parse_heading_argument(argument: str) -> tuple[Optional[int], Optional[str]]:
+    """Parse `<level> <title>` from a `:heading` meta-command argument.
+
+    Returns `(level, title)` on success or `(None, None)` for any
+    malformed input. `level` must be a single digit 1..6; `title`
+    must be non-empty after stripping whitespace.
+    """
+    stripped = argument.strip()
+    if not stripped:
+        return None, None
+    parts = stripped.split(maxsplit=1)
+    if len(parts) != 2:
+        return None, None
+    level_text, title = parts
+    if not level_text.isdigit():
+        return None, None
+    level = int(level_text)
+    if not (1 <= level <= 6):
+        return None, None
+    title = title.strip()
+    if not title:
+        return None, None
+    return level, title
 
 
 def _parse_reset_scope(argument: str) -> Optional[ResetScope]:

--- a/asat/notebook.py
+++ b/asat/notebook.py
@@ -673,9 +673,16 @@ class NotebookCursor:
             transition = "buffer"
         self._state = new_state
         command = ""
+        kind_value = CellKind.COMMAND.value
+        heading_level: Optional[int] = None
+        heading_title: Optional[str] = None
         if new_state.cell_id is not None:
             try:
-                command = self._session.get_cell(new_state.cell_id).command
+                focused = self._session.get_cell(new_state.cell_id)
+                command = focused.command
+                kind_value = focused.kind.value
+                heading_level = focused.heading_level
+                heading_title = focused.heading_title
             except SessionError:
                 command = ""
         publish_event(
@@ -689,6 +696,9 @@ class NotebookCursor:
                 "input_buffer": new_state.input_buffer,
                 "transition": transition,
                 "command": command,
+                "kind": kind_value,
+                "heading_level": heading_level,
+                "heading_title": heading_title,
             },
             source=self.SOURCE,
         )

--- a/asat/sound_engine.py
+++ b/asat/sound_engine.py
@@ -23,6 +23,7 @@ turning the bank into a programming language:
     key == <literal>        equality (literal parsed via ast.literal_eval)
     key != <literal>        inequality
     key in [<literals>]     membership in a list
+    <clause> and <clause>   conjunction (all clauses must match)
 
 Templates use `str.format_map` with a default-to-empty-string missing
 lookup so a binding can reference any payload key without worrying
@@ -99,6 +100,10 @@ class DefaultPredicateEvaluator:
         text = expression.strip()
         if not text:
             return True
+        if " and " in text:
+            return all(
+                self.matches(clause, payload) for clause in text.split(" and ")
+            )
         for operator, comparer in (
             (" != ", _not_equal),
             (" == ", _equal),

--- a/asat/terminal.py
+++ b/asat/terminal.py
@@ -98,6 +98,14 @@ class TerminalRenderer:
         mode = event.payload.get("new_mode", "?")
         cell_id = event.payload.get("new_cell_id")
         suffix = f" #{cell_id[:6]}" if isinstance(cell_id, str) else ""
+        kind = event.payload.get("kind")
+        heading_level = event.payload.get("heading_level")
+        heading_title = event.payload.get("heading_title")
+        if kind == "heading" and heading_level is not None and heading_title:
+            self._write_line(
+                f"[{mode}{suffix} H{heading_level} {heading_title}]"
+            )
+            return
         self._write_line(f"[{mode}{suffix}]")
 
     def _on_action_invoked(self, event: Event) -> None:

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -134,7 +134,7 @@ and `asat.notebook.NotebookCursor` (`source="notebook"`).
 
 | EventType        | Payload keys                                                                   | Source          |
 |------------------|--------------------------------------------------------------------------------|-----------------|
-| `FOCUS_CHANGED`  | `old_mode`, `new_mode`, `old_cell_id`, `new_cell_id`, `input_buffer`, `transition`, `command` | `notebook`      |
+| `FOCUS_CHANGED`  | `old_mode`, `new_mode`, `old_cell_id`, `new_cell_id`, `input_buffer`, `transition`, `command`, `kind`, `heading_level`, `heading_title` | `notebook`      |
 | `KEY_PRESSED`    | `name`, `char`, `modifiers`                                                    | `input_router`  |
 | `ACTION_INVOKED` | `action`, `focus_mode`, `cell_id`, `key_name`, plus action-specific extras     | `input_router`  |
 
@@ -148,6 +148,13 @@ and `asat.notebook.NotebookCursor` (`source="notebook"`).
 * `command` is the focused cell's current command text at transition
   time, or `""` when no cell is focused. Bindings can narrate it with
   a `{command}` template.
+* `kind` is the focused cell's `CellKind` value (`"command"` or
+  `"heading"`) at transition time; defaults to `"command"` when no
+  cell is focused. `heading_level` / `heading_title` are populated
+  only for heading cells (1-6 and the title string respectively);
+  otherwise `None`. Bindings can branch on `transition == cell and
+  kind == 'heading'` to narrate headings distinctly — see the
+  `focus_changed_heading` binding in the default bank.
 
 `ACTION_INVOKED` extras:
 

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -3300,43 +3300,43 @@ killing-the-shell, sentinel-prefix-mid-line) and
 
 ## F61 — Cell hierarchy: sections, folds, and grouping
 
-**Gap.** `Session.cells` is a flat ordered list. There is no
-parent/child relationship, no section header that groups several
-cells together, no fold/collapse, no "this cell depends on that
-cell". The only navigation primitive is "previous / next cell
-linearly" (`asat/notebook.py:546-559`).
+**Sketch (partially shipped).** The flat `Session.cells` list now
+has a polymorphic `Cell.kind: CellKind` discriminator with two
+values: `COMMAND` (the existing executable cell) and `HEADING`
+(an announce-only section header carrying `heading_level` 1-6 and
+`heading_title`). Heading cells cannot be executed (`mark_running`
+/ `update_command` guard on `is_executable`); `Application.execute`
+short-circuits if the target cell is a heading. Session JSON
+gained `kind` / `heading_level` / `heading_title` fields with
+backward compatibility — a missing `kind` defaults to `COMMAND` so
+pre-F61 sessions keep loading.
 
-**Where it surfaces.** A long session — say twenty exploratory
-shell commands followed by ten cells of a Python data pull —
-walks as a single flat list. A user who wants to "jump back to
-the data-pull section" has to remember roughly where it started
-and Up-arrow there. There is no "collapse the chunk I'm not
-working on", no folding for navigation by section, and no parent
-context narrated when entering a cell.
+NOTEBOOK mode gained NVDA-style keystrokes for outline jumping:
+`]` / `[` step to the next / previous heading of any level, and
+`1`-`6` jump to the next heading of that specific level. INPUT
+mode grew two meta-commands: `:heading <level> <title>` inserts a
+heading cell before the next prompt, and `:toc` narrates the
+outline (ambient — the buffer survives so the user can resume
+typing). `FOCUS_CHANGED` now carries `kind` / `heading_level` /
+`heading_title`; the default sound bank branches on
+`transition == cell and kind == 'heading'` to voice "heading level
+N: title" instead of the usual `{command}` readout.
 
-**Sketch.** Two layered changes, either one shippable on its
-own.
-
-1. **Section headers (lightweight).** Add a new `CellKind`
-   discriminator on `Cell` (`SECTION` vs the existing
-   `COMMAND`). A section cell carries a title string, no
-   command, no output. NOTEBOOK navigation gains
-   "previous / next section" (Ctrl+Up / Ctrl+Down) and the
-   `:state` meta-command additionally narrates "section: <title>"
-   when the cursor is inside one. Sections do not nest in the
-   first cut.
-2. **Folding (deeper).** Each section can be collapsed; while
-   collapsed, Up/Down skips its children and the narrator says
-   "section <title>, <N> cells, collapsed". A `z` keystroke at
-   a section header toggles the fold, mirroring vim.
+**Remaining.** Parent-scope navigation (`{` / `}` jump to the
+enclosing heading), fold / collapse (`z` toggles), and scope-
+based selection (`select_heading_scope()` picks the focused
+heading plus its children through the next same-level heading)
+are still open. Those layer on top of the current flat
+implementation without rewriting it.
 
 **Forward-looking notes.**
 
 - **Nested sections.** Real-world workflows want subsections
   (a top-level "data" section with "load" and "clean"
-  subsections). Defer to a v2 once the flat case settles —
-  nesting adds focus-restoration complexity (where does the
-  cursor land after collapsing the parent of where you were?).
+  subsections). The `heading_level` field already models nesting;
+  what's missing is a `scope_range(cells, heading_index)` helper
+  and focus-restoration rules when collapsing a parent of the
+  current cursor.
 - **Cross-cell dependencies.** Once F60 ships a persistent
   backend, sections become natural dependency boundaries (a
   "setup" section everyone re-runs, a "scratch" section nobody
@@ -3344,8 +3344,10 @@ own.
 - **Macro interaction.** F56's `expect`/`capture` steps will
   want a way to address "every cell in section X" — give
   sections stable ids, not just titles.
-- **Persistence.** Bump the `Session` JSON schema_version when
-  sections land so loaders can detect old files cleanly.
+- **Persistence.** The current loader accepts missing `kind` as
+  `COMMAND`; when folding / scope data lands, bump
+  `Session.schema_version` so old loaders reject files they
+  cannot render faithfully.
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -283,6 +283,8 @@ discarded and the cell is not modified.
 | `:state`     | Narrate focus mode, cell position, session id, and cwd. |
 | `:commands`  | List every available meta-command.                   |
 | `:reset bank` | Reset the whole sound bank to the built-in defaults (also `:reset all`). |
+| `:heading <level> <title>` | Append a heading landmark at level 1..6 for NVDA-style navigation (F61). |
+| `:toc`       | Narrate the notebook's heading outline.              |
 
 Meta-command names are **case-insensitive** — `:HELP`, `:Help`, and
 `:help` all do the same thing. A single trailing argument is
@@ -542,6 +544,8 @@ Every key you need, one table.
 | NOTEBOOK   | Alt+Up / Alt+Down | Move focused cell up / down           |
 | NOTEBOOK   | Ctrl+R            | Repeat the most recent narration      |
 | NOTEBOOK   | F2 / Ctrl+.       | Open actions menu                     |
+| NOTEBOOK   | `]` / `[`         | Next / previous heading (any level)   |
+| NOTEBOOK   | `1`..`6`          | Next heading of that level (F61)      |
 | INPUT      | Enter             | Submit command                        |
 | INPUT      | Backspace         | Delete char before caret              |
 | INPUT      | Delete            | Delete char under caret               |
@@ -566,6 +570,8 @@ Every key you need, one table.
 | INPUT      | `:state`⏎         | Announce focus, cell position, cwd    |
 | INPUT      | `:commands`⏎      | List every meta-command               |
 | INPUT      | `:reset bank`⏎    | Reset the whole bank to defaults      |
+| INPUT      | `:heading <N> <title>`⏎ | Append a level-N heading landmark |
+| INPUT      | `:toc`⏎           | Narrate the heading outline           |
 | OUTPUT     | Up / Down         | Prev / next line                      |
 | OUTPUT     | PageUp / PageDown | Jump a page                           |
 | OUTPUT     | Home / End        | First / last line                     |

--- a/tests/test_default_bank.py
+++ b/tests/test_default_bank.py
@@ -54,6 +54,9 @@ SAMPLE_PAYLOADS: dict[EventType, dict[str, object]] = {
         "input_buffer": "",
         "transition": "mode",
         "command": "",
+        "kind": "command",
+        "heading_level": None,
+        "heading_title": None,
     },
     EventType.OUTPUT_LINE_FOCUSED: {
         "cell_id": "c1",
@@ -284,6 +287,61 @@ class DefaultBankSmokeTests(unittest.TestCase):
                 "command_failed_timeout",
                 "command_failed_generic",
             ],
+        )
+
+    def test_focus_changed_cell_branches_by_kind(self) -> None:
+        """F61: heading landings narrate the heading; command landings
+        narrate the command. The two branches are mutually exclusive so
+        the user never hears both."""
+        bus = EventBus()
+        sink = MemorySink()
+        engine = SoundEngine(bus, default_sound_bank(), sink, sample_rate=8000)
+        self.addCleanup(engine.close)
+
+        spoken_labels: list[str] = []
+        bus.subscribe(
+            EventType.AUDIO_SPOKEN,
+            lambda event: spoken_labels.append(event.payload["binding_id"]),
+        )
+
+        publish_event(
+            bus,
+            EventType.FOCUS_CHANGED,
+            {
+                "old_mode": "notebook",
+                "new_mode": "notebook",
+                "old_cell_id": "c0",
+                "new_cell_id": "c1",
+                "input_buffer": "",
+                "transition": "cell",
+                "command": "",
+                "kind": "heading",
+                "heading_level": 2,
+                "heading_title": "Setup",
+            },
+            source="notebook",
+        )
+        publish_event(
+            bus,
+            EventType.FOCUS_CHANGED,
+            {
+                "old_mode": "notebook",
+                "new_mode": "notebook",
+                "old_cell_id": "c1",
+                "new_cell_id": "c2",
+                "input_buffer": "",
+                "transition": "cell",
+                "command": "ls",
+                "kind": "command",
+                "heading_level": None,
+                "heading_title": None,
+            },
+            source="notebook",
+        )
+
+        self.assertEqual(
+            spoken_labels,
+            ["focus_changed_heading", "focus_changed_cell"],
         )
 
     def test_settings_reset_outcome_branches_each_pick_a_binding(self) -> None:

--- a/tests/test_input_router.py
+++ b/tests/test_input_router.py
@@ -1676,5 +1676,183 @@ class ParseResetScopeTests(unittest.TestCase):
         self.assertIsNone(_parse_reset_scope("everything"))
 
 
+class HeadingNavigationBindingTests(unittest.TestCase):
+    """F61: `]` / `[` and `1`..`6` walk headings from NOTEBOOK mode."""
+
+    def _build_with_headings(self):
+        bus = EventBus()
+        session = Session.new()
+        session.add_cell(Cell.new_heading(1, "Intro"))
+        session.add_cell(Cell.new("ls"))
+        session.add_cell(Cell.new_heading(2, "Setup"))
+        session.add_cell(Cell.new("install"))
+        session.add_cell(Cell.new_heading(1, "Runs"))
+        cursor = NotebookCursor(session, bus)
+        cursor.focus_cell(session.cells[0].cell_id)
+        router = InputRouter(cursor, bus)
+        return bus, session, cursor, router
+
+    def test_right_bracket_jumps_to_next_heading_any_level(self) -> None:
+        _bus, session, cursor, router = self._build_with_headings()
+        action = router.handle_key(Key.printable("]"))
+        self.assertEqual(action, "next_heading")
+        self.assertEqual(cursor.focus.cell_id, session.cells[2].cell_id)
+
+    def test_left_bracket_jumps_to_previous_heading_any_level(self) -> None:
+        _bus, session, cursor, router = self._build_with_headings()
+        cursor.focus_cell(session.cells[-1].cell_id)
+        action = router.handle_key(Key.printable("["))
+        self.assertEqual(action, "prev_heading")
+        self.assertEqual(cursor.focus.cell_id, session.cells[2].cell_id)
+
+    def test_digit_one_jumps_to_next_h1(self) -> None:
+        _bus, session, cursor, router = self._build_with_headings()
+        action = router.handle_key(Key.printable("1"))
+        self.assertEqual(action, "next_heading_1")
+        self.assertEqual(cursor.focus.cell_id, session.cells[4].cell_id)
+
+    def test_digit_two_jumps_to_next_h2(self) -> None:
+        _bus, session, cursor, router = self._build_with_headings()
+        action = router.handle_key(Key.printable("2"))
+        self.assertEqual(action, "next_heading_2")
+        self.assertEqual(cursor.focus.cell_id, session.cells[2].cell_id)
+
+    def test_digit_no_match_is_reported_via_action_payload(self) -> None:
+        bus, session, cursor, router = self._build_with_headings()
+        rec = _Recorder(bus)
+        router.handle_key(Key.printable("6"))  # no H6 in this session
+        invoked = rec.types_of(EventType.ACTION_INVOKED)
+        self.assertEqual(invoked[-1].payload["action"], "next_heading_6")
+        self.assertFalse(invoked[-1].payload["matched"])
+        # Cursor stays put.
+        self.assertEqual(cursor.focus.cell_id, session.cells[0].cell_id)
+
+    def test_heading_nav_ignored_in_input_mode(self) -> None:
+        _bus, _session, cursor, router = self._build_with_headings()
+        cursor.focus_cell(cursor.session.cells[1].cell_id)  # command cell
+        cursor.enter_input_mode()
+        # `]` is printable in INPUT mode — it falls through as a
+        # text insertion. That's the correct behaviour.
+        router.handle_key(Key.printable("]"))
+        self.assertEqual(cursor.focus.mode, FocusMode.INPUT)
+        self.assertEqual(cursor.focus.input_buffer, "ls]")
+
+    def test_heading_nav_payload_reports_level_when_filtered(self) -> None:
+        bus, _session, _cursor, router = self._build_with_headings()
+        rec = _Recorder(bus)
+        router.handle_key(Key.printable("1"))
+        invoked = [e for e in rec.types_of(EventType.ACTION_INVOKED) if e.payload["action"] == "next_heading_1"]
+        self.assertEqual(invoked[-1].payload["level"], 1)
+
+
+class HeadingMetaCommandTests(unittest.TestCase):
+    """F61: `:heading <level> <title>` and `:toc`."""
+
+    def _type_meta(self, router, cursor, text: str) -> None:
+        cursor.enter_input_mode()
+        # Clear any pre-existing command text first so the meta-line
+        # is submitted cleanly.
+        router.handle_key(Key.combo("u", Modifier.CTRL))
+        for ch in text:
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+
+    def test_heading_meta_creates_heading_cell(self) -> None:
+        bus, session, cursor, router, _ = _build(["ls"])
+        self._type_meta(router, cursor, ":heading 2 Setup")
+        # New heading appended at end.
+        last = session.cells[-1]
+        self.assertEqual(last.heading_level, 2)
+        self.assertEqual(last.heading_title, "Setup")
+        self.assertEqual(cursor.focus.cell_id, last.cell_id)
+        self.assertEqual(cursor.focus.mode, FocusMode.NOTEBOOK)
+
+    def test_heading_meta_rejects_bad_level(self) -> None:
+        bus, session, cursor, router, _ = _build(["ls"])
+        rec = _Recorder(bus)
+        initial_count = len(session.cells)
+        self._type_meta(router, cursor, ":heading 9 Bad")
+        # `:heading` is non-ambient — it abandons INPUT and does not
+        # auto-advance, so cell count stays put.
+        self.assertEqual(len(session.cells), initial_count)
+        for cell in session.cells:
+            self.assertFalse(cell.is_heading)
+        help_events = rec.types_of(EventType.HELP_REQUESTED)
+        self.assertTrue(help_events)
+        self.assertIn(":heading", "\n".join(help_events[-1].payload["lines"]))
+
+    def test_heading_meta_rejects_missing_title(self) -> None:
+        bus, session, cursor, router, _ = _build(["ls"])
+        rec = _Recorder(bus)
+        self._type_meta(router, cursor, ":heading 2")
+        for cell in session.cells:
+            self.assertFalse(cell.is_heading)
+        self.assertTrue(rec.types_of(EventType.HELP_REQUESTED))
+
+    def test_toc_meta_publishes_outline(self) -> None:
+        bus = EventBus()
+        session = Session.new()
+        session.add_cell(Cell.new_heading(1, "Intro"))
+        session.add_cell(Cell.new("ls"))
+        session.add_cell(Cell.new_heading(2, "Setup"))
+        cursor = NotebookCursor(session, bus)
+        cursor.focus_cell(session.cells[1].cell_id)
+        router = InputRouter(cursor, bus)
+        rec = _Recorder(bus)
+        self._type_meta(router, cursor, ":toc")
+        help_events = rec.types_of(EventType.HELP_REQUESTED)
+        self.assertTrue(help_events)
+        lines = help_events[-1].payload["lines"]
+        text = "\n".join(lines)
+        self.assertIn("Intro", text)
+        self.assertIn("Setup", text)
+        self.assertIn("H1", text)
+        self.assertIn("H2", text)
+
+    def test_toc_meta_empty_notebook_hint(self) -> None:
+        bus, _session, cursor, router, _ = _build(["ls"])
+        rec = _Recorder(bus)
+        self._type_meta(router, cursor, ":toc")
+        help_events = rec.types_of(EventType.HELP_REQUESTED)
+        self.assertTrue(help_events)
+        text = "\n".join(help_events[-1].payload["lines"])
+        self.assertIn("No headings", text)
+
+    def test_toc_meta_is_ambient(self) -> None:
+        """`:toc` keeps the user in INPUT mode so they can keep typing."""
+        from asat.input_router import AMBIENT_META_COMMANDS
+        self.assertIn("toc", AMBIENT_META_COMMANDS)
+
+
+class ParseHeadingArgumentTests(unittest.TestCase):
+    """F61: `:heading <level> <title>` argument parser."""
+
+    def test_valid_level_and_title(self) -> None:
+        from asat.input_router import _parse_heading_argument
+        self.assertEqual(_parse_heading_argument("2 Setup"), (2, "Setup"))
+        self.assertEqual(
+            _parse_heading_argument("  1  A longer title "),
+            (1, "A longer title"),
+        )
+
+    def test_missing_title_returns_none(self) -> None:
+        from asat.input_router import _parse_heading_argument
+        self.assertEqual(_parse_heading_argument("2"), (None, None))
+        self.assertEqual(_parse_heading_argument("2   "), (None, None))
+
+    def test_empty_returns_none(self) -> None:
+        from asat.input_router import _parse_heading_argument
+        self.assertEqual(_parse_heading_argument(""), (None, None))
+
+    def test_out_of_range_level_returns_none(self) -> None:
+        from asat.input_router import _parse_heading_argument
+        self.assertEqual(_parse_heading_argument("0 zero"), (None, None))
+        self.assertEqual(_parse_heading_argument("7 seven"), (None, None))
+
+    def test_non_numeric_level_returns_none(self) -> None:
+        from asat.input_router import _parse_heading_argument
+        self.assertEqual(_parse_heading_argument("H1 Intro"), (None, None))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sound_engine.py
+++ b/tests/test_sound_engine.py
@@ -80,6 +80,26 @@ class PredicateTests(unittest.TestCase):
         with self.assertRaises(SoundEngineError):
             self.evaluator.matches("stream ~= 'weird'", {"stream": "x"})
 
+    def test_conjunction_requires_all_clauses_to_match(self) -> None:
+        payload = {"transition": "cell", "kind": "heading"}
+        self.assertTrue(
+            self.evaluator.matches(
+                "transition == 'cell' and kind == 'heading'", payload
+            )
+        )
+        self.assertFalse(
+            self.evaluator.matches(
+                "transition == 'cell' and kind == 'heading'",
+                {"transition": "cell", "kind": "command"},
+            )
+        )
+        self.assertFalse(
+            self.evaluator.matches(
+                "transition == 'cell' and kind == 'heading'",
+                {"transition": "mode", "kind": "heading"},
+            )
+        )
+
 
 class SoundEngineDispatchTests(unittest.TestCase):
 


### PR DESCRIPTION
## Summary

F61 PR A (merged in #66) added `CellKind`, heading fields on `Cell`, and heading navigation on `NotebookCursor` as pure data + cursor changes. This PR wires those primitives into the five surfaces that actually observe them, so a blind user can land on a heading and hear "heading level 2: setup" instead of the usual command readout, and a sighted developer running `python -m asat` sees a matching outline hint.

### What lands

- **Input router.** NOTEBOOK gets `]` / `[` (next / previous heading of any level) and `1`..`6` (next heading of that specific level). INPUT grows two meta-commands — `:heading <level> <title>` inserts a heading before the next prompt (non-ambient, abandons the buffer), and `:toc` narrates the outline (ambient, preserves the in-flight command so a user can peek at structure mid-typing). `_parse_heading_argument` lives as a module-level helper with its own tests.
- **Application.** `execute(cell_id)` early-returns when the target cell is non-executable, so pressing Enter on a heading or enqueueing one via `ExecutionWorker` is a safe no-op instead of a shell-backend crash.
- **Notebook cursor.** `_transition` adds `kind`, `heading_level`, and `heading_title` to every `FOCUS_CHANGED` payload so downstream observers can branch without reaching back into the session.
- **Terminal renderer.** Heading landings render as `[<mode> #<id> H<level> <title>]` instead of the plain `[<mode> #<id>]`.
- **Default sound bank.** New `focus_changed_heading` binding (priority 120, predicate `transition == cell and kind == 'heading'`) voices "heading level N title"; the existing `focus_changed_cell` narrows to `kind == 'command'` so the two branches are mutually exclusive. Enabling the conjunction predicate required the smallest possible grammar extension in `sound_engine.DefaultPredicateEvaluator` — split on ` and ` and require every clause to match.

### Docs

- `USER_MANUAL.md` — `:heading` / `:toc` rows in the meta-command table and the INPUT cheat sheet; new NOTEBOOK cheat-sheet entries for `] / [` and `1..6`.
- `FEATURE_REQUESTS.md` — F61 flips to "partially shipped"; remaining fold / scope work called out explicitly.
- `EVENTS.md` — three new FOCUS_CHANGED payload keys documented with a pointer at the new default-bank binding.

## Test plan

- [x] 20 new tests across router / default bank / predicate grammar
- [x] Full suite `python -m unittest discover tests` — 924 passing
- [x] `test_every_meta_command_is_documented` passes (USER_MANUAL sync gate)
- [ ] Manual smoke: press `2` twice in a session with mixed headings to confirm the narrator speaks "heading level 2 …" and nothing else

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS