### PR TITLE
F27: text cells via :text meta-command

### DIFF
--- a/asat/cell.py
+++ b/asat/cell.py
@@ -56,13 +56,16 @@ class CellKind(str, Enum):
 
     COMMAND cells are the executable input/output units the notebook
     was originally built around. HEADING cells are structural
-    landmarks that anchor NVDA-style heading navigation (F61). Future
-    kinds (pure-input, pure-output, terminal) plug in here without
-    rewriting the session/cursor/render layers.
+    landmarks that anchor NVDA-style heading navigation (F61). TEXT
+    cells carry prose inside a notebook — the "we train for ten
+    epochs because earlier runs overfit" annotation that the heading
+    work couldn't hold (F27). Future kinds (terminal, rich-media)
+    plug in here without rewriting the session/cursor/render layers.
     """
 
     COMMAND = "command"
     HEADING = "heading"
+    TEXT = "text"
 
 
 MIN_HEADING_LEVEL = 1
@@ -93,6 +96,7 @@ class Cell:
     kind: CellKind = CellKind.COMMAND
     heading_level: Optional[int] = None
     heading_title: Optional[str] = None
+    text: Optional[str] = None
 
     def __post_init__(self) -> None:
         if self.kind is CellKind.HEADING:
@@ -110,6 +114,12 @@ class Cell:
                 raise ValueError(
                     "heading_level / heading_title only apply to HEADING cells"
                 )
+        if self.kind is CellKind.TEXT:
+            if self.text is None or not self.text.strip():
+                raise ValueError("text cell requires a non-empty text body")
+        else:
+            if self.text is not None:
+                raise ValueError("text only applies to TEXT cells")
 
     @classmethod
     def new(cls, command: str, parent_id: Optional[str] = None) -> "Cell":
@@ -126,6 +136,27 @@ class Cell:
             created_at=now,
             updated_at=now,
             parent_id=parent_id,
+        )
+
+    @classmethod
+    def new_text(cls, text: str) -> "Cell":
+        """Create a fresh prose/text cell (F27).
+
+        Text cells carry narrative alongside a notebook's commands and
+        headings. They are non-executable (`is_executable` returns
+        False) so the kernel, worker, and auto-advance paths skip them.
+        """
+        if not text.strip():
+            raise ValueError("text cell requires a non-empty body")
+        now = utcnow()
+        return cls(
+            cell_id=new_id(),
+            command="",
+            created_at=now,
+            updated_at=now,
+            status=CellStatus.COMPLETED,
+            kind=CellKind.TEXT,
+            text=text,
         )
 
     @classmethod
@@ -152,6 +183,10 @@ class Cell:
     @property
     def is_heading(self) -> bool:
         return self.kind is CellKind.HEADING
+
+    @property
+    def is_text(self) -> bool:
+        return self.kind is CellKind.TEXT
 
     @property
     def is_executable(self) -> bool:
@@ -203,6 +238,15 @@ class Cell:
         self.status = CellStatus.PENDING
         self.updated_at = utcnow()
 
+    def update_text(self, new_text: str) -> None:
+        """Edit the prose of a text cell in place."""
+        if not self.is_text:
+            raise ValueError("update_text only applies to text cells")
+        if not new_text.strip():
+            raise ValueError("text cell requires a non-empty body")
+        self.text = new_text
+        self.updated_at = utcnow()
+
     def update_heading(self, level: int, title: str) -> None:
         """Edit the level/title of a heading cell in place."""
         if not self.is_heading:
@@ -239,6 +283,7 @@ class Cell:
             kind=self.kind,
             heading_level=self.heading_level,
             heading_title=self.heading_title,
+            text=self.text,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -254,8 +299,9 @@ class Cell:
     def from_dict(cls, data: dict[str, Any]) -> "Cell":
         """Rebuild a Cell from a dictionary previously produced by to_dict.
 
-        Missing `kind` / `heading_level` / `heading_title` default to a
-        COMMAND cell so sessions written before F61 load cleanly.
+        Missing `kind` / `heading_level` / `heading_title` / `text`
+        default to a COMMAND cell so sessions written before F61 /
+        F27 load cleanly.
         """
         return cls(
             cell_id=data["cell_id"],
@@ -271,4 +317,5 @@ class Cell:
             kind=CellKind(data.get("kind", CellKind.COMMAND.value)),
             heading_level=data.get("heading_level"),
             heading_title=data.get("heading_title"),
+            text=data.get("text"),
         )

--- a/asat/default_bank.py
+++ b/asat/default_bank.py
@@ -626,6 +626,15 @@ def _default_bindings() -> tuple[EventBinding, ...]:
             priority=120,
         ),
         EventBinding(
+            id="focus_changed_text",
+            event_type=EventType.FOCUS_CHANGED.value,
+            voice_id="narrator",
+            sound_id="nav_blip",
+            say_template="text, {text}",
+            predicate="transition == cell and kind == 'text'",
+            priority=115,
+        ),
+        EventBinding(
             id="focus_changed_cell",
             event_type=EventType.FOCUS_CHANGED.value,
             voice_id="narrator",

--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -270,6 +270,7 @@ META_COMMANDS: tuple[str, ...] = (
     "repeat",
     "state",
     "heading",
+    "text",
     "toc",
     "workspace",
     "list-notebooks",
@@ -337,7 +338,7 @@ HELP_LINES: tuple[str, ...] = (
     "           Ctrl+Z undo, Ctrl+Y redo edits in the order you made them.",
     "           Ctrl+R resets to defaults at cursor scope (Enter confirms, Escape cancels).",
     "Menu:      F2 (or Ctrl+.) opens contextual actions; Up/Down walk, Enter invokes, Escape closes.",
-    "Meta:      :help, :settings, :save, :quit, :delete, :duplicate, :pwd, :state, :commands, :reset, :welcome, :repeat, :heading, :toc, :workspace, :list-notebooks, :new-notebook, :bindings, :bookmark, :unbookmark, :bookmarks, :jump, :verbosity, :reload-bank.",
+    "Meta:      :help, :settings, :save, :quit, :delete, :duplicate, :pwd, :state, :commands, :reset, :welcome, :repeat, :heading, :text, :toc, :workspace, :list-notebooks, :new-notebook, :bindings, :bookmark, :unbookmark, :bookmarks, :jump, :verbosity, :reload-bank.",
     "           `:help topics` lists focused tours; `:help <topic>` narrates one (navigation, cells, settings, audio, search, meta).",
     "           `:welcome` replays the first-run tour; `:repeat` (or Ctrl+R in notebook/input) re-speaks the last narration.",
     "           Meta-commands are case-insensitive and accept a trailing argument.",
@@ -690,6 +691,29 @@ class InputRouter:
             )
             return
         self._cursor.new_heading_cell(level, title)
+
+    def _handle_meta_text(self, argument: str) -> None:
+        """Append a text cell from `:text <prose>` (F27).
+
+        The entire argument string becomes the prose body. Empty
+        arguments surface a HELP_REQUESTED hint rather than creating
+        an invisible blank cell.
+        """
+        body = argument.strip()
+        if not body:
+            publish_event(
+                self._bus,
+                EventType.HELP_REQUESTED,
+                {
+                    "lines": [
+                        "`:text <prose>` — body is the remainder of the line.",
+                        "Example: `:text Training overfits past 20 epochs.`",
+                    ],
+                },
+                source=self.SOURCE,
+            )
+            return
+        self._cursor.new_text_cell(body)
 
     def _publish_bindings(self, argument: str) -> None:
         """Surface the keybinding report via HELP_REQUESTED (F64).
@@ -1557,6 +1581,7 @@ _META_HANDLERS: dict[str, Callable[["InputRouter", str], None]] = {
     "commands": lambda router, _arg: router._publish_commands(),
     "reset": lambda router, arg: router._handle_meta_reset(arg),
     "heading": lambda router, arg: router._handle_meta_heading(arg),
+    "text": lambda router, arg: router._handle_meta_text(arg),
     "toc": lambda router, _arg: router._publish_toc(),
     "bindings": lambda router, arg: router._publish_bindings(arg),
     "bookmark": lambda router, arg: router._handle_meta_bookmark(arg),

--- a/asat/notebook.py
+++ b/asat/notebook.py
@@ -182,6 +182,27 @@ class NotebookCursor:
         )
         return cell
 
+    def new_text_cell(self, text: str) -> Cell:
+        """Append a prose/text cell, focus it, and stay in NOTEBOOK mode.
+
+        Text cells carry narrative the heading and command kinds can't
+        (F27). Like headings they are non-executable and live in
+        NOTEBOOK mode as read-only landmarks.
+        """
+        cell = Cell.new_text(text)
+        self._session.add_cell(cell)
+        self._session.set_active(cell.cell_id)
+        self._publish_cell_created(cell, len(self._session.cells) - 1)
+        self._transition(
+            FocusState(
+                mode=FocusMode.NOTEBOOK,
+                cell_id=cell.cell_id,
+                input_buffer="",
+                cursor_position=0,
+            )
+        )
+        return cell
+
     def move_to_next_heading(self, level: Optional[int] = None) -> Optional[Cell]:
         """Jump forward to the next heading. None level = any level.
 
@@ -284,6 +305,9 @@ class NotebookCursor:
             assert source.heading_level is not None
             assert source.heading_title is not None
             duplicate = Cell.new_heading(source.heading_level, source.heading_title)
+        elif source.is_text:
+            assert source.text is not None
+            duplicate = Cell.new_text(source.text)
         else:
             duplicate = Cell.new(source.command)
         target_index = self._session.index_of(cell_id) + 1
@@ -766,6 +790,7 @@ class NotebookCursor:
         kind_value = CellKind.COMMAND.value
         heading_level: Optional[int] = None
         heading_title: Optional[str] = None
+        text: Optional[str] = None
         if new_state.cell_id is not None:
             try:
                 focused = self._session.get_cell(new_state.cell_id)
@@ -773,6 +798,7 @@ class NotebookCursor:
                 kind_value = focused.kind.value
                 heading_level = focused.heading_level
                 heading_title = focused.heading_title
+                text = focused.text
             except SessionError:
                 command = ""
         publish_event(
@@ -789,6 +815,7 @@ class NotebookCursor:
                 "kind": kind_value,
                 "heading_level": heading_level,
                 "heading_title": heading_title,
+                "text": text,
             },
             source=self.SOURCE,
         )

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -804,10 +804,14 @@ cells"). Cross-notebook paste falls out for free once F29 lands.
 
 ## F27 — Heading and text cells with hierarchy, navigation, and scope selection
 
-**Status.** Partially shipped as F61. Heading cells, flat outline
-navigation (`]` / `[`, `1`-`6`), `:toc`, `:heading <level>
-<title>`, and the default-bank heading voice are in (see F61).
-What is still pending from the original F27 sketch: text cells,
+**Status.** Partially shipped as F61 (headings) and an F27
+text-cell slice. Heading cells, flat outline navigation (`]` /
+`[`, `1`-`6`), `:toc`, `:heading <level> <title>`, and the
+default-bank heading voice are in (see F61). Text cells now
+exist as `CellKind.TEXT` with a `:text <prose>` INPUT
+meta-command and a dedicated `focus_changed_text` narration
+binding. What is still pending from the original F27 sketch:
+the NOTEBOOK `i` keybinding for in-place text insertion,
 parent-scope navigation (`{` / `}`), `select_heading_scope()`,
 fold / collapse, and the dedicated `asat/outline.py` scope
 helper.
@@ -828,14 +832,15 @@ type is a narrow change.
 
 **Sketch — remaining work after F61.**
 
-1. **Text cell kind.** Extend `CellKind` with `TEXT` and add a
-   `text: str` field on `Cell`; `is_executable` returns False so
-   `Application.execute` short-circuits (same guard F61 added for
-   headings). NOTEBOOK gains an `i` binding that inserts a text
-   cell below the focus; INPUT grows a `:text <prose>` meta-command
-   that writes a text cell before the next prompt. Reuses every
-   serialisation, renderer, and FOCUS_CHANGED hook the heading
-   work already proved out.
+1. **Text cell kind.** *(Text-cell slice shipped.)* `CellKind.TEXT`
+   and a `text: str` field on `Cell` are in; `is_executable`
+   returns False so `Application.execute` short-circuits (same
+   guard F61 added for headings). INPUT's `:text <prose>`
+   meta-command appends a text cell and abandons INPUT (parallels
+   `:heading`), and FOCUS_CHANGED narrates "text, {text}". Still
+   pending: the NOTEBOOK `i` binding for in-place insertion
+   (needs an in-place editor for the text body; typing-in-line
+   is not yet wired).
 2. **Parent-scope navigation.** `{` / `}` in NOTEBOOK jump to the
    previous / next heading whose `heading_level` is *shallower*
    than the current scope. Same module-level helper that F61 uses

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -288,6 +288,7 @@ discarded and the cell is not modified.
 | `:commands`  | List every available meta-command.                   |
 | `:reset bank` | Reset the whole sound bank to the built-in defaults (also `:reset all`). |
 | `:heading <level> <title>` | Append a heading landmark at level 1..6 for NVDA-style navigation (F61). |
+| `:text <prose>` | Append a non-executable prose cell carrying narrative alongside commands and headings (F27). |
 | `:toc`       | Narrate the notebook's heading outline.              |
 | `:workspace` | Re-announce the active project root and notebook count (no-op without a workspace). |
 | `:list-notebooks` | Narrate every notebook in the workspace by name. |
@@ -596,6 +597,7 @@ Every key you need, one table.
 | INPUT      | `:reset bank`⏎    | Reset the whole bank to defaults      |
 | INPUT      | `:reload-bank`⏎   | Reload the bank from disk (F3)        |
 | INPUT      | `:heading <N> <title>`⏎ | Append a level-N heading landmark |
+| INPUT      | `:text <prose>`⏎  | Append a prose/text cell (F27)        |
 | INPUT      | `:toc`⏎           | Narrate the heading outline           |
 | OUTPUT     | Up / Down         | Prev / next line                      |
 | OUTPUT     | PageUp / PageDown | Jump a page                           |

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -236,6 +236,83 @@ class CellSnapshotKindTests(unittest.TestCase):
         self.assertEqual(snap.heading_level, 2)
         self.assertEqual(snap.heading_title, "Setup")
 
+    def test_text_snapshot_preserves_body(self) -> None:
+        cell = Cell.new_text("We train for ten epochs.")
+        snap = cell.snapshot()
+        self.assertEqual(snap.kind, CellKind.TEXT)
+        self.assertEqual(snap.text, "We train for ten epochs.")
+
+
+class CellTextFactoryTests(unittest.TestCase):
+    """Cell.new_text produces structurally valid prose cells (F27)."""
+
+    def test_new_text_sets_kind_and_body(self) -> None:
+        cell = Cell.new_text("Some prose.")
+        self.assertEqual(cell.kind, CellKind.TEXT)
+        self.assertTrue(cell.is_text)
+        self.assertFalse(cell.is_executable)
+        self.assertFalse(cell.is_heading)
+        self.assertEqual(cell.text, "Some prose.")
+        self.assertEqual(cell.command, "")
+        self.assertEqual(cell.status, CellStatus.COMPLETED)
+
+    def test_new_text_rejects_blank_body(self) -> None:
+        with self.assertRaises(ValueError):
+            Cell.new_text("")
+        with self.assertRaises(ValueError):
+            Cell.new_text("   ")
+
+    def test_text_cells_are_not_executable_and_refuse_exec_mutations(self) -> None:
+        cell = Cell.new_text("prose")
+        with self.assertRaises(ValueError):
+            cell.mark_running()
+        with self.assertRaises(ValueError):
+            cell.mark_completed("", "", 0)
+        with self.assertRaises(ValueError):
+            cell.mark_cancelled()
+        with self.assertRaises(ValueError):
+            cell.update_command("echo")
+
+    def test_update_text_edits_body(self) -> None:
+        cell = Cell.new_text("first draft")
+        cell.update_text("revised")
+        self.assertEqual(cell.text, "revised")
+
+    def test_update_text_rejects_blank(self) -> None:
+        cell = Cell.new_text("prose")
+        with self.assertRaises(ValueError):
+            cell.update_text("")
+        with self.assertRaises(ValueError):
+            cell.update_text("   ")
+
+    def test_update_text_refuses_on_command_cell(self) -> None:
+        cell = Cell.new("echo")
+        with self.assertRaises(ValueError):
+            cell.update_text("nope")
+
+    def test_heading_fields_rejected_on_text_cell(self) -> None:
+        # Construction-level guard: a direct TEXT cell with a heading
+        # level should fail fast.
+        from datetime import datetime
+        with self.assertRaises(ValueError):
+            Cell(
+                cell_id="c1",
+                command="",
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                kind=CellKind.TEXT,
+                text="prose",
+                heading_level=1,
+                heading_title="x",
+            )
+
+    def test_text_round_trips_through_to_dict(self) -> None:
+        cell = Cell.new_text("note: verify fixtures")
+        restored = Cell.from_dict(cell.to_dict())
+        self.assertEqual(restored.kind, CellKind.TEXT)
+        self.assertEqual(restored.text, "note: verify fixtures")
+        self.assertEqual(restored.cell_id, cell.cell_id)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_input_router.py
+++ b/tests/test_input_router.py
@@ -1920,6 +1920,43 @@ class HeadingMetaCommandTests(unittest.TestCase):
         self.assertIn("toc", AMBIENT_META_COMMANDS)
 
 
+class TextMetaCommandTests(unittest.TestCase):
+    """F27: `:text <prose>` appends a prose cell."""
+
+    def _type_meta(self, router, cursor, text: str) -> None:
+        cursor.enter_input_mode()
+        router.handle_key(Key.combo("u", Modifier.CTRL))
+        for ch in text:
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+
+    def test_text_meta_creates_text_cell(self) -> None:
+        _bus, session, cursor, router, _ = _build(["ls"])
+        self._type_meta(router, cursor, ":text A prose note.")
+        last = session.cells[-1]
+        self.assertTrue(last.is_text)
+        self.assertEqual(last.text, "A prose note.")
+        self.assertEqual(cursor.focus.cell_id, last.cell_id)
+        self.assertEqual(cursor.focus.mode, FocusMode.NOTEBOOK)
+
+    def test_text_meta_rejects_blank_body(self) -> None:
+        bus, session, cursor, router, _ = _build(["ls"])
+        rec = _Recorder(bus)
+        initial_count = len(session.cells)
+        self._type_meta(router, cursor, ":text   ")
+        self.assertEqual(len(session.cells), initial_count)
+        for cell in session.cells:
+            self.assertFalse(cell.is_text)
+        help_events = rec.types_of(EventType.HELP_REQUESTED)
+        self.assertTrue(help_events)
+        self.assertIn(":text", "\n".join(help_events[-1].payload["lines"]))
+
+    def test_text_meta_is_not_ambient(self) -> None:
+        """`:text` behaves like `:heading` — transitions INPUT -> NOTEBOOK."""
+        from asat.input_router import AMBIENT_META_COMMANDS
+        self.assertNotIn("text", AMBIENT_META_COMMANDS)
+
+
 class ParseHeadingArgumentTests(unittest.TestCase):
     """F61: `:heading <level> <title>` argument parser."""
 


### PR DESCRIPTION
## Summary

- Adds `CellKind.TEXT` and a `text: str` field on `Cell`, with factory, validation, `update_text`, and serialisation round-trip.
- Registers `:text <prose>` INPUT meta-command that appends a text cell and abandons INPUT (mirrors `:heading`); blank body prints help.
- FOCUS_CHANGED payload now threads the text body so the default bank's new `focus_changed_text` narrator binding speaks `text, {body}` when focus lands on a text cell.
- Text cells reuse the existing `is_executable` short-circuit — no new guards needed in kernel / app / auto-advance.

## What's still pending on F27

- NOTEBOOK `i` binding for in-place text insertion (needs an in-place text editor; not trivially addressable with today's input router).
- Parent-scope navigation (`{` / `}`), `select_heading_scope()`, fold / collapse, and the dedicated `asat/outline.py` scope helper.

`docs/FEATURE_REQUESTS.md` reflects F27's updated partial status.

## Test plan

- [x] `pytest tests/test_cell.py` — 34 pass (8 new `CellTextFactoryTests` + 1 snapshot test)
- [x] `pytest tests/test_input_router.py::TextMetaCommandTests` — 3 pass
- [x] Full suite: `pytest -q` — 1131 pass

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS