### PR TITLE
F7: default OSC 133 prompt-ready binding

### DIFF
--- a/asat/default_bank.py
+++ b/asat/default_bank.py
@@ -96,6 +96,7 @@ COVERED_EVENT_TYPES: frozenset[EventType] = frozenset({
     EventType.BOOKMARK_CREATED,
     EventType.BOOKMARK_JUMPED,
     EventType.BOOKMARK_REMOVED,
+    EventType.ANSI_OSC_RECEIVED,
 })
 
 
@@ -257,6 +258,17 @@ def _default_sounds() -> tuple[SoundRecipe, ...]:
             volume=0.95,
             azimuth=55.0,
             elevation=10.0,
+        ),
+        # F7: short, unobtrusive blip for OSC 133 prompt-start markers.
+        # Quieter and higher than `start` so a user whose shell paints
+        # a prompt every command doesn't get pummelled with the same
+        # tone they hear when the kernel begins running their code.
+        SoundRecipe(
+            id="prompt_ready",
+            kind="tone",
+            params={"frequency": 990.0, "duration": 0.03, "waveform": "sine"},
+            volume=0.35,
+            elevation=20.0,
         ),
     )
 
@@ -753,5 +765,24 @@ def _default_bindings() -> tuple[EventBinding, ...]:
             say_template="last exit {last_exit_code}",
             predicate="last_exit_code != 0",
             priority=90,
+        ),
+
+        # F7: OSC 133 semantic prompt markers. Shells emitting these
+        # (zsh+powerlevel10k, starship, kitty, vscode shell-integration,
+        # etc.) signal where the prompt sits, when it ends, and when
+        # the command's output begins. We surface only the prompt-start
+        # cue by default — that's the moment a blind user most cares
+        # about (the shell is ready for input). The other subcommands
+        # remain silent until users opt in via the editor; otherwise
+        # every command would emit four blips. Other ANSI_OSC_RECEIVED
+        # categories (title, hyperlink, color, prompt subcommands beyond
+        # A) stay silent because no predicate matches them.
+        EventBinding(
+            id="osc_prompt_ready",
+            event_type=EventType.ANSI_OSC_RECEIVED.value,
+            voice_id="system",
+            sound_id="prompt_ready",
+            predicate="category == prompt_start",
+            priority=80,
         ),
     )

--- a/asat/tui_bridge.py
+++ b/asat/tui_bridge.py
@@ -288,6 +288,14 @@ def _classify_osc(body: str) -> str:
     only special-case the handful a terminal emulator actually reacts
     to; everything else is `"other"` so unknown sequences still emit an
     event but do not get mistaken for a title or a hyperlink.
+
+    OSC 133 (FinalTerm semantic prompt markers, also emitted by
+    powerlevel10k, starship, kitty, vscode, etc.) is split by
+    subcommand because each marker means something different: ``A``
+    starts a prompt, ``B`` ends it (command region begins), ``C``
+    starts the command's output, ``D`` reports completion. Bindings
+    that want a "prompt is ready" cue can gate on
+    ``category == "prompt_start"`` without re-parsing the body.
     """
     prefix = body.split(";", 1)[0] if ";" in body else body
     if prefix in {"0", "1", "2"}:
@@ -296,7 +304,18 @@ def _classify_osc(body: str) -> str:
         return "hyperlink"
     if prefix in {"4", "10", "11"}:
         return "color"
+    if prefix == "133":
+        subcommand = body.split(";", 2)[1] if ";" in body else ""
+        return _OSC_133_CATEGORIES.get(subcommand, "prompt")
     return "other"
+
+
+_OSC_133_CATEGORIES: dict[str, str] = {
+    "A": "prompt_start",
+    "B": "prompt_end",
+    "C": "command_start",
+    "D": "command_end",
+}
 
 
 def _menus_equivalent(a: InteractiveMenu, b: InteractiveMenu) -> bool:

--- a/docs/CLAUDE_CODE_MODES.md
+++ b/docs/CLAUDE_CODE_MODES.md
@@ -34,9 +34,12 @@ Raw ANSI signals worth binding:
   `CSI 201~` around pasted data. Bracketed paste is visible only as
   `OUTPUT_LINE_APPENDED` with a synthetic "Pasted N lines" string.
 - Semantic prompt markers (OSC 133): emitted by some shells around
-  prompt / command / output regions; exposed as
-  `ANSI_OSC_RECEIVED` with `category == "other"` and `body` starting
-  `133`.
+  prompt / command / output regions; exposed as `ANSI_OSC_RECEIVED`
+  with `category` set to one of `"prompt_start"`, `"prompt_end"`,
+  `"command_start"`, `"command_end"` (or `"prompt"` for unknown OSC
+  133 subcommands) and `body` starting `133`. The default bank ships
+  a short blip on `category == "prompt_start"`; the other subcommands
+  stay silent until users opt in.
 
 ---
 
@@ -184,7 +187,7 @@ default bank today.
 
 | Surface | Event type | Voice | Cue (sound kind) | Template snippet |
 |---|---|---|---|---|
-| Default prompt ready | `ANSI_OSC_RECEIVED` (title) | narrator | short tone 440 Hz 60 ms | "ready" |
+| Default prompt ready | `ANSI_OSC_RECEIVED` (`category=="prompt_start"`) | system | short tone 990 Hz 30 ms | — |
 | Multiline continuation | `OUTPUT_LINE_APPENDED` | — | tone 220 Hz 40 ms | — |
 | Bash mode entered | `KEY_PRESSED` (`key=="!"`) | system | chord (440, 660) 80 ms | "bash mode" |
 | Memory append | `KEY_PRESSED` (`key=="#"`) | system | tone 660 Hz 50 ms | "remembered" |

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -239,9 +239,12 @@ absolute state.
 `ANSI_LINE_ERASED.mode` is the `K` parameter (0, 1, 2).
 
 `ANSI_OSC_RECEIVED.category` is one of `"title"` (OSC 0/1/2),
-`"hyperlink"` (OSC 8), `"color"` (OSC 4/10/11), or `"other"`. The raw
-`body` is included so advanced bindings can match on specific
-subcommands.
+`"hyperlink"` (OSC 8), `"color"` (OSC 4/10/11), one of the four
+OSC 133 (FinalTerm) semantic-prompt categories — `"prompt_start"`
+(`133;A`), `"prompt_end"` (`133;B`), `"command_start"` (`133;C`),
+`"command_end"` (`133;D`) — `"prompt"` (any other OSC 133
+subcommand), or `"other"`. The raw `body` is included so advanced
+bindings can match on specific subcommands.
 
 `ANSI_BELL` carries no extra data: it fires once per BEL byte (0x07)
 unless the byte is the OSC terminator.

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -169,6 +169,18 @@ narration voice starts) should be designed together with this.
 
 ## F7 — Default binding for OSC 133 semantic prompt
 
+**Status. Shipped.** `asat/tui_bridge.py::_classify_osc` now splits
+OSC 133 by subcommand into four distinct categories — `prompt_start`
+(`133;A`), `prompt_end` (`133;B`), `command_start` (`133;C`),
+`command_end` (`133;D`) — plus a generic `prompt` for any unknown
+subcommand. The default bank ships a `prompt_ready` 990 Hz / 30 ms
+tone on the `system` voice, gated on `category == "prompt_start"`,
+so users running zsh + powerlevel10k, starship, kitty, or vscode's
+shell-integration get an audible "shell is ready" cue out of the
+box. The other subcommands stay silent so the default doesn't fire
+four blips per command; users can clone the recipe in the editor to
+sonify command-end (with exit code) once F7 follow-ups land.
+
 **Gap.** `ANSI_OSC_RECEIVED` is emitted and
 [CLAUDE_CODE_MODES.md](CLAUDE_CODE_MODES.md) points at OSC 133 as a
 prompt-boundary signal, but the default bank has no OSC 133 binding.

--- a/tests/test_default_bank.py
+++ b/tests/test_default_bank.py
@@ -172,6 +172,11 @@ SAMPLE_PAYLOADS: dict[EventType, dict[str, object]] = {
     EventType.BOOKMARK_CREATED: {"name": "setup", "cell_id": "c1"},
     EventType.BOOKMARK_JUMPED: {"name": "setup", "cell_id": "c1"},
     EventType.BOOKMARK_REMOVED: {"name": "setup", "cell_id": "c1"},
+    EventType.ANSI_OSC_RECEIVED: {
+        "cell_id": "c1",
+        "body": "133;A",
+        "category": "prompt_start",
+    },
 }
 
 
@@ -238,7 +243,6 @@ class CoverageTests(unittest.TestCase):
                 EventType.ANSI_SGR_CHANGED,
                 EventType.ANSI_DISPLAY_CLEARED,
                 EventType.ANSI_LINE_ERASED,
-                EventType.ANSI_OSC_RECEIVED,
                 EventType.ANSI_BELL,
             },
         )

--- a/tests/test_tui_bridge.py
+++ b/tests/test_tui_bridge.py
@@ -210,6 +210,26 @@ class AnsiEventTests(unittest.TestCase):
         self.assertEqual(len(oscs), 1)
         self.assertEqual(oscs[0].payload["category"], "hyperlink")
 
+    def test_osc_133_subcommands_get_distinct_categories(self) -> None:
+        """F7: each OSC 133 subcommand maps to a unique category so the
+        default bank can bind only the prompt-start blip without firing
+        on every prompt-end / command-start / command-end marker."""
+        bus = EventBus()
+        events = _Recorder(bus)
+        bridge = TuiBridge(bus, cell_id="c1")
+        bridge.feed("\x1b]133;A\x07")
+        bridge.feed("\x1b]133;B\x07")
+        bridge.feed("\x1b]133;C\x07")
+        bridge.feed("\x1b]133;D;0\x07")
+        bridge.feed("\x1b]133;Z\x07")  # unknown subcommand
+        oscs = events.of(EventType.ANSI_OSC_RECEIVED)
+        categories = [event.payload["category"] for event in oscs]
+        self.assertEqual(
+            categories,
+            ["prompt_start", "prompt_end", "command_start", "command_end", "prompt"],
+        )
+        self.assertEqual(oscs[3].payload["body"], "133;D;0")
+
 
 class ResetTests(unittest.TestCase):
 


### PR DESCRIPTION
## Summary
- Splits OSC 133 (FinalTerm semantic prompt markers) by subcommand in `asat/tui_bridge.py::_classify_osc` so bindings can target prompt boundaries individually: `133;A` → `prompt_start`, `133;B` → `prompt_end`, `133;C` → `command_start`, `133;D` → `command_end`, unknown → `prompt`.
- Adds a `prompt_ready` 990 Hz / 30 ms tone on the `system` voice and binds it to `ANSI_OSC_RECEIVED` gated on `category == "prompt_start"`. Users running zsh + powerlevel10k, starship, kitty, or vscode shell-integration now get an audible "shell is ready" cue without editing the bank.
- Other OSC 133 subcommands stay silent so the default doesn't fire four blips per command; users can clone the recipe in the editor for finer cues.
- Doc updates: `docs/EVENTS.md` enumerates the new categories, `docs/CLAUDE_CODE_MODES.md` swaps the speculative "title-based prompt-ready" entry for the real OSC 133 binding, `docs/FEATURE_REQUESTS.md` gains an F7 status header.

## Test plan
- [x] `python -m unittest discover tests` (1040 tests pass)
- [x] New `test_osc_133_subcommands_get_distinct_categories` covers `133;A/B/C/D` plus an unknown subcommand
- [x] Default-bank coverage tests updated (ANSI_OSC_RECEIVED moved out of the silent allow-list, sample payload matches the new category)
- [x] Drift guards (`test_user_manual_sync`, `test_events_docs_sync`, `test_bindings_introspection`) green

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS