### PR TITLE
F32: duck non-speech cues while speech is mixing

### DIFF
--- a/asat/sound_bank.py
+++ b/asat/sound_bank.py
@@ -275,6 +275,13 @@ class SoundBank:
     sounds: tuple[SoundRecipe, ...] = ()
     bindings: tuple[EventBinding, ...] = ()
     version: int = SCHEMA_VERSION
+    # F32: when `ducking_enabled` is True, the engine attenuates a
+    # concurrent non-speech buffer to `duck_level * gain` whenever a
+    # speech buffer is in the same mix cycle, so narration stays
+    # intelligible over per-event cues. Both fields are scalar so
+    # they round-trip through JSON without any custom coercion.
+    ducking_enabled: bool = True
+    duck_level: float = 0.4
 
     def voice_for(self, voice_id: str) -> Optional[Voice]:
         """Return the voice with this id, or None if it is missing."""
@@ -334,6 +341,8 @@ class SoundBank:
             "voices": [voice.to_dict() for voice in self.voices],
             "sounds": [sound.to_dict() for sound in self.sounds],
             "bindings": [binding.to_dict() for binding in self.bindings],
+            "ducking_enabled": self.ducking_enabled,
+            "duck_level": self.duck_level,
         }
 
     @classmethod
@@ -350,7 +359,16 @@ class SoundBank:
         bindings = tuple(
             EventBinding.from_dict(item) for item in data.get("bindings", []) or ()
         )
-        bank = cls(voices=voices, sounds=sounds, bindings=bindings, version=version)
+        ducking_enabled = bool(data.get("ducking_enabled", True))
+        duck_level = _unit_float(data.get("duck_level", 0.4), "duck_level")
+        bank = cls(
+            voices=voices,
+            sounds=sounds,
+            bindings=bindings,
+            version=version,
+            ducking_enabled=ducking_enabled,
+            duck_level=duck_level,
+        )
         bank.validate()
         return bank
 
@@ -418,6 +436,14 @@ def _angle(value: Any, label: str, low: float, high: float) -> float:
     number = _as_float(value, label)
     if number < low or number > high:
         raise SoundBankError(f"{label} must be in [{low}, {high}], got {number}")
+    return number
+
+
+def _unit_float(value: Any, label: str) -> float:
+    """Parse value as a float in [0.0, 1.0]; rejects out-of-range numbers."""
+    number = _as_float(value, label)
+    if number < 0.0 or number > 1.0:
+        raise SoundBankError(f"{label} must be in [0.0, 1.0], got {number}")
     return number
 
 

--- a/asat/sound_bank_schema.json
+++ b/asat/sound_bank_schema.json
@@ -25,6 +25,18 @@
       "type": "array",
       "items": { "$ref": "#/$defs/binding" },
       "default": []
+    },
+    "ducking_enabled": {
+      "type": "boolean",
+      "default": true,
+      "description": "F32: when true, the engine attenuates a concurrent non-speech buffer to `duck_level * gain` whenever a speech buffer is in the same mix cycle."
+    },
+    "duck_level": {
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "default": 0.4,
+      "description": "F32: gain multiplier applied to a concurrent non-speech buffer while speech is mixing. 0.0 silences cues entirely; 1.0 disables ducking even if `ducking_enabled` is true."
     }
   },
   "additionalProperties": false,

--- a/asat/sound_engine.py
+++ b/asat/sound_engine.py
@@ -280,6 +280,17 @@ class SoundEngine:
             effective_sound = _apply_sound_overrides(sound, binding.sound_overrides)
             sound_buffer = self._synthesise_sound(effective_sound)
 
+        # F32: duck the cue under concurrent narration so the voice
+        # stays intelligible. The attenuation is per mix cycle: each
+        # _render call is its own cycle, so the next event with no
+        # speech automatically plays at full level.
+        if (
+            speech_buffer is not None
+            and sound_buffer is not None
+            and self._bank.ducking_enabled
+        ):
+            sound_buffer = _apply_gain(sound_buffer, self._bank.duck_level)
+
         mixed = _mix_buffers(speech_buffer, sound_buffer, self._sample_rate)
         if mixed is None:
             return
@@ -424,6 +435,20 @@ def _mix_buffers(
 def _sample_or_zero(samples: tuple[float, ...], index: int) -> float:
     """Return samples[index] or 0.0 if the index is out of range."""
     return samples[index] if index < len(samples) else 0.0
+
+
+def _apply_gain(buffer: AudioBuffer, gain: float) -> AudioBuffer:
+    """Return a copy of buffer with every sample scaled by `gain`.
+
+    Used by the F32 ducking path to attenuate a non-speech cue when
+    speech is mixing in the same cycle. `gain == 1.0` short-circuits
+    to the original buffer because the multiplication is a no-op and
+    we save tuple-construction churn on hot dispatches.
+    """
+    if gain == 1.0:
+        return buffer
+    scaled = tuple(sample * gain for sample in buffer.samples)
+    return AudioBuffer(scaled, buffer.sample_rate, buffer.layout)
 
 
 def _clamp(value: float) -> float:

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -978,6 +978,14 @@ which profile they just entered. Pairs cleanly with F21c reset so
 
 ## F32 — Audio ducking under active narration
 
+**Status: Shipped.** `SoundBank` carries `ducking_enabled` (default
+`True`) and `duck_level` (default `0.4`); the engine multiplies any
+concurrent non-speech cue by `duck_level` whenever a speech buffer
+is in the same `_render` mix cycle. Both fields round-trip through
+JSON and the schema documents the bounds. Live-edit today is via
+the bank file plus `:reload`; an editor surfacing pass can land
+later if needed.
+
 **Gap.** When TTS narration plays while non-speech output cues fire
 (output-line chords, keystroke blips), the speech gets masked. There
 is no automatic gain management to keep voice intelligible.

--- a/tests/test_sound_bank.py
+++ b/tests/test_sound_bank.py
@@ -300,6 +300,52 @@ class JsonSchemaFileTests(unittest.TestCase):
         kinds = data["$defs"]["sound"]["properties"]["kind"]["enum"]
         self.assertEqual(tuple(kinds), SOUND_KINDS)
 
+    def test_schema_declares_ducking_fields(self) -> None:
+        """F32: schema must list ducking_enabled and duck_level so the
+        on-disk format documents them at the same level as the dataclass."""
+        schema_path = Path(__file__).resolve().parents[1] / "asat" / "sound_bank_schema.json"
+        data = json.loads(schema_path.read_text(encoding="utf-8"))
+        self.assertEqual(data["properties"]["ducking_enabled"]["type"], "boolean")
+        self.assertEqual(data["properties"]["ducking_enabled"]["default"], True)
+        duck_level = data["properties"]["duck_level"]
+        self.assertEqual(duck_level["type"], "number")
+        self.assertEqual(duck_level["minimum"], 0.0)
+        self.assertEqual(duck_level["maximum"], 1.0)
+        self.assertEqual(duck_level["default"], 0.4)
+
+
+class DuckingFieldTests(unittest.TestCase):
+    """F32 — ducking_enabled / duck_level live on the bank itself."""
+
+    def test_defaults_match_spec(self) -> None:
+        bank = SoundBank()
+        self.assertTrue(bank.ducking_enabled)
+        self.assertEqual(bank.duck_level, 0.4)
+
+    def test_round_trip_preserves_non_default_values(self) -> None:
+        bank = SoundBank(ducking_enabled=False, duck_level=0.2)
+        restored = SoundBank.from_dict(bank.to_dict())
+        self.assertFalse(restored.ducking_enabled)
+        self.assertEqual(restored.duck_level, 0.2)
+
+    def test_loader_supplies_defaults_when_fields_missing(self) -> None:
+        """Older bank files won't carry the F32 fields. Loader fills them
+        with the dataclass defaults so existing on-disk banks keep loading."""
+        legacy = {"version": SCHEMA_VERSION}
+        bank = SoundBank.from_dict(legacy)
+        self.assertTrue(bank.ducking_enabled)
+        self.assertEqual(bank.duck_level, 0.4)
+
+    def test_duck_level_out_of_range_raises(self) -> None:
+        with self.assertRaises(SoundBankError):
+            SoundBank.from_dict({"version": SCHEMA_VERSION, "duck_level": 1.5})
+        with self.assertRaises(SoundBankError):
+            SoundBank.from_dict({"version": SCHEMA_VERSION, "duck_level": -0.1})
+
+    def test_duck_level_non_numeric_raises(self) -> None:
+        with self.assertRaises(SoundBankError):
+            SoundBank.from_dict({"version": SCHEMA_VERSION, "duck_level": "loud"})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sound_engine.py
+++ b/tests/test_sound_engine.py
@@ -13,6 +13,7 @@ from asat.sound_engine import (
     DefaultPredicateEvaluator,
     SoundEngine,
     SoundEngineError,
+    _apply_gain,
 )
 from asat.tts import ToneTTSEngine
 
@@ -662,6 +663,161 @@ class NarrationHistoryTests(unittest.TestCase):
         self.assertIsNone(engine.replay_last_narration())
         # No new buffer, no NARRATION_REPLAYED.
         self.assertEqual(len(sink.buffers), 1)
+
+
+class _SilentTTS:
+    """TTS shim that always returns mono silence of a fixed length.
+
+    Used by the ducking tests so the speech contribution is zero and
+    every sample the sink sees is sourced from the cue alone — that
+    lets us assert duck_level was applied by comparing the cue's peak
+    amplitude against the same engine run with ducking disabled.
+    """
+
+    def __init__(self, sample_rate: int = 8000, frames: int = 64) -> None:
+        self.sample_rate = sample_rate
+        self._frames = frames
+
+    def synthesize(self, text: str, voice: VoiceProfile) -> AudioBuffer:
+        return AudioBuffer.mono([0.0] * self._frames, self.sample_rate)
+
+
+class _ApplyGainTests(unittest.TestCase):
+    """F32 — _apply_gain scales every sample, keeps metadata intact."""
+
+    def test_scales_every_sample(self) -> None:
+        buffer = AudioBuffer.mono([0.5, -0.5, 1.0, -1.0], sample_rate=8000)
+        scaled = _apply_gain(buffer, 0.5)
+        self.assertEqual(scaled.samples, (0.25, -0.25, 0.5, -0.5))
+        self.assertEqual(scaled.sample_rate, 8000)
+        self.assertEqual(scaled.layout, ChannelLayout.MONO)
+
+    def test_unity_gain_returns_input_buffer(self) -> None:
+        # Hot-path optimisation: identical instance, no tuple churn.
+        buffer = AudioBuffer.mono([0.1, 0.2, 0.3], sample_rate=8000)
+        self.assertIs(_apply_gain(buffer, 1.0), buffer)
+
+    def test_zero_gain_silences_buffer(self) -> None:
+        buffer = AudioBuffer.mono([0.5, -0.5, 1.0], sample_rate=8000)
+        silenced = _apply_gain(buffer, 0.0)
+        self.assertEqual(silenced.samples, (0.0, 0.0, 0.0))
+
+
+class SoundEngineDuckingTests(unittest.TestCase):
+    """F32 — concurrent cues are attenuated while speech is mixing."""
+
+    def _bank(self, *, ducking_enabled: bool, duck_level: float) -> SoundBank:
+        return SoundBank(
+            voices=(_voice(),),
+            sounds=(_tone(),),
+            bindings=(
+                EventBinding(
+                    id="b1",
+                    event_type=EventType.CELL_CREATED.value,
+                    voice_id="narrator",
+                    sound_id="ding",
+                    say_template="hi",
+                ),
+            ),
+            ducking_enabled=ducking_enabled,
+            duck_level=duck_level,
+        )
+
+    def _peak(self, sink: MemorySink) -> float:
+        self.assertEqual(len(sink.buffers), 1)
+        return max(abs(sample) for sample in sink.buffers[0].samples)
+
+    def test_ducking_attenuates_concurrent_cue(self) -> None:
+        # Run the same dispatch twice, once with ducking off and once
+        # with duck_level 0.25; the attenuated peak must be smaller.
+        bus_off, sink_off = EventBus(), MemorySink()
+        engine_off = SoundEngine(
+            bus_off,
+            self._bank(ducking_enabled=False, duck_level=0.25),
+            sink_off,
+            tts=_SilentTTS(),
+            sample_rate=8000,
+        )
+        self.addCleanup(engine_off.close)
+        publish_event(bus_off, EventType.CELL_CREATED, {}, source="notebook")
+        peak_off = self._peak(sink_off)
+
+        bus_on, sink_on = EventBus(), MemorySink()
+        engine_on = SoundEngine(
+            bus_on,
+            self._bank(ducking_enabled=True, duck_level=0.25),
+            sink_on,
+            tts=_SilentTTS(),
+            sample_rate=8000,
+        )
+        self.addCleanup(engine_on.close)
+        publish_event(bus_on, EventType.CELL_CREATED, {}, source="notebook")
+        peak_on = self._peak(sink_on)
+
+        # Speech is silent in both runs, so the only contribution to
+        # the mix is the cue. With the silent-speech short-circuit at
+        # gain 1.0 disabled, the ducked peak should be ~25% of the
+        # full-level one — allow a small numerical fudge for the
+        # spatializer's HRTF convolution.
+        self.assertGreater(peak_off, 0.0)
+        self.assertLess(peak_on, peak_off * 0.5)
+
+    def test_disabled_ducking_leaves_cue_untouched(self) -> None:
+        bus = EventBus()
+        sink = MemorySink()
+        engine = SoundEngine(
+            bus,
+            self._bank(ducking_enabled=False, duck_level=0.0),
+            sink,
+            tts=_SilentTTS(),
+            sample_rate=8000,
+        )
+        self.addCleanup(engine.close)
+        publish_event(bus, EventType.CELL_CREATED, {}, source="notebook")
+        # duck_level is 0.0 but ducking is OFF, so the cue must still
+        # be audible — the disabled flag wins over the level value.
+        self.assertGreater(self._peak(sink), 0.0)
+
+    def test_ducking_skipped_when_no_speech_buffer(self) -> None:
+        # A sound-only binding has no speech to duck against, so the
+        # cue must come through at full level even with ducking on.
+        bank = SoundBank(
+            sounds=(_tone(),),
+            bindings=(
+                EventBinding(
+                    id="b1",
+                    event_type=EventType.CELL_CREATED.value,
+                    sound_id="ding",
+                ),
+            ),
+            ducking_enabled=True,
+            duck_level=0.1,
+        )
+        bus = EventBus()
+        sink = MemorySink()
+        engine = SoundEngine(bus, bank, sink, sample_rate=8000)
+        self.addCleanup(engine.close)
+        publish_event(bus, EventType.CELL_CREATED, {}, source="notebook")
+        peak_solo = self._peak(sink)
+
+        # Same cue without ducking should match — confirms the ducking
+        # branch was never entered.
+        bus2 = EventBus()
+        sink2 = MemorySink()
+        engine2 = SoundEngine(
+            bus2,
+            SoundBank(
+                sounds=(_tone(),),
+                bindings=bank.bindings,
+                ducking_enabled=False,
+                duck_level=0.1,
+            ),
+            sink2,
+            sample_rate=8000,
+        )
+        self.addCleanup(engine2.close)
+        publish_event(bus2, EventType.CELL_CREATED, {}, source="notebook")
+        self.assertEqual(peak_solo, self._peak(sink2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- `SoundBank` carries `ducking_enabled` (default `True`) and `duck_level` (default `0.4`); both round-trip through JSON and are documented in the schema with bounds `[0.0, 1.0]`.
- `SoundEngine._render` now multiplies any concurrent non-speech buffer by `duck_level` whenever a speech buffer is in the same mix cycle. Sound-only events still play at full level because each `_render` call is its own cycle.
- New `_apply_gain(buffer, gain)` helper short-circuits at `gain == 1.0` so disabled ducking allocates no extra buffer.
- Live-edit works today via the bank file plus `:reload` (F3 shipped). Surfacing these scalars in the in-terminal settings editor would require a fourth section and is left for a follow-up if needed.

## Test plan

- [x] `python -m unittest discover -s tests` — 1060 tests pass (was 1048; +12 new):
  - `DuckingFieldTests` — defaults, round-trip, missing-key defaults, range + type rejection.
  - `_ApplyGainTests` — scaling, unity short-circuit, zero-gain silence.
  - `SoundEngineDuckingTests` — attenuation when concurrent speech, disabled flag preserves cue, no-speech cycle untouched.
  - `JsonSchemaFileTests.test_schema_declares_ducking_fields` — schema documents both properties with correct defaults/bounds.

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS