### PR TITLE
Feature batch: F10 (shipped marker) + F31 verbosity + F37 pacing + F43 first-command tour

### DIFF
--- a/asat/app.py
+++ b/asat/app.py
@@ -53,6 +53,7 @@ from asat.session import Session
 from asat.settings_controller import SettingsController
 from asat.sound_bank import SoundBank
 from asat.sound_engine import SoundEngine
+from asat.streaming_monitor import StreamingMonitor
 from asat.terminal import TerminalRenderer
 from asat.workspace import Workspace, WorkspaceError
 
@@ -85,6 +86,7 @@ class Application:
     prompt_context: PromptContext
     error_tail: StderrTailAnnouncer
     completion_watcher: CompletionFocusWatcher
+    streaming_monitor: Optional[StreamingMonitor] = None
     onboarding: Optional[OnboardingCoordinator] = None
     event_logger: Optional[JsonlEventLogger] = None
     session_path: Optional[Path] = None
@@ -252,6 +254,13 @@ class Application:
         # first focus event fires (via cursor.new_cell below) so the
         # shadow focus is never empty when a command completes (F34).
         completion_watcher = CompletionFocusWatcher(bus)
+        # streaming_monitor (F37) subscribes alongside completion_watcher
+        # so the silence / beat windows track every cell from the first
+        # COMMAND_STARTED onward. The background ticker is a daemon
+        # thread, safe to start unconditionally — tests still drive
+        # `check()` with an injected clock and never observe the ticker.
+        streaming_monitor = StreamingMonitor(bus)
+        streaming_monitor.start_background_ticker()
         if text_trace is not None:
             TerminalRenderer(bus, stream=text_trace)
         onboarding = onboarding_factory(bus) if onboarding_factory is not None else None
@@ -280,6 +289,7 @@ class Application:
             prompt_context=prompt_context,
             error_tail=error_tail,
             completion_watcher=completion_watcher,
+            streaming_monitor=streaming_monitor,
             onboarding=onboarding,
             event_logger=event_logger,
             session_path=Path(session_path) if session_path is not None else None,
@@ -384,6 +394,8 @@ class Application:
         # torn-down backend.
         if self.execution_worker is not None:
             self.execution_worker.close()
+        if self.streaming_monitor is not None:
+            self.streaming_monitor.close()
         if self.session_path is not None:
             self.session.save(self.session_path)
             publish_event(

--- a/asat/app.py
+++ b/asat/app.py
@@ -435,6 +435,8 @@ class Application:
                 self._announce_notebook_list()
             elif meta == "new-notebook":
                 self._create_notebook(str(payload.get("meta_argument", "")))
+            elif meta == "verbosity":
+                self._set_verbosity(str(payload.get("meta_argument", "")))
 
     def _cancel_running_command(self) -> None:
         """`cancel_command` (Ctrl+C in INPUT mode) — F1.
@@ -612,3 +614,39 @@ class Application:
             },
             source="app",
         )
+
+    def _set_verbosity(self, argument: str) -> None:
+        """`:verbosity <level>` — swap the bank's F31 narration ceiling.
+
+        Malformed arguments emit HELP_REQUESTED listing the allowed
+        levels instead of crashing; the engine itself publishes
+        VERBOSITY_CHANGED when the swap takes effect so the user
+        hears the new preset through the default-bank binding.
+        """
+        from asat.sound_bank import SoundBankError, VERBOSITY_LEVELS
+
+        level = argument.strip().lower()
+        if not level:
+            publish_event(
+                self.bus,
+                EventType.HELP_REQUESTED,
+                {
+                    "lines": [
+                        "`:verbosity <level>` — level is one of "
+                        + ", ".join(VERBOSITY_LEVELS)
+                        + ".",
+                        f"Currently: {self.sound_engine.bank.verbosity_level}.",
+                    ],
+                },
+                source="app",
+            )
+            return
+        try:
+            self.sound_engine.set_verbosity_level(level)
+        except SoundBankError as exc:
+            publish_event(
+                self.bus,
+                EventType.HELP_REQUESTED,
+                {"lines": [str(exc)]},
+                source="app",
+            )

--- a/asat/app.py
+++ b/asat/app.py
@@ -345,10 +345,26 @@ class Application:
                 },
                 source="app",
             )
+        # F43: on the very first launch of ASAT, pre-populate the
+        # notebook's first cell with a known-good command so the
+        # newcomer can press Enter and immediately hear the
+        # submit → start → complete → exit-code arc. We check the
+        # sentinel BEFORE `onboarding.run()` flips it, then publish
+        # the tour step AFTER the welcome fires so the audio order
+        # is: welcome → "press Enter to run your first command".
+        from asat.onboarding import FIRST_RUN_TOUR_COMMAND
+
+        first_run_tour = (
+            seeded
+            and onboarding is not None
+            and onboarding.is_first_run()
+        )
         if seeded:
-            cursor.new_cell()
+            cursor.new_cell(FIRST_RUN_TOUR_COMMAND if first_run_tour else "")
         if onboarding is not None:
             onboarding.run()
+        if first_run_tour and onboarding is not None:
+            onboarding.publish_tour_step()
         return app
 
     def handle_key(self, key: Key) -> Optional[str]:

--- a/asat/default_bank.py
+++ b/asat/default_bank.py
@@ -96,6 +96,7 @@ COVERED_EVENT_TYPES: frozenset[EventType] = frozenset({
     EventType.BOOKMARK_CREATED,
     EventType.BOOKMARK_JUMPED,
     EventType.BOOKMARK_REMOVED,
+    EventType.VERBOSITY_CHANGED,
     EventType.ANSI_OSC_RECEIVED,
 })
 
@@ -360,6 +361,19 @@ def _default_bindings() -> tuple[EventBinding, ...]:
             sound_id="cancel",
             say_template="removed bookmark {name}",
             priority=160,
+        ),
+
+        # Narration verbosity presets (F31). Kept at the "minimal"
+        # tier so the user hears every preset change, including when
+        # they just dropped the bank to minimal.
+        EventBinding(
+            id="verbosity_changed",
+            event_type=EventType.VERBOSITY_CHANGED.value,
+            voice_id="system",
+            sound_id="tick",
+            say_template="verbosity {level}",
+            priority=180,
+            verbosity="minimal",
         ),
 
         # Cell lifecycle: small blips, no speech to stay quiet.

--- a/asat/default_bank.py
+++ b/asat/default_bank.py
@@ -91,6 +91,7 @@ COVERED_EVENT_TYPES: frozenset[EventType] = frozenset({
     EventType.HELP_REQUESTED,
     EventType.PROMPT_REFRESH,
     EventType.FIRST_RUN_DETECTED,
+    EventType.FIRST_RUN_TOUR_STEP,
     EventType.WORKSPACE_OPENED,
     EventType.NOTEBOOK_OPENED,
     EventType.NOTEBOOK_CREATED,
@@ -805,6 +806,22 @@ def _default_bindings() -> tuple[EventBinding, ...]:
                 "cheat sheet."
             ),
             priority=250,
+        ),
+
+        # F43: the guided first-command tour. The notebook's first cell
+        # has just been pre-populated with `echo hello, ASAT`; this
+        # narrator beat tells the user they can press Enter to run it
+        # or Escape to clear and type their own command. Fires once,
+        # right after the F20 welcome.
+        EventBinding(
+            id="first_run_tour_step",
+            event_type=EventType.FIRST_RUN_TOUR_STEP.value,
+            voice_id="narrator",
+            say_template=(
+                "Your first cell has {command} ready to go. "
+                "Press Enter to run it."
+            ),
+            priority=245,
         ),
 
         # Prompt context: when the user lands in INPUT mode AFTER a

--- a/asat/default_bank.py
+++ b/asat/default_bank.py
@@ -66,6 +66,8 @@ COVERED_EVENT_TYPES: frozenset[EventType] = frozenset({
     EventType.QUEUE_DRAINED,
     EventType.OUTPUT_CHUNK,
     EventType.ERROR_CHUNK,
+    EventType.OUTPUT_STREAM_PAUSED,
+    EventType.OUTPUT_STREAM_BEAT,
     EventType.FOCUS_CHANGED,
     EventType.OUTPUT_LINE_FOCUSED,
     EventType.ACTION_MENU_OPENED,
@@ -259,6 +261,25 @@ def _default_sounds() -> tuple[SoundRecipe, ...]:
             volume=0.95,
             azimuth=55.0,
             elevation=10.0,
+        ),
+        # F37: pacing cues for long-running commands. `stream_paused`
+        # is a single low sine so the user hears the stream go quiet
+        # without being startled. `stream_beat` is a very short, very
+        # quiet blip so a noisy build feels like it's ticking along
+        # without the progress tick itself becoming annoying.
+        SoundRecipe(
+            id="stream_paused",
+            kind="tone",
+            params={"frequency": 196.0, "duration": 0.12, "waveform": "sine"},
+            volume=0.45,
+            elevation=-10.0,
+        ),
+        SoundRecipe(
+            id="stream_beat",
+            kind="tone",
+            params={"frequency": 1480.0, "duration": 0.02, "waveform": "sine"},
+            volume=0.25,
+            elevation=25.0,
         ),
         # F7: short, unobtrusive blip for OSC 133 prompt-start markers.
         # Quieter and higher than `start` so a user whose shell paints
@@ -516,6 +537,25 @@ def _default_bindings() -> tuple[EventBinding, ...]:
             voice_id="alert",
             say_template="{line}",
             priority=90,
+        ),
+
+        # F37: pacing cues for long-running commands. `stream_paused`
+        # fires once per quiet window (default: five seconds with no
+        # chunk); `stream_beat` fires every thirty seconds the stream
+        # is alive. Kept at the default "normal" tier so they play out
+        # of the box — minimal banks skip them, and users who want
+        # total silence during long builds disable the bindings.
+        EventBinding(
+            id="output_stream_paused",
+            event_type=EventType.OUTPUT_STREAM_PAUSED.value,
+            sound_id="stream_paused",
+            priority=85,
+        ),
+        EventBinding(
+            id="output_stream_beat",
+            event_type=EventType.OUTPUT_STREAM_BEAT.value,
+            sound_id="stream_beat",
+            priority=70,
         ),
 
         # Navigation cues: mode changes are overhead ("system") and

--- a/asat/events.py
+++ b/asat/events.py
@@ -128,6 +128,8 @@ class EventType(str, Enum):
 
     OUTPUT_CHUNK = "output.chunk"
     ERROR_CHUNK = "error.chunk"
+    OUTPUT_STREAM_PAUSED = "output.stream.paused"
+    OUTPUT_STREAM_BEAT = "output.stream.beat"
 
     FOCUS_CHANGED = "focus.changed"
     KEY_PRESSED = "input.key"

--- a/asat/events.py
+++ b/asat/events.py
@@ -73,7 +73,10 @@ class EventType(str, Enum):
         PROMPT_REFRESH
 
     Onboarding:
-        FIRST_RUN_DETECTED
+        FIRST_RUN_DETECTED, FIRST_RUN_TOUR_STEP (F43: the guided first-
+        command tour event that narrates "press Enter to run your first
+        command" while the notebook's first cell is pre-populated with
+        ``echo hello, ASAT``).
 
     Workspace (F50):
         WORKSPACE_OPENED fires once on launch with the resolved
@@ -159,6 +162,7 @@ class EventType(str, Enum):
     PROMPT_REFRESH = "prompt.refresh"
 
     FIRST_RUN_DETECTED = "onboarding.first_run"
+    FIRST_RUN_TOUR_STEP = "onboarding.first_run.tour_step"
 
     WORKSPACE_OPENED = "workspace.opened"
     NOTEBOOK_OPENED = "workspace.notebook.opened"

--- a/asat/events.py
+++ b/asat/events.py
@@ -187,6 +187,8 @@ class EventType(str, Enum):
 
     SELF_CHECK_STEP = "self_check.step"
 
+    VERBOSITY_CHANGED = "verbosity.changed"
+
 
 @dataclass(frozen=True)
 class Event:

--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -277,6 +277,7 @@ META_COMMANDS: tuple[str, ...] = (
     "unbookmark",
     "bookmarks",
     "jump",
+    "verbosity",
 )
 
 # "Ambient" meta-commands do their job without taking focus away from
@@ -303,6 +304,7 @@ AMBIENT_META_COMMANDS: frozenset[str] = frozenset(
         "bookmark",
         "unbookmark",
         "bookmarks",
+        "verbosity",
     }
 )
 
@@ -331,7 +333,7 @@ HELP_LINES: tuple[str, ...] = (
     "           Ctrl+Z undo, Ctrl+Y redo edits in the order you made them.",
     "           Ctrl+R resets to defaults at cursor scope (Enter confirms, Escape cancels).",
     "Menu:      F2 (or Ctrl+.) opens contextual actions; Up/Down walk, Enter invokes, Escape closes.",
-    "Meta:      :help, :settings, :save, :quit, :delete, :duplicate, :pwd, :state, :commands, :reset, :welcome, :repeat, :heading, :toc, :workspace, :list-notebooks, :new-notebook, :bindings, :bookmark, :unbookmark, :bookmarks, :jump.",
+    "Meta:      :help, :settings, :save, :quit, :delete, :duplicate, :pwd, :state, :commands, :reset, :welcome, :repeat, :heading, :toc, :workspace, :list-notebooks, :new-notebook, :bindings, :bookmark, :unbookmark, :bookmarks, :jump, :verbosity.",
     "           `:help topics` lists focused tours; `:help <topic>` narrates one (navigation, cells, settings, audio, search, meta).",
     "           `:welcome` replays the first-run tour; `:repeat` (or Ctrl+R in notebook/input) re-speaks the last narration.",
     "           Meta-commands are case-insensitive and accept a trailing argument.",

--- a/asat/onboarding.py
+++ b/asat/onboarding.py
@@ -43,6 +43,18 @@ DEFAULT_ONBOARDING_LINES: tuple[str, ...] = (
 )
 
 
+# F43: after the welcome tour fires we pre-populate the first cell
+# with a known-good command so a brand-new user hears the submit →
+# start → complete → exit-code arc on their first Enter press.
+FIRST_RUN_TOUR_COMMAND: str = "echo hello, ASAT"
+
+
+FIRST_RUN_TOUR_LINES: tuple[str, ...] = (
+    "Your first cell is ready.",
+    "Press Enter to run it, or use Backspace to edit before running.",
+)
+
+
 SILENT_SINK_HINT = (
     "[asat] First-run welcome is narrating into an in-memory sink so "
     "you will not hear it. Pass --live (Windows) or --wav-dir DIR to "
@@ -126,6 +138,27 @@ class OnboardingCoordinator:
         self._sentinel_path.parent.mkdir(parents=True, exist_ok=True)
         self._sentinel_path.write_text("first-run-done\n", encoding="utf-8")
         return True
+
+    def publish_tour_step(
+        self,
+        *,
+        command: str = FIRST_RUN_TOUR_COMMAND,
+        lines: Iterable[str] = FIRST_RUN_TOUR_LINES,
+    ) -> None:
+        """Publish F43's `FIRST_RUN_TOUR_STEP` event.
+
+        Application.build calls this exactly once per first run, right
+        after pre-populating the notebook's first cell with `command`.
+        Kept here (rather than inlined in Application) so the tour's
+        command + narration live next to the rest of the onboarding
+        vocabulary and can be reused by future tour variants.
+        """
+        publish_event(
+            self._bus,
+            EventType.FIRST_RUN_TOUR_STEP,
+            {"command": command, "lines": list(lines)},
+            source=self.SOURCE,
+        )
 
     def reset(self) -> None:
         """Delete the sentinel so the next `.run()` re-fires the tour."""

--- a/asat/sample_payloads.py
+++ b/asat/sample_payloads.py
@@ -181,6 +181,7 @@ SAMPLE_PAYLOADS: dict[EventType, dict[str, object]] = {
     EventType.BOOKMARK_CREATED: {"name": "setup", "cell_id": "c1"},
     EventType.BOOKMARK_JUMPED: {"name": "setup", "cell_id": "c1"},
     EventType.BOOKMARK_REMOVED: {"name": "setup", "cell_id": "c1"},
+    EventType.VERBOSITY_CHANGED: {"level": "normal", "previous": "verbose"},
     EventType.ANSI_OSC_RECEIVED: {
         "cell_id": "c1",
         "body": "133;A",

--- a/asat/sample_payloads.py
+++ b/asat/sample_payloads.py
@@ -163,6 +163,13 @@ SAMPLE_PAYLOADS: dict[EventType, dict[str, object]] = {
         "lines": ["Welcome."],
         "sentinel_path": "/tmp/first-run-done",
     },
+    EventType.FIRST_RUN_TOUR_STEP: {
+        "command": "echo hello, ASAT",
+        "lines": [
+            "Your first cell is ready.",
+            "Press Enter to run it, or use Backspace to edit before running.",
+        ],
+    },
     EventType.WORKSPACE_OPENED: {
         "root": "/tmp/proj",
         "name": "proj",

--- a/asat/sample_payloads.py
+++ b/asat/sample_payloads.py
@@ -55,6 +55,8 @@ SAMPLE_PAYLOADS: dict[EventType, dict[str, object]] = {
     EventType.QUEUE_DRAINED: {"last_cell_id": "c1", "queue_depth": 0},
     EventType.OUTPUT_CHUNK: {"cell_id": "c1", "line": "hello"},
     EventType.ERROR_CHUNK: {"cell_id": "c1", "line": "boom"},
+    EventType.OUTPUT_STREAM_PAUSED: {"cell_id": "c1", "gap_sec": 5.2},
+    EventType.OUTPUT_STREAM_BEAT: {"cell_id": "c1", "elapsed_sec": 30.0},
     EventType.FOCUS_CHANGED: {
         "old_mode": "notebook",
         "new_mode": "input",

--- a/asat/sound_bank.py
+++ b/asat/sound_bank.py
@@ -43,6 +43,15 @@ SOUND_KINDS = ("tone", "chord", "sample", "silence")
 VOICE_OVERRIDE_FIELDS = ("rate", "pitch", "volume", "azimuth", "elevation")
 SOUND_OVERRIDE_FIELDS = ("volume", "azimuth", "elevation")
 
+# F31: tiered narration. A binding's `verbosity` says how chatty it is
+# ("minimal" = critical only, "verbose" = chatty), and the bank's
+# `verbosity_level` is the user's current ceiling. The engine plays a
+# binding only when its rank <= the bank's rank, so raising the level
+# unlocks chattier tiers and lowering it silences them without losing
+# the bindings themselves.
+VERBOSITY_LEVELS: tuple[str, ...] = ("minimal", "normal", "verbose")
+VERBOSITY_RANK: dict[str, int] = {level: rank for rank, level in enumerate(VERBOSITY_LEVELS)}
+
 
 class SoundBankError(ValueError):
     """Raised when a SoundBank document fails structural validation."""
@@ -206,6 +215,12 @@ class EventBinding:
     enabled: bool = True
     voice_overrides: dict[str, float] = field(default_factory=dict)
     sound_overrides: dict[str, float] = field(default_factory=dict)
+    # F31: which verbosity tier this binding belongs to. The engine
+    # filters out bindings whose tier is stricter than the bank's
+    # current `verbosity_level` (e.g. a "verbose" keystroke cue is
+    # silent under "minimal"), but never modifies the binding itself
+    # so flipping back restores the cue without an edit.
+    verbosity: str = "normal"
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize this binding to a JSON-compatible dictionary."""
@@ -220,6 +235,7 @@ class EventBinding:
             "enabled": self.enabled,
             "voice_overrides": dict(self.voice_overrides),
             "sound_overrides": dict(self.sound_overrides),
+            "verbosity": self.verbosity,
         }
 
     @classmethod
@@ -259,6 +275,7 @@ class EventBinding:
             enabled=bool(data.get("enabled", True)),
             voice_overrides=voice_overrides,
             sound_overrides=sound_overrides,
+            verbosity=_verbosity(data.get("verbosity", "normal"), "binding.verbosity"),
         )
 
 
@@ -282,6 +299,11 @@ class SoundBank:
     # they round-trip through JSON without any custom coercion.
     ducking_enabled: bool = True
     duck_level: float = 0.4
+    # F31: bank-wide verbosity ceiling. The engine plays a binding
+    # only when its `verbosity` rank is <= this level's rank
+    # (minimal=0 < normal=1 < verbose=2). Lowering the ceiling
+    # silences chattier tiers without removing the bindings.
+    verbosity_level: str = "normal"
 
     def voice_for(self, voice_id: str) -> Optional[Voice]:
         """Return the voice with this id, or None if it is missing."""
@@ -297,20 +319,42 @@ class SoundBank:
                 return sound
         return None
 
-    def bindings_for(self, event_type: str, *, include_disabled: bool = False) -> tuple[EventBinding, ...]:
+    def bindings_for(
+        self,
+        event_type: str,
+        *,
+        include_disabled: bool = False,
+        respect_verbosity: bool = True,
+    ) -> tuple[EventBinding, ...]:
         """Return bindings matching event_type, sorted by priority desc.
 
         Enabled bindings come first by default; pass include_disabled
-        when an editor needs to surface the full list.
+        when an editor needs to surface the full list. Verbosity
+        filtering (F31) is on by default so the engine sees only the
+        bindings the current preset allows; the editor passes
+        ``respect_verbosity=False`` to surface all bindings.
         """
+        ceiling = VERBOSITY_RANK[self.verbosity_level]
         matches = [
             binding
             for binding in self.bindings
             if binding.event_type == event_type
             and (include_disabled or binding.enabled)
+            and (
+                not respect_verbosity
+                or VERBOSITY_RANK.get(binding.verbosity, VERBOSITY_RANK["normal"]) <= ceiling
+            )
         ]
         matches.sort(key=lambda b: b.priority, reverse=True)
         return tuple(matches)
+
+    def with_verbosity_level(self, level: str) -> "SoundBank":
+        """Return a copy of the bank with `verbosity_level` set to `level`.
+
+        Raises `SoundBankError` for unknown levels so callers (engine,
+        meta-command handler) get a uniform validation surface.
+        """
+        return replace(self, verbosity_level=_verbosity(level, "verbosity_level"))
 
     def validate(self) -> None:
         """Raise SoundBankError if internal references are inconsistent.
@@ -343,6 +387,7 @@ class SoundBank:
             "bindings": [binding.to_dict() for binding in self.bindings],
             "ducking_enabled": self.ducking_enabled,
             "duck_level": self.duck_level,
+            "verbosity_level": self.verbosity_level,
         }
 
     @classmethod
@@ -361,6 +406,7 @@ class SoundBank:
         )
         ducking_enabled = bool(data.get("ducking_enabled", True))
         duck_level = _unit_float(data.get("duck_level", 0.4), "duck_level")
+        verbosity_level = _verbosity(data.get("verbosity_level", "normal"), "verbosity_level")
         bank = cls(
             voices=voices,
             sounds=sounds,
@@ -368,6 +414,7 @@ class SoundBank:
             version=version,
             ducking_enabled=ducking_enabled,
             duck_level=duck_level,
+            verbosity_level=verbosity_level,
         )
         bank.validate()
         return bank
@@ -437,6 +484,17 @@ def _angle(value: Any, label: str, low: float, high: float) -> float:
     if number < low or number > high:
         raise SoundBankError(f"{label} must be in [{low}, {high}], got {number}")
     return number
+
+
+def _verbosity(value: Any, label: str) -> str:
+    """Coerce value to a known verbosity level; raise on anything else."""
+    if not isinstance(value, str):
+        raise SoundBankError(f"{label} must be a string, got {type(value).__name__}")
+    if value not in VERBOSITY_RANK:
+        raise SoundBankError(
+            f"{label} must be one of {VERBOSITY_LEVELS}, got {value!r}"
+        )
+    return value
 
 
 def _unit_float(value: Any, label: str) -> float:

--- a/asat/sound_bank_schema.json
+++ b/asat/sound_bank_schema.json
@@ -37,6 +37,12 @@
       "maximum": 1.0,
       "default": 0.4,
       "description": "F32: gain multiplier applied to a concurrent non-speech buffer while speech is mixing. 0.0 silences cues entirely; 1.0 disables ducking even if `ducking_enabled` is true."
+    },
+    "verbosity_level": {
+      "type": "string",
+      "enum": ["minimal", "normal", "verbose"],
+      "default": "normal",
+      "description": "F31: bank-wide narration ceiling. The engine plays a binding only when its `verbosity` rank (minimal=0 < normal=1 < verbose=2) is <= this level's rank."
     }
   },
   "additionalProperties": false,
@@ -118,6 +124,12 @@
             "azimuth": { "type": "number", "minimum": -180, "maximum": 180 },
             "elevation": { "type": "number", "minimum": -90, "maximum": 90 }
           }
+        },
+        "verbosity": {
+          "type": "string",
+          "enum": ["minimal", "normal", "verbose"],
+          "default": "normal",
+          "description": "F31: tier this binding belongs to. The engine plays the binding only when its rank is <= the bank's `verbosity_level` rank."
         }
       },
       "additionalProperties": false,

--- a/asat/sound_engine.py
+++ b/asat/sound_engine.py
@@ -232,6 +232,29 @@ class SoundEngine:
         self._bank = bank
         self._resubscribe()
 
+    def set_verbosity_level(self, level: str) -> SoundBank:
+        """F31: change the bank's verbosity ceiling and announce it.
+
+        Builds a new bank via `SoundBank.with_verbosity_level` (which
+        validates `level`), swaps it in via `set_bank`, then publishes
+        a `VERBOSITY_CHANGED` event carrying the previous and new
+        levels so observers (default-bank narration, future settings
+        editor) can react. Returns the new bank for callers that need
+        to chain further edits.
+        """
+        previous = self._bank.verbosity_level
+        new_bank = self._bank.with_verbosity_level(level)
+        if new_bank.verbosity_level == previous:
+            return new_bank
+        self.set_bank(new_bank)
+        publish_event(
+            self._bus,
+            EventType.VERBOSITY_CHANGED,
+            {"level": new_bank.verbosity_level, "previous": previous},
+            source=self.SOURCE,
+        )
+        return new_bank
+
     def close(self) -> None:
         """Unsubscribe from every active event type and close the sink."""
         for event_type in list(self._subscribed_types):

--- a/asat/streaming_monitor.py
+++ b/asat/streaming_monitor.py
@@ -1,0 +1,196 @@
+"""StreamingMonitor: silence detection + periodic beats for long output (F37).
+
+A long-running command (``pytest``, ``make``, log tailing) emits
+hundreds of ``OUTPUT_CHUNK`` events. After thirty seconds of streaming
+a user has lost sense of progress, and a command that hangs silently
+is indistinguishable from one that is just slow. The StreamingMonitor
+closes both gaps by subscribing to the execution-event stream and
+republishing two synthetic events:
+
+- ``OUTPUT_STREAM_PAUSED`` fires the first time the gap between the
+  last chunk and "now" crosses ``silence_threshold_sec`` while a cell
+  is still running. The default bank binds it to a quiet cue the user
+  hears once — "the stream went quiet".
+- ``OUTPUT_STREAM_BEAT`` fires every ``progress_beat_interval_sec``
+  while streaming. The default bank binds it to a subtle progress
+  tick so the user keeps a temporal frame on a noisy build.
+
+The monitor itself is pure: ``check()`` consults the injected clock
+and publishes at most one event per call. Production wiring launches
+a small daemon thread via ``start_background_ticker()`` that invokes
+``check()`` every ``tick_interval_sec``; tests drive ``check`` directly
+with an injected clock so no thread or real time is needed.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Callable, Optional
+
+from asat.event_bus import EventBus, publish_event
+from asat.events import Event, EventType
+
+
+class StreamingMonitor:
+    """Track per-cell output streaming and publish pacing events."""
+
+    SOURCE = "streaming_monitor"
+
+    def __init__(
+        self,
+        bus: EventBus,
+        *,
+        silence_threshold_sec: float = 5.0,
+        progress_beat_interval_sec: float = 30.0,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        """Subscribe to the streaming events on `bus`.
+
+        ``silence_threshold_sec`` controls how quiet the chunk stream
+        must be before an ``OUTPUT_STREAM_PAUSED`` event fires;
+        ``progress_beat_interval_sec`` controls how often an
+        ``OUTPUT_STREAM_BEAT`` fires while streaming is live. Both
+        accept fractional seconds so tests can run on a compressed
+        timeline. ``clock`` is injected so tests advance time
+        deterministically without real sleeps.
+        """
+        if silence_threshold_sec <= 0:
+            raise ValueError("silence_threshold_sec must be > 0")
+        if progress_beat_interval_sec <= 0:
+            raise ValueError("progress_beat_interval_sec must be > 0")
+        self._bus = bus
+        self._silence_threshold = float(silence_threshold_sec)
+        self._beat_interval = float(progress_beat_interval_sec)
+        self._clock = clock
+        self._active_cell_id: Optional[str] = None
+        self._started_at: Optional[float] = None
+        self._last_chunk_at: Optional[float] = None
+        self._last_beat_at: Optional[float] = None
+        self._paused_sent = False
+        self._ticker_thread: Optional[threading.Thread] = None
+        self._ticker_stop: Optional[threading.Event] = None
+        for event_type in (
+            EventType.COMMAND_STARTED,
+            EventType.OUTPUT_CHUNK,
+            EventType.ERROR_CHUNK,
+            EventType.COMMAND_COMPLETED,
+            EventType.COMMAND_FAILED,
+            EventType.COMMAND_CANCELLED,
+        ):
+            bus.subscribe(event_type, self._on_event)
+
+    @property
+    def active_cell_id(self) -> Optional[str]:
+        """Return the cell currently being tracked, or None if idle."""
+        return self._active_cell_id
+
+    def _on_event(self, event: Event) -> None:
+        """Update internal state from an execution-lifecycle event."""
+        now = self._clock()
+        cell_id = event.payload.get("cell_id")
+        if event.event_type is EventType.COMMAND_STARTED:
+            self._start_tracking(str(cell_id) if cell_id is not None else None, now)
+        elif event.event_type in (EventType.OUTPUT_CHUNK, EventType.ERROR_CHUNK):
+            self._record_chunk(cell_id, now)
+        else:
+            self._stop_tracking(cell_id)
+
+    def _start_tracking(self, cell_id: Optional[str], now: float) -> None:
+        """Begin silence/beat tracking for a freshly-launched cell."""
+        self._active_cell_id = cell_id
+        self._started_at = now
+        self._last_chunk_at = now
+        self._last_beat_at = now
+        self._paused_sent = False
+
+    def _record_chunk(self, cell_id: object, now: float) -> None:
+        """Reset the silence timer when a chunk arrives for the active cell."""
+        if self._active_cell_id is None or cell_id != self._active_cell_id:
+            return
+        self._last_chunk_at = now
+        # A fresh chunk after a pause re-arms the gate so a subsequent
+        # silence window fires again. Pause is a "once per quiet
+        # stretch" signal, not a level.
+        self._paused_sent = False
+
+    def _stop_tracking(self, cell_id: object) -> None:
+        """Clear state when the active cell's command ends."""
+        if self._active_cell_id is None or cell_id != self._active_cell_id:
+            return
+        self._active_cell_id = None
+        self._started_at = None
+        self._last_chunk_at = None
+        self._last_beat_at = None
+        self._paused_sent = False
+
+    def check(self, now: Optional[float] = None) -> None:
+        """Publish any pacing events whose thresholds have elapsed.
+
+        Idempotent when no active cell is being tracked; safe to call
+        every tick of a background poller. ``now`` lets tests step the
+        virtual clock without touching the real one.
+        """
+        if self._active_cell_id is None:
+            return
+        current = self._clock() if now is None else now
+        if (
+            not self._paused_sent
+            and self._last_chunk_at is not None
+            and current - self._last_chunk_at >= self._silence_threshold
+        ):
+            gap = current - self._last_chunk_at
+            publish_event(
+                self._bus,
+                EventType.OUTPUT_STREAM_PAUSED,
+                {"cell_id": self._active_cell_id, "gap_sec": gap},
+                source=self.SOURCE,
+            )
+            self._paused_sent = True
+        if (
+            self._last_beat_at is not None
+            and self._started_at is not None
+            and current - self._last_beat_at >= self._beat_interval
+        ):
+            elapsed = current - self._started_at
+            publish_event(
+                self._bus,
+                EventType.OUTPUT_STREAM_BEAT,
+                {"cell_id": self._active_cell_id, "elapsed_sec": elapsed},
+                source=self.SOURCE,
+            )
+            self._last_beat_at = current
+
+    def start_background_ticker(self, tick_interval_sec: float = 1.0) -> None:
+        """Launch a daemon thread that polls ``check()`` in production.
+
+        Tests don't call this; they invoke ``check()`` with an injected
+        clock. ``tick_interval_sec`` should divide both thresholds so
+        no cue fires noticeably late.
+        """
+        if self._ticker_thread is not None:
+            return
+        stop_event = threading.Event()
+
+        def _tick() -> None:
+            while not stop_event.wait(tick_interval_sec):
+                try:
+                    self.check()
+                except Exception:
+                    # A misbehaving subscriber shouldn't take down the
+                    # ticker; the next iteration retries.
+                    continue
+
+        thread = threading.Thread(
+            target=_tick, name="asat-streaming-monitor", daemon=True
+        )
+        self._ticker_stop = stop_event
+        self._ticker_thread = thread
+        thread.start()
+
+    def close(self) -> None:
+        """Stop the background ticker if one was started."""
+        if self._ticker_stop is not None:
+            self._ticker_stop.set()
+        self._ticker_thread = None
+        self._ticker_stop = None

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -121,11 +121,17 @@ worker entirely.
 ## Output streaming
 
 Producer: `asat.kernel.ExecutionKernel` as the subprocess streams.
+`OUTPUT_STREAM_PAUSED` and `OUTPUT_STREAM_BEAT` (F37) are synthesised
+by `asat.streaming_monitor.StreamingMonitor`, which subscribes to the
+chunk stream and publishes pacing cues when the stream goes quiet or
+when a beat interval elapses.
 
-| EventType      | Payload keys               |
-|----------------|----------------------------|
-| `OUTPUT_CHUNK` | `cell_id`, `line`          |
-| `ERROR_CHUNK`  | `cell_id`, `line`          |
+| EventType              | Payload keys                      | Source              |
+|------------------------|-----------------------------------|---------------------|
+| `OUTPUT_CHUNK`         | `cell_id`, `line`                 | `kernel`            |
+| `ERROR_CHUNK`          | `cell_id`, `line`                 | `kernel`            |
+| `OUTPUT_STREAM_PAUSED` | `cell_id`, `gap_sec`              | `streaming_monitor` |
+| `OUTPUT_STREAM_BEAT`   | `cell_id`, `elapsed_sec`          | `streaming_monitor` |
 
 ## Input + focus router
 

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -341,13 +341,19 @@ Producer: `asat.onboarding.OnboardingCoordinator` (`source="onboarding"`).
 file) when ASAT launches for the first time, and again on demand via
 the `:welcome` meta-command with `replay=True`.
 
-| EventType            | Payload keys                                         |
-|----------------------|------------------------------------------------------|
-| `FIRST_RUN_DETECTED` | `lines`, `sentinel_path`, `replay`                   |
+| EventType              | Payload keys                                         |
+|------------------------|------------------------------------------------------|
+| `FIRST_RUN_DETECTED`   | `lines`, `sentinel_path`, `replay`                   |
+| `FIRST_RUN_TOUR_STEP`  | `command`, `lines`                                   |
 
 `replay` is `True` when the event is a `:welcome` re-invocation and
 `False` on the genuine first run; a binding that wants to sound
 different on replay can key off it.
+
+`FIRST_RUN_TOUR_STEP` (F43) fires exactly once, right after
+`FIRST_RUN_DETECTED` on a first launch. `command` is the pre-populated
+first-cell command (default `echo hello, ASAT`); `lines` is a short
+spoken prompt telling the user Enter runs it and Escape clears it.
 
 ## Workspace
 

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -378,6 +378,17 @@ prune; the router publishes the event when the user invoked
 | `BOOKMARK_JUMPED`   | `name`, `cell_id`                                |
 | `BOOKMARK_REMOVED`  | `name`, `cell_id`                                |
 
+## Narration verbosity
+
+Producer: `asat.sound_engine.SoundEngine` (`source="sound_engine"`),
+fired when `set_verbosity_level` swaps the bank's F31 narration
+ceiling to a different level. `level` is the new ceiling
+(`minimal` / `normal` / `verbose`); `previous` is the prior ceiling.
+
+| EventType             | Payload keys          |
+|-----------------------|-----------------------|
+| `VERBOSITY_CHANGED`   | `level`, `previous`   |
+
 ## Self-check
 
 Producer: `asat.self_check.run_self_check` (`source="self_check"`),

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -961,10 +961,23 @@ is left as F30b for a future sweep.
 
 ## F31 — Narration verbosity presets
 
-**Gap.** Some users want bare-minimum narration (errors + exit codes
-only), others want chatty feedback on every keystroke. Today, the
-only way to quiet a class of events is to manually disable bindings
-one-by-one in the settings editor.
+**Status: Shipped.** `EventBinding` carries `verbosity`
+(`minimal` / `normal` / `verbose`, default `normal`) and `SoundBank`
+carries a matching `verbosity_level` ceiling. `bindings_for` now
+filters by verbosity by default so the engine only sees the bindings
+the current preset allows; the editor passes `respect_verbosity=False`
+to keep surfacing every record. `:verbosity <level>` calls
+`SoundEngine.set_verbosity_level`, which swaps the bank and publishes
+`VERBOSITY_CHANGED` — the default bank binds that event at the
+`minimal` tier so the user always hears the new preset, even when
+they just dropped to `minimal`. Round-trips through JSON and the
+schema documents both fields. `Ctrl+M` cycling inside SETTINGS and a
+settings-editor row for the ceiling remain as follow-ups.
+
+**Gap (at time of shipping).** Some users want bare-minimum narration
+(errors + exit codes only), others want chatty feedback on every
+keystroke. Today, the only way to quiet a class of events is to
+manually disable bindings one-by-one in the settings editor.
 
 **Where it surfaces.** A user running a 10-minute build doesn't need
 per-line narration but does want the failure cue; today they have

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -221,10 +221,16 @@ Document the SOFA-to-stereo-WAV conversion recipe in AUDIO.md.
 
 ## F10 — Non-blocking execution + cancel keystroke
 
-**Gap.** `Application.execute(cell_id)` runs the kernel synchronously,
-so while a command is running the entry-point loop cannot read keys.
-That makes F1 (Ctrl+C cancel) impossible to implement without moving
-execution off the main thread.
+**Status: Shipped.** `ExecutionKernel` runs each cell on a worker
+thread under `_cancel_lock`/`_cancelled_cells` state, exposes
+`cancel(cell_id)` that terminates the subprocess and publishes
+`COMMAND_CANCELLED`, and the router binds Ctrl+C in INPUT mode to
+that path (the F1 entry tracks the keystroke shipping).
+
+**Gap (at time of shipping).** `Application.execute(cell_id)` ran the
+kernel synchronously, so while a command was running the entry-point
+loop could not read keys. That made F1 (Ctrl+C cancel) impossible to
+implement without moving execution off the main thread.
 
 **Where it surfaces.** Every long-running command — `pytest`, `npm
 install`, `git clone` — blocks the whole terminal until it finishes.

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -1431,38 +1431,32 @@ quick-start; cross-reference from F41's silent-sink hint.
 
 ## F43 — Guided first-command tour
 
-**Gap.** F20 (shipped) narrates a welcome and explains the key
-meta-commands, but stops there. The user is then dropped into an
-empty notebook with no prompt to actually run anything, so the
-first-run experience ends on a passive "press colon h e l p" —
-the user still has to invent their own first command to hear what
-`COMMAND_SUBMITTED` / `COMMAND_STARTED` / `COMMAND_COMPLETED` /
-exit-code narration sound like.
+**Status: Shipped.**
 
-**Where it surfaces.** A brand-new user who has just finished
-onboarding knows how to invoke `:help` but has not yet heard any
-of the execution cues that define ASAT's identity. They often
-spend their first minute guessing what to type.
+**Gap (at time of shipping).** F20 narrated a welcome and explained
+the key meta-commands but stopped there. The user was then dropped
+into an empty notebook with no prompt to run anything, so the
+first-run experience ended on a passive "press colon h e l p" —
+the newcomer still had to invent their own first command to hear
+what `COMMAND_SUBMITTED` / `COMMAND_STARTED` / `COMMAND_COMPLETED`
+/ exit-code narration sounded like.
 
-**Sketch.** After `OnboardingCoordinator.run()`
-(`asat/onboarding.py`) publishes `FIRST_RUN_DETECTED` and
-commits the sentinel, queue one follow-up step: pre-populate the
-first cell with `echo hello, ASAT` and narrate *"Press Enter to
-run your first command. Press Escape to clear the line and type
-your own."* Fire a new `FIRST_RUN_TOUR_STEP` event the default
-bank binds to the narrator. The user hears the full
-submit→start→complete arc on a known-good command, learns the
-cues by association, and can replace the placeholder at will.
-
-Cleanly opt-out-able by the same `--quiet` / `--check` /
-sentinel flags as F20. If the user overwrites or clears the
-pre-filled line before pressing Enter, the tour step is
-considered complete either way — we do not re-insert.
-
-**Documentation touch points.** Extend
-`docs/USER_MANUAL.md`'s "Five-minute tour" so the first
-paragraph matches what a fresh install actually does now;
-mention the tour in `README.md` quick-start.
+**Sketch (shipped).** `asat/onboarding.py` gained
+`FIRST_RUN_TOUR_COMMAND = "echo hello, ASAT"` + a short
+`FIRST_RUN_TOUR_LINES` prompt and a new
+`OnboardingCoordinator.publish_tour_step(...)` helper.
+`Application.build()` reads `onboarding.is_first_run()` *before*
+`onboarding.run()` flips the sentinel; when it's a first run and
+the build seeded a fresh session, `cursor.new_cell(...)` is called
+with the tour command so the newcomer's first Enter press exercises
+the full submit → start → complete → exit-code arc. The tour step
+fires after the welcome event so the audio order is "welcome, then
+prompt". If the user clears or rewrites the pre-filled line before
+pressing Enter, the tour is considered complete — the coordinator
+never re-inserts. A new `FIRST_RUN_TOUR_STEP` event in
+`asat/events.py` carries `command` + `lines`; the default bank
+binds it to the narrator voice. `--quiet` / `--check` skip
+onboarding entirely, which transparently skips the tour too.
 
 ---
 

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -1135,25 +1135,31 @@ stderr and feed both OUTPUT-mode review and the F36 announcer.
 
 ## F37 — Long-output pacing
 
-**Gap.** A command emitting thousands of lines produces a continuous
-narration stream. After thirty seconds the user has lost sense of
-progress and the per-line cues become noise. There's no silence
-detection ("it's been quiet for 10s — still running?") and no
-periodic progress beat during streaming.
+**Status: Shipped.**
 
-**Where it surfaces.** `pytest -v`, `make`, log-tailing. Also:
-commands that hang silently have no distinguishing cue from commands
-that are just slow.
+**Gap (at time of shipping).** A command emitting thousands of lines
+produced a continuous narration stream. After thirty seconds the user
+had lost sense of progress and the per-line cues became noise. There
+was no silence detection ("it's been quiet for 10s — still running?")
+and no periodic progress beat during streaming.
 
-**Sketch.** A `StreamingMonitor` subscribes to `OUTPUT_CHUNK` and
-`COMMAND_STARTED`/`_COMPLETED` for the active cell. It tracks the
-time since the last chunk; if the gap crosses `silence_threshold_sec`
-(default 5.0) it publishes `OUTPUT_STREAM_PAUSED`, and every
-`progress_beat_interval_sec` (default 30.0) while output is
-streaming it publishes `OUTPUT_STREAM_BEAT`. Both are opt-in
-bindings — the default bank binds them to subtle non-speech cues.
-Pairs with F24 (continuous playback): together they give the user a
-temporal frame for long-running output.
+**Sketch (shipped).** New `asat/streaming_monitor.py` holds a
+`StreamingMonitor` that subscribes to `COMMAND_STARTED`,
+`OUTPUT_CHUNK`, `ERROR_CHUNK`, `COMMAND_COMPLETED`/`_FAILED`/
+`_CANCELLED` and tracks per-cell streaming state. `check(now=None)`
+publishes `OUTPUT_STREAM_PAUSED` once per quiet window
+(`silence_threshold_sec`, default 5.0) and `OUTPUT_STREAM_BEAT`
+every `progress_beat_interval_sec` (default 30.0) the stream is
+alive. `Application.build` constructs the monitor, wires it onto
+the bus alongside `CompletionFocusWatcher`, and launches a daemon
+ticker via `start_background_ticker()` that polls `check()` every
+second; `Application.close` stops the ticker. The default bank
+binds both events to two new subtle cues (`stream_paused`,
+`stream_beat`) at the default "normal" verbosity tier, so they play
+out of the box — `minimal` banks skip them, and users who want
+total silence during long builds disable the bindings in settings.
+Tests inject a virtual `clock` and drive
+`check(now)` directly, so no real sleeps are ever needed.
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -297,6 +297,7 @@ discarded and the cell is not modified.
 | `:unbookmark <name>` | Remove a previously registered bookmark (F35). |
 | `:bookmarks` | Narrate every bookmark and the cell index it points at (F35). |
 | `:jump <name>` | Move focus to the cell registered under `<name>` (F35). Leaves you in NOTEBOOK mode at the target cell. |
+| `:verbosity <level>` | Set the bank-wide narration ceiling to `minimal`, `normal`, or `verbose` (F31). Chattier tiers are silenced when the level drops. Plain `:verbosity` narrates the allowed values and the current setting. |
 
 Meta-command names are **case-insensitive** — `:HELP`, `:Help`, and
 `:help` all do the same thing. A single trailing argument is

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -402,6 +402,51 @@ class ApplicationMetaCommandTests(unittest.TestCase):
         app.handle_key(kc.ENTER)
         self.assertTrue(app.running)
 
+    def test_verbosity_meta_command_swaps_bank_level(self) -> None:
+        """F31: `:verbosity minimal` drops the bank ceiling and publishes
+        VERBOSITY_CHANGED so the default-bank binding can narrate the new
+        preset."""
+        app = Application.build()
+        events: list[dict] = []
+        app.bus.subscribe(
+            EventType.VERBOSITY_CHANGED,
+            lambda event: events.append(dict(event.payload)),
+        )
+        _type(app, ":verbosity minimal")
+        app.handle_key(kc.ENTER)
+        self.assertEqual(app.sound_engine.bank.verbosity_level, "minimal")
+        self.assertEqual(events, [{"level": "minimal", "previous": "normal"}])
+
+    def test_verbosity_meta_command_rejects_unknown_level(self) -> None:
+        """F31: an unknown level surfaces a HELP_REQUESTED hint rather
+        than crashing or silently swallowing the submission."""
+        app = Application.build()
+        helps: list[dict] = []
+        app.bus.subscribe(
+            EventType.HELP_REQUESTED,
+            lambda event: helps.append(dict(event.payload)),
+        )
+        _type(app, ":verbosity whisper")
+        app.handle_key(kc.ENTER)
+        self.assertEqual(app.sound_engine.bank.verbosity_level, "normal")
+        self.assertTrue(any("whisper" in " ".join(h["lines"]) for h in helps))
+
+    def test_verbosity_meta_command_without_argument_lists_levels(self) -> None:
+        """F31: a bare `:verbosity` narrates the allowed values and the
+        current setting so the user can discover the options."""
+        app = Application.build()
+        helps: list[dict] = []
+        app.bus.subscribe(
+            EventType.HELP_REQUESTED,
+            lambda event: helps.append(dict(event.payload)),
+        )
+        _type(app, ":verbosity")
+        app.handle_key(kc.ENTER)
+        self.assertEqual(app.sound_engine.bank.verbosity_level, "normal")
+        text = "\n".join(line for h in helps for line in h["lines"])
+        self.assertIn("minimal", text)
+        self.assertIn("verbose", text)
+
 
 class ApplicationRepeatNarrationTests(unittest.TestCase):
     """F30: `:repeat` and Ctrl+R replay the last narration."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -160,6 +160,72 @@ class ApplicationBuildTests(unittest.TestCase):
             self.assertLess(session_idx, welcome_idx)
             self.assertTrue(sentinel.exists())
 
+    def test_first_run_tour_prefills_cell_and_fires_tour_step(self) -> None:
+        """F43: a first-run Application.build pre-populates the seeded
+        notebook's first cell with `echo hello, ASAT` and publishes
+        FIRST_RUN_TOUR_STEP right after FIRST_RUN_DETECTED."""
+        import tempfile
+        from pathlib import Path
+
+        from asat.event_bus import EventBus
+        from asat.onboarding import FIRST_RUN_TOUR_COMMAND, OnboardingCoordinator
+
+        with tempfile.TemporaryDirectory() as td:
+            sentinel = Path(td) / "first-run-done"
+            seen: list[EventType] = []
+
+            def _factory(bus: EventBus) -> OnboardingCoordinator:
+                bus.subscribe("*", lambda e: seen.append(e.event_type))
+                return OnboardingCoordinator(bus, sentinel)
+
+            app = Application.build(onboarding_factory=_factory)
+
+            self.assertEqual(len(app.session.cells), 1)
+            self.assertEqual(
+                app.session.cells[0].command, FIRST_RUN_TOUR_COMMAND
+            )
+            welcome_idx = seen.index(EventType.FIRST_RUN_DETECTED)
+            tour_idx = seen.index(EventType.FIRST_RUN_TOUR_STEP)
+            self.assertLess(welcome_idx, tour_idx)
+
+    def test_second_run_skips_tour_prefill(self) -> None:
+        """F43: once the sentinel exists, the build must NOT pre-fill
+        the cell — a returning user would otherwise open every session
+        with a stale `echo hello, ASAT`."""
+        import tempfile
+        from pathlib import Path
+
+        from asat.event_bus import EventBus
+        from asat.onboarding import OnboardingCoordinator
+
+        with tempfile.TemporaryDirectory() as td:
+            sentinel = Path(td) / "first-run-done"
+            sentinel.write_text("done\n", encoding="utf-8")
+
+            seen: list[EventType] = []
+
+            def _factory(bus: EventBus) -> OnboardingCoordinator:
+                bus.subscribe("*", lambda e: seen.append(e.event_type))
+                return OnboardingCoordinator(bus, sentinel)
+
+            app = Application.build(onboarding_factory=_factory)
+
+            self.assertEqual(app.session.cells[0].command, "")
+            self.assertNotIn(EventType.FIRST_RUN_TOUR_STEP, seen)
+
+    def test_no_onboarding_factory_skips_tour(self) -> None:
+        """Tests and --quiet mode leave onboarding off; F43 must not
+        run in that path either."""
+        from asat.events import EventType
+
+        app = Application.build()
+
+        self.assertEqual(app.session.cells[0].command, "")
+        # No events of this kind should have fired; if the app ever
+        # subscribes to it for its own reasons we still want the cell
+        # to stay empty.
+        self.assertIsNone(app.onboarding)
+
 
 class ApplicationSharedShellTests(unittest.TestCase):
     """End-to-end check that two cells submitted through one
@@ -372,12 +438,16 @@ class ApplicationMetaCommandTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as td:
             sentinel = Path(td) / "first-run-done"
+            # Pre-seed the sentinel so Application.build takes the
+            # post-first-run path and leaves the cell empty — the F43
+            # tour pre-populates the cell on a genuine first run, and
+            # this test is only about the `:welcome` replay path.
+            sentinel.write_text("done\n", encoding="utf-8")
 
             def _factory(bus: EventBus) -> OnboardingCoordinator:
                 return OnboardingCoordinator(bus, sentinel)
 
             app = Application.build(onboarding_factory=_factory)
-            # Launch fired FIRST_RUN_DETECTED once and wrote the sentinel.
             first_mtime = sentinel.stat().st_mtime_ns
 
             replays: list[dict] = []

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -11,6 +11,8 @@ from asat.event_bus import EventBus
 from asat.events import Event, EventType
 from asat.onboarding import (
     DEFAULT_ONBOARDING_LINES,
+    FIRST_RUN_TOUR_COMMAND,
+    FIRST_RUN_TOUR_LINES,
     SILENT_SINK_HINT,
     OnboardingCoordinator,
 )
@@ -221,6 +223,35 @@ class OnboardingCoordinatorTests(unittest.TestCase):
         coordinator.run(force=True)
 
         self.assertEqual(stream.getvalue(), "")
+
+    def test_publish_tour_step_fires_first_run_tour_step_event(self) -> None:
+        """F43: the coordinator publishes FIRST_RUN_TOUR_STEP with the
+        pre-filled command and the short prompt lines so the default
+        bank can narrate them."""
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        coordinator = OnboardingCoordinator(bus, self.sentinel)
+
+        coordinator.publish_tour_step()
+
+        events = recorder.of(EventType.FIRST_RUN_TOUR_STEP)
+        self.assertEqual(len(events), 1)
+        payload = events[0].payload
+        self.assertEqual(payload["command"], FIRST_RUN_TOUR_COMMAND)
+        self.assertEqual(payload["lines"], list(FIRST_RUN_TOUR_LINES))
+
+    def test_publish_tour_step_accepts_custom_command(self) -> None:
+        """Callers can override the tour command for localisation or
+        environment-specific seeds (e.g. `Get-Date` on PowerShell)."""
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        coordinator = OnboardingCoordinator(bus, self.sentinel)
+
+        coordinator.publish_tour_step(command="Get-Date", lines=("Press Enter.",))
+
+        payload = recorder.of(EventType.FIRST_RUN_TOUR_STEP)[0].payload
+        self.assertEqual(payload["command"], "Get-Date")
+        self.assertEqual(payload["lines"], ["Press Enter."])
 
     def test_default_lines_mention_help_and_quit(self) -> None:
         # Sanity check the welcome text a newcomer will actually hear

--- a/tests/test_sound_bank.py
+++ b/tests/test_sound_bank.py
@@ -7,6 +7,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from asat.events import EventType
 from asat.sound_bank import (
     EventBinding,
     SCHEMA_VERSION,
@@ -345,6 +346,130 @@ class DuckingFieldTests(unittest.TestCase):
     def test_duck_level_non_numeric_raises(self) -> None:
         with self.assertRaises(SoundBankError):
             SoundBank.from_dict({"version": SCHEMA_VERSION, "duck_level": "loud"})
+
+
+class VerbosityFieldTests(unittest.TestCase):
+    """F31 — verbosity tier on bindings + bank-wide ceiling."""
+
+    def _bank_with_tiered_bindings(self, bank_level: str) -> SoundBank:
+        voice = Voice(id="v")
+        return SoundBank(
+            voices=(voice,),
+            bindings=(
+                EventBinding(
+                    id="critical",
+                    event_type=EventType.COMMAND_FAILED.value,
+                    voice_id="v",
+                    say_template="boom",
+                    verbosity="minimal",
+                ),
+                EventBinding(
+                    id="chatty",
+                    event_type=EventType.COMMAND_FAILED.value,
+                    voice_id="v",
+                    say_template="details",
+                    verbosity="verbose",
+                ),
+            ),
+            verbosity_level=bank_level,
+        )
+
+    def test_defaults_match_spec(self) -> None:
+        bank = SoundBank()
+        self.assertEqual(bank.verbosity_level, "normal")
+        self.assertEqual(
+            EventBinding(id="b", event_type="x", say_template="t").verbosity,
+            "normal",
+        )
+
+    def test_round_trip_preserves_non_default_values(self) -> None:
+        bank = SoundBank(
+            voices=(Voice(id="v"),),
+            bindings=(
+                EventBinding(
+                    id="b",
+                    event_type=EventType.COMMAND_FAILED.value,
+                    voice_id="v",
+                    say_template="hi",
+                    verbosity="verbose",
+                ),
+            ),
+            verbosity_level="minimal",
+        )
+        restored = SoundBank.from_dict(bank.to_dict())
+        self.assertEqual(restored.verbosity_level, "minimal")
+        self.assertEqual(restored.bindings[0].verbosity, "verbose")
+
+    def test_loader_supplies_defaults_when_fields_missing(self) -> None:
+        legacy = {
+            "version": SCHEMA_VERSION,
+            "voices": [{"id": "v"}],
+            "bindings": [
+                {
+                    "id": "b",
+                    "event_type": EventType.COMMAND_FAILED.value,
+                    "voice_id": "v",
+                    "say_template": "hi",
+                }
+            ],
+        }
+        bank = SoundBank.from_dict(legacy)
+        self.assertEqual(bank.verbosity_level, "normal")
+        self.assertEqual(bank.bindings[0].verbosity, "normal")
+
+    def test_unknown_verbosity_level_raises(self) -> None:
+        with self.assertRaises(SoundBankError):
+            SoundBank.from_dict({"version": SCHEMA_VERSION, "verbosity_level": "whisper"})
+
+    def test_unknown_binding_verbosity_raises(self) -> None:
+        with self.assertRaises(SoundBankError):
+            SoundBank.from_dict(
+                {
+                    "version": SCHEMA_VERSION,
+                    "bindings": [
+                        {
+                            "id": "b",
+                            "event_type": EventType.COMMAND_FAILED.value,
+                            "say_template": "hi",
+                            "verbosity": "whisper",
+                        }
+                    ],
+                }
+            )
+
+    def test_bindings_for_filters_by_verbosity(self) -> None:
+        bank = self._bank_with_tiered_bindings("minimal")
+        ids = [b.id for b in bank.bindings_for(EventType.COMMAND_FAILED.value)]
+        self.assertEqual(ids, ["critical"])
+
+        bank = self._bank_with_tiered_bindings("normal")
+        ids = [b.id for b in bank.bindings_for(EventType.COMMAND_FAILED.value)]
+        self.assertEqual(ids, ["critical"])
+
+        bank = self._bank_with_tiered_bindings("verbose")
+        ids = sorted(b.id for b in bank.bindings_for(EventType.COMMAND_FAILED.value))
+        self.assertEqual(ids, ["chatty", "critical"])
+
+    def test_editor_view_ignores_verbosity_filter(self) -> None:
+        bank = self._bank_with_tiered_bindings("minimal")
+        ids = sorted(
+            b.id
+            for b in bank.bindings_for(
+                EventType.COMMAND_FAILED.value,
+                respect_verbosity=False,
+            )
+        )
+        self.assertEqual(ids, ["chatty", "critical"])
+
+    def test_with_verbosity_level_returns_updated_copy(self) -> None:
+        bank = SoundBank()
+        changed = bank.with_verbosity_level("verbose")
+        self.assertEqual(changed.verbosity_level, "verbose")
+        self.assertEqual(bank.verbosity_level, "normal")
+
+    def test_with_verbosity_level_rejects_unknown(self) -> None:
+        with self.assertRaises(SoundBankError):
+            SoundBank().with_verbosity_level("whisper")
 
 
 if __name__ == "__main__":

--- a/tests/test_sound_engine.py
+++ b/tests/test_sound_engine.py
@@ -820,5 +820,83 @@ class SoundEngineDuckingTests(unittest.TestCase):
         self.assertEqual(peak_solo, self._peak(sink2))
 
 
+class SoundEngineVerbosityTests(unittest.TestCase):
+    """F31 — bank-level verbosity ceiling filters bindings at dispatch."""
+
+    def _tiered_bank(self, level: str) -> SoundBank:
+        return SoundBank(
+            voices=(_voice(),),
+            sounds=(_tone(),),
+            bindings=(
+                EventBinding(
+                    id="critical",
+                    event_type=EventType.CELL_CREATED.value,
+                    voice_id="narrator",
+                    sound_id="ding",
+                    say_template="boom",
+                    verbosity="minimal",
+                ),
+                EventBinding(
+                    id="chatty",
+                    event_type=EventType.CELL_CREATED.value,
+                    voice_id="narrator",
+                    sound_id="ding",
+                    say_template="details",
+                    verbosity="verbose",
+                ),
+            ),
+            verbosity_level=level,
+        )
+
+    def _spoken_binding_ids(self, bus: EventBus, sink: MemorySink) -> list[str]:
+        recorded: list[str] = []
+        bus.subscribe(
+            EventType.AUDIO_SPOKEN,
+            lambda event: recorded.append(str(event.payload.get("binding_id"))),
+        )
+        publish_event(bus, EventType.CELL_CREATED, {}, source="notebook")
+        return recorded
+
+    def test_minimal_level_silences_verbose_bindings(self) -> None:
+        bus, sink = EventBus(), MemorySink()
+        engine = SoundEngine(bus, self._tiered_bank("minimal"), sink, sample_rate=8000)
+        self.addCleanup(engine.close)
+        fired = self._spoken_binding_ids(bus, sink)
+        self.assertEqual(fired, ["critical"])
+
+    def test_verbose_level_plays_every_tier(self) -> None:
+        bus, sink = EventBus(), MemorySink()
+        engine = SoundEngine(bus, self._tiered_bank("verbose"), sink, sample_rate=8000)
+        self.addCleanup(engine.close)
+        fired = sorted(self._spoken_binding_ids(bus, sink))
+        self.assertEqual(fired, ["chatty", "critical"])
+
+    def test_set_verbosity_level_swaps_bank_and_publishes_event(self) -> None:
+        bus, sink = EventBus(), MemorySink()
+        engine = SoundEngine(bus, self._tiered_bank("verbose"), sink, sample_rate=8000)
+        self.addCleanup(engine.close)
+        observed: list[dict] = []
+        bus.subscribe(
+            EventType.VERBOSITY_CHANGED,
+            lambda event: observed.append(dict(event.payload)),
+        )
+        engine.set_verbosity_level("minimal")
+        self.assertEqual(engine.bank.verbosity_level, "minimal")
+        self.assertEqual(observed, [{"level": "minimal", "previous": "verbose"}])
+
+        # Re-setting to the current level is a no-op and publishes nothing.
+        engine.set_verbosity_level("minimal")
+        self.assertEqual(len(observed), 1)
+
+    def test_set_verbosity_level_rejects_unknown(self) -> None:
+        from asat.sound_bank import SoundBankError
+
+        bus, sink = EventBus(), MemorySink()
+        engine = SoundEngine(bus, self._tiered_bank("normal"), sink, sample_rate=8000)
+        self.addCleanup(engine.close)
+        with self.assertRaises(SoundBankError):
+            engine.set_verbosity_level("whisper")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_streaming_monitor.py
+++ b/tests/test_streaming_monitor.py
@@ -1,0 +1,255 @@
+"""Unit tests for asat/streaming_monitor.py (F37)."""
+
+from __future__ import annotations
+
+import unittest
+
+from asat.event_bus import EventBus, publish_event
+from asat.events import Event, EventType
+from asat.streaming_monitor import StreamingMonitor
+
+
+class _Clock:
+    """Mutable virtual clock for deterministic pacing tests."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _capture(bus: EventBus, event_type: EventType) -> list[Event]:
+    captured: list[Event] = []
+    bus.subscribe(event_type, captured.append)
+    return captured
+
+
+class StreamingMonitorSilenceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.bus = EventBus()
+        self.clock = _Clock()
+        self.monitor = StreamingMonitor(
+            self.bus,
+            silence_threshold_sec=5.0,
+            progress_beat_interval_sec=30.0,
+            clock=self.clock,
+        )
+        self.paused = _capture(self.bus, EventType.OUTPUT_STREAM_PAUSED)
+        self.beats = _capture(self.bus, EventType.OUTPUT_STREAM_BEAT)
+
+    def _start(self, cell_id: str = "c1") -> None:
+        publish_event(
+            self.bus,
+            EventType.COMMAND_STARTED,
+            {"cell_id": cell_id},
+            source="test",
+        )
+
+    def _chunk(self, cell_id: str = "c1") -> None:
+        publish_event(
+            self.bus,
+            EventType.OUTPUT_CHUNK,
+            {"cell_id": cell_id, "line": "x"},
+            source="test",
+        )
+
+    def _complete(self, cell_id: str = "c1") -> None:
+        publish_event(
+            self.bus,
+            EventType.COMMAND_COMPLETED,
+            {"cell_id": cell_id, "exit_code": 0, "timed_out": False},
+            source="test",
+        )
+
+    def test_no_events_before_any_command_starts(self) -> None:
+        self.clock.advance(3600.0)
+        self.monitor.check()
+        self.assertEqual(self.paused, [])
+        self.assertEqual(self.beats, [])
+
+    def test_silence_fires_once_per_quiet_window(self) -> None:
+        self._start()
+        self.clock.advance(4.0)
+        self.monitor.check()
+        self.assertEqual(self.paused, [])
+        self.clock.advance(2.0)
+        self.monitor.check()
+        self.assertEqual(len(self.paused), 1)
+        self.assertEqual(self.paused[0].payload["cell_id"], "c1")
+        self.assertGreaterEqual(self.paused[0].payload["gap_sec"], 5.0)
+        # A second check with no fresh chunk should not re-fire.
+        self.clock.advance(10.0)
+        self.monitor.check()
+        self.assertEqual(len(self.paused), 1)
+
+    def test_chunk_rearms_silence_gate(self) -> None:
+        self._start()
+        self.clock.advance(6.0)
+        self.monitor.check()
+        self.assertEqual(len(self.paused), 1)
+        self._chunk()
+        self.clock.advance(6.0)
+        self.monitor.check()
+        self.assertEqual(len(self.paused), 2)
+
+    def test_chunk_before_threshold_suppresses_pause(self) -> None:
+        self._start()
+        self.clock.advance(3.0)
+        self._chunk()
+        self.clock.advance(3.0)
+        self.monitor.check()
+        self.assertEqual(self.paused, [])
+
+    def test_completion_stops_tracking(self) -> None:
+        self._start()
+        self._complete()
+        self.clock.advance(60.0)
+        self.monitor.check()
+        self.assertEqual(self.paused, [])
+        self.assertEqual(self.beats, [])
+        self.assertIsNone(self.monitor.active_cell_id)
+
+
+class StreamingMonitorBeatTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.bus = EventBus()
+        self.clock = _Clock()
+        self.monitor = StreamingMonitor(
+            self.bus,
+            silence_threshold_sec=5.0,
+            progress_beat_interval_sec=10.0,
+            clock=self.clock,
+        )
+        self.beats = _capture(self.bus, EventType.OUTPUT_STREAM_BEAT)
+
+    def test_beat_fires_on_each_interval(self) -> None:
+        publish_event(
+            self.bus,
+            EventType.COMMAND_STARTED,
+            {"cell_id": "c1"},
+            source="test",
+        )
+        self.clock.advance(9.0)
+        self.monitor.check()
+        self.assertEqual(self.beats, [])
+        self.clock.advance(2.0)
+        self.monitor.check()
+        self.assertEqual(len(self.beats), 1)
+        self.assertEqual(self.beats[0].payload["cell_id"], "c1")
+        self.assertGreaterEqual(self.beats[0].payload["elapsed_sec"], 10.0)
+        self.clock.advance(10.0)
+        self.monitor.check()
+        self.assertEqual(len(self.beats), 2)
+
+    def test_beat_payload_tracks_elapsed_since_start(self) -> None:
+        publish_event(
+            self.bus,
+            EventType.COMMAND_STARTED,
+            {"cell_id": "c1"},
+            source="test",
+        )
+        self.clock.advance(25.0)
+        self.monitor.check()
+        self.assertEqual(len(self.beats), 1)
+        self.assertAlmostEqual(self.beats[0].payload["elapsed_sec"], 25.0)
+
+
+class StreamingMonitorLifecycleTests(unittest.TestCase):
+    def test_error_chunk_resets_silence_timer(self) -> None:
+        bus = EventBus()
+        clock = _Clock()
+        monitor = StreamingMonitor(
+            bus,
+            silence_threshold_sec=5.0,
+            progress_beat_interval_sec=30.0,
+            clock=clock,
+        )
+        paused = _capture(bus, EventType.OUTPUT_STREAM_PAUSED)
+        publish_event(bus, EventType.COMMAND_STARTED, {"cell_id": "c1"}, source="test")
+        clock.advance(3.0)
+        publish_event(
+            bus,
+            EventType.ERROR_CHUNK,
+            {"cell_id": "c1", "line": "oops"},
+            source="test",
+        )
+        clock.advance(3.0)
+        monitor.check()
+        self.assertEqual(paused, [])
+        clock.advance(3.0)
+        monitor.check()
+        self.assertEqual(len(paused), 1)
+
+    def test_chunk_for_other_cell_is_ignored(self) -> None:
+        bus = EventBus()
+        clock = _Clock()
+        monitor = StreamingMonitor(
+            bus,
+            silence_threshold_sec=5.0,
+            progress_beat_interval_sec=30.0,
+            clock=clock,
+        )
+        paused = _capture(bus, EventType.OUTPUT_STREAM_PAUSED)
+        publish_event(bus, EventType.COMMAND_STARTED, {"cell_id": "c1"}, source="test")
+        clock.advance(3.0)
+        publish_event(
+            bus,
+            EventType.OUTPUT_CHUNK,
+            {"cell_id": "other", "line": "x"},
+            source="test",
+        )
+        clock.advance(3.0)
+        monitor.check()
+        self.assertEqual(len(paused), 1)
+
+    def test_cancelled_stops_tracking(self) -> None:
+        bus = EventBus()
+        clock = _Clock()
+        monitor = StreamingMonitor(
+            bus,
+            silence_threshold_sec=5.0,
+            progress_beat_interval_sec=30.0,
+            clock=clock,
+        )
+        paused = _capture(bus, EventType.OUTPUT_STREAM_PAUSED)
+        publish_event(bus, EventType.COMMAND_STARTED, {"cell_id": "c1"}, source="test")
+        publish_event(bus, EventType.COMMAND_CANCELLED, {"cell_id": "c1"}, source="test")
+        clock.advance(60.0)
+        monitor.check()
+        self.assertEqual(paused, [])
+
+    def test_failed_stops_tracking(self) -> None:
+        bus = EventBus()
+        clock = _Clock()
+        monitor = StreamingMonitor(
+            bus,
+            silence_threshold_sec=5.0,
+            progress_beat_interval_sec=30.0,
+            clock=clock,
+        )
+        beats = _capture(bus, EventType.OUTPUT_STREAM_BEAT)
+        publish_event(bus, EventType.COMMAND_STARTED, {"cell_id": "c1"}, source="test")
+        publish_event(
+            bus,
+            EventType.COMMAND_FAILED,
+            {"cell_id": "c1", "exit_code": 2, "timed_out": False},
+            source="test",
+        )
+        clock.advance(60.0)
+        monitor.check()
+        self.assertEqual(beats, [])
+
+    def test_invalid_thresholds_rejected(self) -> None:
+        bus = EventBus()
+        with self.assertRaises(ValueError):
+            StreamingMonitor(bus, silence_threshold_sec=0.0)
+        with self.assertRaises(ValueError):
+            StreamingMonitor(bus, progress_beat_interval_sec=-1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Four small features batched as one commit each on a single branch.

- **F10** — mark the "non-blocking execution + cancel keystroke" status as Shipped (already landed alongside F1).
- **F31** — narration verbosity presets. New `minimal` / `normal` / `verbose` tiers on `SoundBank`, a `verbosity` field on `EventBinding`, engine filter that skips bindings stricter than the bank, `:verbosity <level>` meta-command, new `VERBOSITY_CHANGED` event.
- **F37** — long-output pacing. New `StreamingMonitor` publishes `OUTPUT_STREAM_PAUSED` once per quiet window (default 5s no chunk) and `OUTPUT_STREAM_BEAT` every 30s a command is streaming. Wired into `Application.build` with a 1s daemon ticker; default bank binds both events to subtle non-speech cues.
- **F43** — guided first-command tour. On a fresh install, pre-populate the notebook's first cell with `echo hello, ASAT` and fire a new `FIRST_RUN_TOUR_STEP` event so the newcomer's first Enter exercises the full submit → start → complete → exit-code arc.

## Test plan

- [x] `python -m unittest discover -q` — 1093 tests, all pass
- [x] `tests/test_streaming_monitor.py` — 12 new unit tests with an injected virtual clock
- [x] `tests/test_onboarding.py` — 2 new tests for `publish_tour_step`
- [x] `tests/test_app.py` — 3 new tests for F43 pre-fill + 3 new tests for F31
- [x] `tests/test_sound_bank.py` + `tests/test_sound_engine.py` — F31 verbosity + filter + engine set_verbosity_level
- [x] Docs sync tests (`test_events_docs_sync`, `test_default_bank`, `test_self_check`) green after adding the three new events + sample payloads.

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS