### PR TITLE
F49: mark code-quality backlog as Shipped

### DIFF
--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -1600,6 +1600,13 @@ silently regress discoverability.
 
 ## F49 — Code-quality hygiene backlog
 
+**Status: Shipped.** Every bullet below landed in its own PR
+(#76 None-guard decorator, #77 search sentinel, #78 _action_handler
+split, #79 FIELD_PARSERS, #80 _META_HANDLERS, #81 state-machine
+doc links). The `ComposerMode(str, Enum)` bullet had already
+shipped against `asat/output_cursor.py` before this entry was
+formalised.
+
 **Gap.** A handful of small refactor and regression-guard items
 surfaced during the repo audit. None is blocking; each is short
 enough to serve as a palate cleanser between larger features.


### PR DESCRIPTION
## Summary

Adds a `Status: Shipped.` header to F49 in `docs/FEATURE_REQUESTS.md` and lists each PR that delivered each bullet:

- PR #76 — `_requires_output_cursor` None-guard decorator
- PR #77 — `_search_position = -1` regression guard
- PR #78 — split `_action_handler` into per-subsystem dicts
- PR #79 — `FIELD_PARSERS` table replaces parse ladders
- PR #80 — `_META_HANDLERS` table replaces meta-command ladder
- PR #81 — doc-link comments on state-machine transitions

The `ComposerMode(str, Enum)` bullet had already shipped against `asat/output_cursor.py` before F49 was formalised, so no separate PR is listed for it.

## Test plan

Documentation-only change; no code touched.

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS