### PR TITLE
F49: regression-guard the -1 search sentinel

### DIFF
--- a/asat/settings_editor.py
+++ b/asat/settings_editor.py
@@ -890,6 +890,15 @@ class SettingsEditor:
             self._search_position = 0
             section, record_index = matches[0]
             self._goto_record_match(section, record_index)
+        elif not 0 <= self._search_position < len(matches):
+            # F49 regression guard: when the caller opts out of
+            # jumping, a stale `-1` sentinel from a previous
+            # empty-match step (or an out-of-range index from a
+            # shrinking match list) would index the *last* match
+            # via Python negative-index semantics, then make
+            # `prev_search_match` step to the second-to-last.
+            # Normalising to 0 keeps cycling intuitive.
+            self._search_position = 0
         self._publish_search_update(match=matches[self._search_position])
 
     def _goto_record_match(self, section: Section, record_index: int) -> None:

--- a/tests/test_settings_editor.py
+++ b/tests/test_settings_editor.py
@@ -703,6 +703,34 @@ class SearchOverlayTests(unittest.TestCase):
         self.assertIs(editor.bank, baseline)
         self.assertFalse(editor.state.dirty)
 
+    def test_recompute_without_jump_normalises_stale_sentinel(self) -> None:
+        """F49 regression guard: ``_recompute_matches(jump_to_first=False)``
+        must not leave ``_search_position`` at the ``-1`` sentinel when
+        matches exist. With ``-1`` and a non-empty match list,
+        ``prev_search_match`` would index ``matches[-2]`` (Python
+        negative wrap) and step to the second-to-last hit instead of
+        the previous-from-current one. Normalising to ``0`` keeps the
+        ``next``/``prev`` pair intuitive for any future caller that
+        opts out of jumping."""
+        editor = SettingsEditor(EventBus(), self._search_bank())
+        editor.begin_search()
+        # Drive _search_position to -1 by typing a query with no hits,
+        # then call the internal recompute with jump_to_first=False
+        # against a query that matches multiple records.
+        for ch in "zzz":
+            editor.extend_search(ch)
+        self.assertEqual(editor._search_position, -1)
+        editor._search_buffer = "a"  # matches narrator + alert
+        editor._recompute_matches(jump_to_first=False)
+        self.assertGreaterEqual(
+            editor._search_position,
+            0,
+            "F49: stale -1 sentinel persisted after _recompute_matches "
+            "with matches and jump_to_first=False — prev_search_match "
+            "would now wrap to the wrong end of the match list.",
+        )
+        self.assertLess(editor._search_position, len(editor._search_matches))
+
 
 class SaveTests(unittest.TestCase):
 


### PR DESCRIPTION
## Summary

One bullet from F49's hygiene backlog. `SettingsEditor._recompute_matches(jump_to_first=False)` left `_search_position = -1` whenever the previous query had no matches. With matches present and the sentinel still at `-1`:

- `prev_search_match` does `(-1 - 1) % N` and steps to `matches[N - 2]` instead of the previous-from-current entry.
- The publish-update line reports `matches[-1]` (the *last* match via Python negative indexing) as the focused hit.

Every external caller passes `jump_to_first=True` today, so this never fires in production. Filed under F49 hygiene because a future caller that opts out of jumping would surface the bug.

The fix normalises `_search_position` to `0` whenever it sits outside `[0, len(matches))` after a match-bearing recompute. Added a regression test that names F49 in the failure message so a future change that re-introduces the sentinel persistence is self-describing.

## Test plan

- [x] `python -m unittest tests.test_settings_editor` — 95 tests pass (one new)
- [x] `python -m unittest discover -s tests` — 1048 tests pass
- [x] Confirmed the new test fails without the fix (stash + rerun): asserts `-1 not greater than or equal to 0` with the F49 message

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS