### PR TITLE
F4: Up/Down recall command history in INPUT mode

### DIFF
--- a/asat/help_topics.py
+++ b/asat/help_topics.py
@@ -21,7 +21,7 @@ HELP_TOPICS: dict[str, tuple[str, ...]] = {
     "navigation": (
         "Navigation topic.",
         "NOTEBOOK mode is the home base. Up/Down walk between cells, Home/End jump to the ends of the session, Enter enters INPUT mode on the focused cell, Ctrl+N appends a fresh cell.",
-        "INPUT mode is where you type a command. Enter submits, Escape leaves without running. Left/Right walk the caret; Home/End jump to the line's start/end.",
+        "INPUT mode is where you type a command. Enter submits, Escape leaves without running. Left/Right walk the caret; Home/End jump to the line's start/end. Up/Down walk command history; Down past the most recent restores the in-progress draft.",
         "OUTPUT mode steps through a cell's captured output line-by-line. Ctrl+O enters it, Up/Down step, PageUp/PageDown page, Escape leaves.",
         "Escape is always safe — from any mode it returns you one level up toward NOTEBOOK.",
     ),

--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -107,6 +107,8 @@ def default_bindings() -> BindingMap:
         Delete removes the character under the caret,
         Left / Right / Home / End move the caret within the buffer
         (Ctrl+A / Ctrl+E also jump to start / end),
+        Up / Down walk command history (most recent first; Down past
+        the most recent restores the in-progress draft),
         Ctrl+W kills the word before the caret,
         Ctrl+U kills from the start of the buffer to the caret,
         Ctrl+K kills from the caret to the end of the buffer,
@@ -175,6 +177,8 @@ def default_bindings() -> BindingMap:
             kc.RIGHT: "cursor_right",
             kc.HOME: "cursor_home",
             kc.END: "cursor_end",
+            kc.UP: "history_previous",
+            kc.DOWN: "history_next",
             Key.combo("a", Modifier.CTRL): "cursor_home",
             Key.combo("e", Modifier.CTRL): "cursor_end",
             Key.combo("w", Modifier.CTRL): "delete_word_left",
@@ -283,6 +287,7 @@ HELP_LINES: tuple[str, ...] = (
     "           ] / [ next / prev heading; 1..6 next heading of that level.",
     "INPUT:     Enter submits, Escape leaves without running.",
     "           Backspace/Delete cut, Left/Right walk, Home/End jump (or Ctrl+A/E).",
+    "           Up/Down walk command history (Down past newest restores your draft).",
     "           Ctrl+W kills word, Ctrl+U kills to start, Ctrl+K kills to end.",
     "OUTPUT:    Up/Down step lines, PageUp/PageDown page, Escape leaves.",
     "           / search (type query, Enter commits), n / N next / prev hit, g jump-to-line.",
@@ -1074,6 +1079,8 @@ class InputRouter:
             "delete_word_left": _void(self._cursor.delete_word_left),
             "delete_to_start": _void(self._cursor.delete_to_start),
             "delete_to_end": _void(self._cursor.delete_to_end),
+            "history_previous": self._history_previous,
+            "history_next": self._history_next,
             "view_output": _void(self._view_output),
             "exit_output": _void(self._cursor.exit_output_mode),
             "submit": self._submit,
@@ -1181,6 +1188,16 @@ class InputRouter:
                 payload["cell_id"] = cell.cell_id
             return payload
         return handler
+
+    def _history_previous(self) -> Optional[dict[str, object]]:
+        """Recall an older command from the session's history."""
+        recalled = self._cursor.history_previous()
+        return {"recalled": recalled}
+
+    def _history_next(self) -> Optional[dict[str, object]]:
+        """Step forward through history (or restore the in-progress draft)."""
+        recalled = self._cursor.history_next()
+        return {"recalled": recalled}
 
     def _output_search_begin(self) -> Optional[dict[str, object]]:
         """Open the `/` search composer on the attached output cursor."""

--- a/asat/notebook.py
+++ b/asat/notebook.py
@@ -92,6 +92,14 @@ class NotebookCursor:
         self._state = FocusState(mode=FocusMode.NOTEBOOK, cell_id=initial_cell_id)
         if initial_cell_id is not None and session.active_cell_id is None:
             session.set_active(initial_cell_id)
+        # F4 history-recall browse state. ``_history_index`` is None
+        # whenever we're not actively walking history; an integer means
+        # the buffer currently shows ``session.command_history[idx]``.
+        # ``_history_pre_browse`` remembers what the user had typed
+        # before they reached for Up so Down past the most-recent entry
+        # can restore it.
+        self._history_index: Optional[int] = None
+        self._history_pre_browse: str = ""
 
     @property
     def focus(self) -> FocusState:
@@ -339,6 +347,7 @@ class NotebookCursor:
         cell = self._session.get_cell(self._state.cell_id)
         if not cell.is_executable:
             return None
+        self._clear_history_browse()
         self._transition(
             FocusState(
                 mode=FocusMode.INPUT,
@@ -354,6 +363,7 @@ class NotebookCursor:
         if self._state.mode != FocusMode.INPUT or self._state.cell_id is None:
             return None
         self._commit_buffer_to_cell()
+        self._clear_history_browse()
         self._transition(
             FocusState(
                 mode=FocusMode.NOTEBOOK,
@@ -434,6 +444,7 @@ class NotebookCursor:
         """
         if self._state.mode != FocusMode.INPUT or self._state.cell_id is None:
             return None
+        self._clear_history_browse()
         self._transition(
             FocusState(
                 mode=FocusMode.NOTEBOOK,
@@ -458,6 +469,7 @@ class NotebookCursor:
             return
         if not self._state.input_buffer:
             return
+        self._clear_history_browse()
         self._transition(replace(self._state, input_buffer="", cursor_position=0))
 
     def insert_character(self, character: str) -> None:
@@ -469,6 +481,7 @@ class NotebookCursor:
             return
         if len(character) != 1:
             raise ValueError("insert_character expects exactly one character")
+        self._clear_history_browse()
         position = self._state.cursor_position
         buffer = self._state.input_buffer
         new_buffer = buffer[:position] + character + buffer[position:]
@@ -483,6 +496,7 @@ class NotebookCursor:
         position = self._state.cursor_position
         if position == 0:
             return
+        self._clear_history_browse()
         buffer = self._state.input_buffer
         new_buffer = buffer[: position - 1] + buffer[position:]
         self._transition(
@@ -530,6 +544,7 @@ class NotebookCursor:
         buffer = self._state.input_buffer
         if position >= len(buffer):
             return
+        self._clear_history_browse()
         new_buffer = buffer[:position] + buffer[position + 1 :]
         self._transition(replace(self._state, input_buffer=new_buffer))
 
@@ -549,6 +564,7 @@ class NotebookCursor:
             i -= 1
         if i == position:
             return
+        self._clear_history_browse()
         new_buffer = buffer[:i] + buffer[position:]
         self._transition(replace(self._state, input_buffer=new_buffer, cursor_position=i))
 
@@ -559,6 +575,7 @@ class NotebookCursor:
         position = self._state.cursor_position
         if position == 0:
             return
+        self._clear_history_browse()
         new_buffer = self._state.input_buffer[position:]
         self._transition(replace(self._state, input_buffer=new_buffer, cursor_position=0))
 
@@ -570,6 +587,7 @@ class NotebookCursor:
         buffer = self._state.input_buffer
         if position >= len(buffer):
             return
+        self._clear_history_browse()
         new_buffer = buffer[:position]
         self._transition(replace(self._state, input_buffer=new_buffer))
 
@@ -592,6 +610,8 @@ class NotebookCursor:
         if self._state.mode != FocusMode.INPUT or self._state.cell_id is None:
             return None
         cell = self._commit_buffer_to_cell()
+        self._session.record_command(cell.command)
+        self._clear_history_browse()
         should_autoadvance = (
             bool(cell.command.strip())
             and self._session.cells
@@ -620,6 +640,76 @@ class NotebookCursor:
                 )
             )
         return cell
+
+    def set_input_buffer(self, text: str) -> None:
+        """Replace the input buffer with ``text`` and park the caret at its end.
+
+        Public primitive for code that wants to programmatically
+        overwrite what the user is typing — the F4 history-recall path
+        is the first caller. INPUT mode only; silent no-op elsewhere.
+        Always clears any in-progress history browse so subsequent
+        Up/Down restart from the most-recent entry.
+        """
+        if self._state.mode != FocusMode.INPUT:
+            return
+        self._clear_history_browse()
+        self._transition(replace(self._state, input_buffer=text, cursor_position=len(text)))
+
+    def history_previous(self) -> bool:
+        """Step backward through ``session.command_history``.
+
+        On the first Up the cursor remembers whatever the user had
+        already typed (the "draft") so a later Down past the most
+        recent entry can restore it. Returns True when the buffer
+        actually changed; False when there's nothing to recall (not in
+        INPUT mode, history is empty, or already at the oldest entry).
+        """
+        if self._state.mode != FocusMode.INPUT:
+            return False
+        history = self._session.command_history
+        if not history:
+            return False
+        if self._history_index is None:
+            self._history_pre_browse = self._state.input_buffer
+            self._history_index = len(history)
+        if self._history_index <= 0:
+            return False
+        self._history_index -= 1
+        text = history[self._history_index]
+        self._transition(replace(self._state, input_buffer=text, cursor_position=len(text)))
+        return True
+
+    def history_next(self) -> bool:
+        """Step forward through history; restore the draft past the most recent.
+
+        No-op (returns False) when the cursor isn't currently browsing
+        history — Down is meaningless until Up has put us somewhere to
+        come back from. Stepping forward from the most-recent entry
+        clears the browse state and restores whatever the user had
+        typed before they reached for Up.
+        """
+        if self._state.mode != FocusMode.INPUT:
+            return False
+        if self._history_index is None:
+            return False
+        history = self._session.command_history
+        next_index = self._history_index + 1
+        if next_index >= len(history):
+            text = self._history_pre_browse
+            self._clear_history_browse()
+            self._transition(
+                replace(self._state, input_buffer=text, cursor_position=len(text))
+            )
+            return True
+        self._history_index = next_index
+        text = history[next_index]
+        self._transition(replace(self._state, input_buffer=text, cursor_position=len(text)))
+        return True
+
+    def _clear_history_browse(self) -> None:
+        """Forget any in-progress history walk and the draft we'd restored."""
+        self._history_index = None
+        self._history_pre_browse = ""
 
     def _move(self, delta: int) -> Optional[Cell]:
         """Move the cursor by a signed offset within the cell list."""

--- a/asat/session.py
+++ b/asat/session.py
@@ -45,6 +45,13 @@ class Session:
     # sub-directories. Stored as a string for portable JSON; resolved
     # by ``Workspace.resolve_cwd`` at open time.
     cwd: Optional[str] = None
+    # Ordered list of every non-empty command submitted in this
+    # session, oldest first. Powers F4 history recall (Up/Down in INPUT
+    # mode). Consecutive duplicates are collapsed at append time so a
+    # user re-running the same command doesn't have to walk past it
+    # repeatedly. Persisted with the session so resuming preserves the
+    # walk.
+    command_history: list[str] = field(default_factory=list)
 
     @classmethod
     def new(cls) -> "Session":
@@ -150,6 +157,7 @@ class Session:
             "active_cell_id": self.active_cell_id,
             "metadata": dict(self.metadata),
             "cwd": self.cwd,
+            "command_history": list(self.command_history),
             "cells": [cell.to_dict() for cell in self.cells],
         }
 
@@ -164,7 +172,25 @@ class Session:
             active_cell_id=data.get("active_cell_id"),
             metadata=dict(data.get("metadata", {})),
             cwd=data.get("cwd"),
+            command_history=list(data.get("command_history", [])),
         )
+
+    def record_command(self, command: str) -> bool:
+        """Append ``command`` to the history if it's worth recalling.
+
+        Returns True if the command was actually appended. Empty /
+        whitespace-only commands are dropped, and a command identical
+        to the most recent entry is collapsed (so the user doesn't
+        walk past `pytest` ten times to reach the previous edit).
+        """
+        stripped = command.strip()
+        if not stripped:
+            return False
+        if self.command_history and self.command_history[-1] == command:
+            return False
+        self.command_history.append(command)
+        self.updated_at = utcnow()
+        return True
 
     def save(self, path: Path | str) -> None:
         """Write the session as pretty-printed JSON to the given path."""

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -64,6 +64,28 @@ prompt. Bind to a keystroke (Ctrl+R) in SETTINGS mode.
 
 ## F4 — Command history
 
+**Status.** Shipped (Up / Down recall). `Session` now carries a
+`command_history: list[str]` populated at `record_command` time —
+empty / whitespace-only commands are dropped and consecutive
+duplicates collapse so the user doesn't have to walk past the same
+`pytest` invocation ten times. `NotebookCursor.history_previous` /
+`history_next` walk that list while in INPUT mode; Up replaces the
+buffer with the previous command (caret at end), Down steps forward,
+and Down past the most recent entry restores whatever the user had
+typed before they started browsing. Typing or any other buffer
+mutation clears the browse state so the next Up restarts from the
+most-recent entry. Bound to Up / Down in INPUT mode (the keys still
+mean "walk cells" in NOTEBOOK mode and "step lines" in OUTPUT mode
+because the binding map is per focus mode). The router's
+`history_previous` / `history_next` actions publish a
+`recalled: bool` payload so observers can voice an "empty history"
+hint. `command_history` round-trips through `Session.to_dict` /
+`from_dict` so resuming a saved session preserves the walk.
+
+**Deferred.** Ctrl+R reverse-incremental search is still open; it
+needs a composer overlay analogous to the SETTINGS `/` search and is
+worth its own follow-up PR.
+
 **Gap.** Up / Down in INPUT mode do nothing. There is no way to recall
 or search past commands.
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -253,6 +253,7 @@ or when you press Enter from NOTEBOOK mode.
 | Delete    | Deletes the character under the caret.            |
 | Left / Right | Move the caret one character.                  |
 | Home / End | Jump the caret to the start / end of the line.   |
+| Up / Down | Walk command history (F4): Up recalls the previous command, Down steps forward; Down past the most recent restores the in-progress draft. |
 | Ctrl+A / Ctrl+E | Alias for Home / End (readline-style).       |
 | Ctrl+W    | Delete the word immediately before the caret.     |
 | Ctrl+U    | Delete from the start of the line up to the caret. |
@@ -554,6 +555,7 @@ Every key you need, one table.
 | INPUT      | Delete            | Delete char under caret               |
 | INPUT      | Left / Right      | Move caret one character              |
 | INPUT      | Home / End        | Caret to start / end                  |
+| INPUT      | Up / Down         | Walk command history (F4)             |
 | INPUT      | Ctrl+A / Ctrl+E   | Caret to start / end (readline)       |
 | INPUT      | Ctrl+W            | Delete word before caret              |
 | INPUT      | Ctrl+U            | Delete from start of line to caret    |

--- a/tests/test_input_router.py
+++ b/tests/test_input_router.py
@@ -263,6 +263,73 @@ class ActionEventPayloadTests(unittest.TestCase):
         self.assertEqual(actions[0].payload["focus_mode"], FocusMode.NOTEBOOK.value)
 
 
+class CommandHistoryBindingTests(unittest.TestCase):
+    """F4: Up/Down in INPUT mode walk session.command_history."""
+
+    def test_up_and_down_bound_in_input_mode(self) -> None:
+        bindings = default_bindings()
+        self.assertEqual(bindings[FocusMode.INPUT][UP], "history_previous")
+        self.assertEqual(bindings[FocusMode.INPUT][DOWN], "history_next")
+
+    def test_up_recalls_previous_command(self) -> None:
+        _, session, cursor, router, _ = _build(["target"])
+        session.command_history.extend(["older", "newer"])
+        router.handle_key(ENTER)
+        result = router.handle_key(UP)
+        self.assertEqual(result, "history_previous")
+        self.assertEqual(cursor.focus.input_buffer, "newer")
+
+    def test_down_after_up_walks_forward(self) -> None:
+        _, session, cursor, router, _ = _build(["target"])
+        session.command_history.extend(["a", "b", "c"])
+        router.handle_key(ENTER)
+        router.handle_key(UP)  # c
+        router.handle_key(UP)  # b
+        router.handle_key(DOWN)  # back to c
+        self.assertEqual(cursor.focus.input_buffer, "c")
+
+    def test_history_payload_reports_recall_outcome(self) -> None:
+        bus, session, _, router, _ = _build(["target"])
+        session.command_history.append("ls")
+        router.handle_key(ENTER)
+        recorder = _Recorder(bus)
+        router.handle_key(UP)
+        actions = [
+            e for e in recorder.types_of(EventType.ACTION_INVOKED)
+            if e.payload.get("action") == "history_previous"
+        ]
+        self.assertEqual(len(actions), 1)
+        self.assertTrue(actions[0].payload["recalled"])
+
+    def test_up_with_empty_history_is_safe(self) -> None:
+        bus, _, cursor, router, _ = _build(["target"])
+        router.handle_key(ENTER)
+        recorder = _Recorder(bus)
+        router.handle_key(UP)
+        actions = [
+            e for e in recorder.types_of(EventType.ACTION_INVOKED)
+            if e.payload.get("action") == "history_previous"
+        ]
+        self.assertEqual(len(actions), 1)
+        self.assertFalse(actions[0].payload["recalled"])
+        self.assertEqual(cursor.focus.input_buffer, "target")
+
+    def test_up_outside_input_mode_keeps_navigation_meaning(self) -> None:
+        _, _, cursor, router, cells = _build(["a", "b"])
+        cursor.move_to_bottom()
+        result = router.handle_key(UP)
+        self.assertEqual(result, "move_up")
+        self.assertEqual(cursor.focus.cell_id, cells[0].cell_id)
+
+    def test_submit_records_command_in_history(self) -> None:
+        _, session, _, router, _ = _build(["target"])
+        router.handle_key(ENTER)
+        for char in "echo hi":
+            router.handle_key(Key.printable(char))
+        router.handle_key(ENTER)
+        self.assertEqual(session.command_history, ["targetecho hi"])
+
+
 class OutputModeDispatchTests(unittest.TestCase):
 
     def _stack(

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -712,5 +712,86 @@ class HeadingCreationTests(unittest.TestCase):
         self.assertEqual(dup.heading_title, "Setup")
 
 
+class CursorCommandHistoryTests(unittest.TestCase):
+    """F4: Up/Down walk session.command_history while in INPUT mode."""
+
+    def setUp(self) -> None:
+        self.bus = EventBus()
+        self.session, self.cells = _session_with(["target"])
+        self.cursor = NotebookCursor(self.session, self.bus)
+        self.session.command_history.extend(["one", "two", "three"])
+        self.cursor.enter_input_mode()
+        self.cursor.set_input_buffer("")
+
+    def test_history_previous_walks_back_from_most_recent(self) -> None:
+        self.assertTrue(self.cursor.history_previous())
+        self.assertEqual(self.cursor.focus.input_buffer, "three")
+        self.assertEqual(self.cursor.focus.cursor_position, len("three"))
+        self.assertTrue(self.cursor.history_previous())
+        self.assertEqual(self.cursor.focus.input_buffer, "two")
+        self.assertTrue(self.cursor.history_previous())
+        self.assertEqual(self.cursor.focus.input_buffer, "one")
+
+    def test_history_previous_clamps_at_oldest(self) -> None:
+        for _ in range(3):
+            self.cursor.history_previous()
+        self.assertEqual(self.cursor.focus.input_buffer, "one")
+        self.assertFalse(self.cursor.history_previous())
+        self.assertEqual(self.cursor.focus.input_buffer, "one")
+
+    def test_history_next_without_browse_is_noop(self) -> None:
+        self.assertFalse(self.cursor.history_next())
+        self.assertEqual(self.cursor.focus.input_buffer, "")
+
+    def test_history_next_walks_forward_then_restores_draft(self) -> None:
+        self.cursor.set_input_buffer("draft-")
+        self.cursor.history_previous()  # now "three"
+        self.cursor.history_previous()  # now "two"
+        self.assertTrue(self.cursor.history_next())
+        self.assertEqual(self.cursor.focus.input_buffer, "three")
+        self.assertTrue(self.cursor.history_next())
+        # Past most recent: draft restored.
+        self.assertEqual(self.cursor.focus.input_buffer, "draft-")
+        self.assertEqual(self.cursor.focus.cursor_position, len("draft-"))
+        # Subsequent Down is a no-op (we're back to typing).
+        self.assertFalse(self.cursor.history_next())
+
+    def test_typing_clears_browse_state(self) -> None:
+        self.cursor.history_previous()
+        self.cursor.insert_character("x")
+        # After typing, the browse state is gone — Up should restart
+        # from the most recent entry, not continue from "two".
+        self.cursor.history_previous()
+        self.assertEqual(self.cursor.focus.input_buffer, "three")
+
+    def test_history_outside_input_mode_is_noop(self) -> None:
+        self.cursor.exit_input_mode()
+        self.assertFalse(self.cursor.history_previous())
+        self.assertFalse(self.cursor.history_next())
+
+    def test_empty_history_is_noop(self) -> None:
+        self.session.command_history.clear()
+        self.assertFalse(self.cursor.history_previous())
+
+    def test_submit_records_non_empty_command(self) -> None:
+        self.cursor.set_input_buffer("echo hi")
+        cell = self.cursor.submit()
+        assert cell is not None
+        # "three" was the prior most recent; "echo hi" appends now.
+        self.assertEqual(
+            self.session.command_history,
+            ["one", "two", "three", "echo hi"],
+        )
+
+    def test_submit_skips_empty_and_collapses_duplicates(self) -> None:
+        self.cursor.set_input_buffer("   ")
+        self.cursor.submit()
+        # Re-enter INPUT on the same cell so we can submit again.
+        self.cursor.enter_input_mode()
+        self.cursor.set_input_buffer("three")
+        self.cursor.submit()
+        self.assertEqual(self.session.command_history, ["one", "two", "three"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -132,6 +132,36 @@ class SessionFocusAndNavigationTests(unittest.TestCase):
         self.assertIsNone(session.next_cell(c.cell_id))
 
 
+class SessionCommandHistoryTests(unittest.TestCase):
+    """F4: Session tracks the commands the user has submitted."""
+
+    def test_record_appends_non_empty(self) -> None:
+        session = Session.new()
+        appended = session.record_command("echo hi")
+        self.assertTrue(appended)
+        self.assertEqual(session.command_history, ["echo hi"])
+
+    def test_record_drops_whitespace_only(self) -> None:
+        session = Session.new()
+        self.assertFalse(session.record_command("   "))
+        self.assertFalse(session.record_command(""))
+        self.assertEqual(session.command_history, [])
+
+    def test_record_collapses_consecutive_duplicates(self) -> None:
+        session = Session.new()
+        session.record_command("pytest")
+        appended = session.record_command("pytest")
+        self.assertFalse(appended)
+        self.assertEqual(session.command_history, ["pytest"])
+
+    def test_record_keeps_non_consecutive_duplicates(self) -> None:
+        session = Session.new()
+        session.record_command("ls")
+        session.record_command("pwd")
+        session.record_command("ls")
+        self.assertEqual(session.command_history, ["ls", "pwd", "ls"])
+
+
 class SessionSerializationTests(unittest.TestCase):
 
     def test_round_trip_preserves_state(self) -> None:
@@ -141,11 +171,14 @@ class SessionSerializationTests(unittest.TestCase):
         session.add_cell(b)
         session.set_active(b.cell_id)
         session.metadata["project"] = "asat"
+        session.record_command("ls")
+        session.record_command("pwd")
         restored = Session.from_dict(session.to_dict())
         self.assertEqual(restored.session_id, session.session_id)
         self.assertEqual([c.command for c in restored], ["a", "b"])
         self.assertEqual(restored.active_cell_id, b.cell_id)
         self.assertEqual(restored.metadata, {"project": "asat"})
+        self.assertEqual(restored.command_history, ["ls", "pwd"])
 
     def test_save_and_load_roundtrip_on_disk(self) -> None:
         session = Session.new()


### PR DESCRIPTION
## Summary
- `Session.command_history` accumulates every non-empty submitted command; `record_command` drops whitespace-only entries and collapses consecutive duplicates. Round-trips through `to_dict`/`from_dict` so resumed sessions keep their history.
- `NotebookCursor.history_previous` / `history_next` walk that list while in INPUT mode. Up replaces the buffer with the previous command (caret at end), Down steps forward, and Down past the most recent restores the in-progress draft. Any non-history buffer mutation clears the browse state.
- Up / Down bound in INPUT mode only — they still mean "walk cells" in NOTEBOOK and "step lines" in OUTPUT because the binding map is per focus mode. The router's history actions publish `{recalled: bool}` so observers can voice an empty-history hint.
- Ctrl+R reverse-incremental search is intentionally deferred — needs its own composer-state PR.

## Test plan
- [x] `python -m unittest discover tests` — 990 tests pass
- [x] New `SessionCommandHistoryTests` cover append, dedup, drop-empty, and the round-trip preservation
- [x] New `CursorCommandHistoryTests` cover walk-back, walk-forward + draft restore, browse-clear-on-typing, and submit recording
- [x] New `CommandHistoryBindingTests` verify the INPUT-mode binding, payload shape, and that NOTEBOOK Up still means cell navigation
- [x] USER_MANUAL keystroke table + INPUT row updated; FEATURE_REQUESTS F4 marked Shipped with the deferred-search note; help_topics navigation tour mentions Up/Down

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS