### PR TITLE
F49: extract _requires_output_cursor decorator

### DIFF
--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -70,6 +70,25 @@ def _requires_settings_controller(method: Callable[..., object]) -> Callable[...
     return wrapper
 
 
+def _requires_output_cursor(method: Callable[..., object]) -> Callable[..., object]:
+    """Skip the wrapped method when no OutputCursor is attached.
+
+    Same shape as ``_requires_settings_controller``: OUTPUT-mode
+    composer helpers (search, goto, commit, cancel) all began with the
+    same ``if self._output_cursor is None: return None`` early-return.
+    Decorating them collapses that boilerplate so every method body
+    starts with the actual work.
+    """
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if self._output_cursor is None:
+            return None
+        return method(self, *args, **kwargs)
+
+    return wrapper
+
+
 def _void(fn: Callable[..., object]) -> ActionHandler:
     """Wrap a side-effecting callable so it matches the ActionHandler shape.
 
@@ -1402,47 +1421,42 @@ class InputRouter:
         recalled = self._cursor.history_next()
         return {"recalled": recalled}
 
+    @_requires_output_cursor
     def _output_search_begin(self) -> Optional[dict[str, object]]:
         """Open the `/` search composer on the attached output cursor."""
-        if self._output_cursor is None:
-            return None
         started = self._output_cursor.begin_search()
         return {"opened": started}
 
+    @_requires_output_cursor
     def _output_goto_begin(self) -> Optional[dict[str, object]]:
         """Open the `g` line-jump composer on the attached output cursor."""
-        if self._output_cursor is None:
-            return None
         started = self._output_cursor.begin_goto()
         return {"opened": started}
 
+    @_requires_output_cursor
     def _output_search_next(self) -> Optional[dict[str, object]]:
         """Cycle to the next search hit (no-op without prior matches)."""
-        if self._output_cursor is None:
-            return None
         line = self._output_cursor.next_match()
         if line is None:
             return {"matched": False}
         return {"matched": True, "line_number": line.line_number}
 
+    @_requires_output_cursor
     def _output_search_prev(self) -> Optional[dict[str, object]]:
         """Cycle to the previous search hit (no-op without prior matches)."""
-        if self._output_cursor is None:
-            return None
         line = self._output_cursor.prev_match()
         if line is None:
             return {"matched": False}
         return {"matched": True, "line_number": line.line_number}
 
+    @_requires_output_cursor
     def _output_composer_backspace(self) -> None:
         """Trim the in-progress query or line-number buffer by one char."""
-        if self._output_cursor is not None:
-            self._output_cursor.backspace_composer()
+        self._output_cursor.backspace_composer()
 
+    @_requires_output_cursor
     def _output_composer_commit(self) -> Optional[dict[str, object]]:
         """Apply the in-progress composer; report where we landed."""
-        if self._output_cursor is None:
-            return None
         mode = self._output_cursor.composer_mode
         query = self._output_cursor.composer_buffer
         line = self._output_cursor.commit_composer()
@@ -1451,10 +1465,9 @@ class InputRouter:
             payload["line_number"] = line.line_number
         return payload
 
+    @_requires_output_cursor
     def _output_composer_cancel(self) -> Optional[dict[str, object]]:
         """Discard the composer and restore the line the user started on."""
-        if self._output_cursor is None:
-            return None
         self._output_cursor.cancel_composer()
         return None
 


### PR DESCRIPTION
## Summary

One bullet from F49's hygiene backlog. Six OUTPUT-mode composer methods (`_output_search_begin`, `_output_goto_begin`, `_output_search_next`, `_output_search_prev`, `_output_composer_commit`, `_output_composer_cancel`) and the `_output_composer_backspace` shorthand all opened with the same `if self._output_cursor is None: return None` early-return. Add a `_requires_output_cursor` decorator parallel to the existing `_requires_settings_controller` and apply it so each method body starts with the actual work instead of boilerplate.

Pure refactor; behaviour is unchanged.

The single remaining inline `if self._settings_controller is None` guard inside `_handle_meta_reset` stays inline on purpose: decorating the whole method would suppress the HELP_REQUESTED hint that explains the `:reset` argument shape, which is the opposite of what we want.

## Test plan

- [x] `python -m unittest tests.test_input_router` — 171 tests pass
- [x] `python -m unittest discover -s tests` — 1047 tests pass

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS