### PR TITLE
F27: parent-scope navigation via `{` / `}`

### DIFF
--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -184,6 +184,8 @@ def default_bindings() -> BindingMap:
             Key.special("down", Modifier.ALT): "move_cell_down",
             Key.printable("]"): "next_heading",
             Key.printable("["): "prev_heading",
+            Key.printable("}"): "next_parent_heading",
+            Key.printable("{"): "prev_parent_heading",
             Key.printable("1"): "next_heading_1",
             Key.printable("2"): "next_heading_2",
             Key.printable("3"): "next_heading_3",
@@ -326,6 +328,7 @@ HELP_LINES: tuple[str, ...] = (
     "NOTEBOOK:  Up/Down walk cells, Enter type, Ctrl+N new, Ctrl+O output, Ctrl+, settings.",
     "           d delete, y duplicate, Alt+Up/Down reorder.",
     "           ] / [ next / prev heading; 1..6 next heading of that level.",
+    "           } / { next / prev heading shallower than current scope (parent).",
     "INPUT:     Enter submits, Escape leaves without running.",
     "           Backspace/Delete cut, Left/Right walk, Home/End jump (or Ctrl+A/E).",
     "           Up/Down walk command history (Down past newest restores your draft).",
@@ -1333,6 +1336,8 @@ class InputRouter:
             "next_heading_4": self._next_heading_action(4),
             "next_heading_5": self._next_heading_action(5),
             "next_heading_6": self._next_heading_action(6),
+            "next_parent_heading": self._parent_heading_action(direction=+1),
+            "prev_parent_heading": self._parent_heading_action(direction=-1),
         }
 
     def _input_handlers(self) -> dict[str, ActionHandler]:
@@ -1465,6 +1470,21 @@ class InputRouter:
                 payload["level"] = level
             if cell is not None:
                 payload["cell_id"] = cell.cell_id
+            return payload
+        return handler
+
+    def _parent_heading_action(self, direction: int) -> ActionHandler:
+        """F27: `{` / `}` jump to the prev/next heading shallower than scope."""
+        def handler() -> Optional[dict[str, object]]:
+            if direction > 0:
+                cell = self._cursor.move_to_next_parent_heading()
+            else:
+                cell = self._cursor.move_to_previous_parent_heading()
+            payload: dict[str, object] = {"matched": cell is not None}
+            if cell is not None:
+                payload["cell_id"] = cell.cell_id
+                if cell.heading_level is not None:
+                    payload["level"] = cell.heading_level
             return payload
         return handler
 

--- a/asat/notebook.py
+++ b/asat/notebook.py
@@ -252,6 +252,64 @@ class NotebookCursor:
                 out.append((i, cell.heading_level, cell.heading_title, cell.cell_id))
         return out
 
+    def move_to_next_parent_heading(self) -> Optional[Cell]:
+        """Jump forward to the next heading shallower than the current scope (F27).
+
+        "Current scope" is the focused heading's own level when the focus
+        is a heading, or the nearest preceding heading's level when the
+        focus is a regular cell. Returns None (cursor unchanged) when
+        there is no enclosing scope or no shallower heading ahead.
+        """
+        return self._move_to_parent_heading(direction=+1)
+
+    def move_to_previous_parent_heading(self) -> Optional[Cell]:
+        """Jump backward to the previous heading shallower than the current scope (F27)."""
+        return self._move_to_parent_heading(direction=-1)
+
+    def _current_scope_level(self) -> Optional[int]:
+        if self._state.cell_id is None:
+            return None
+        cells = self._session.cells
+        try:
+            index = self._session.index_of(self._state.cell_id)
+        except ValueError:
+            return None
+        focused = cells[index]
+        if focused.kind is CellKind.HEADING and focused.heading_level is not None:
+            return focused.heading_level
+        j = index - 1
+        while j >= 0:
+            cand = cells[j]
+            if cand.kind is CellKind.HEADING and cand.heading_level is not None:
+                return cand.heading_level
+            j -= 1
+        return None
+
+    def _move_to_parent_heading(self, direction: int) -> Optional[Cell]:
+        if self._state.mode != FocusMode.NOTEBOOK:
+            return None
+        scope_level = self._current_scope_level()
+        if scope_level is None:
+            return None
+        cells = self._session.cells
+        if not cells:
+            return None
+        if self._state.cell_id is None:
+            start_index = -1 if direction > 0 else len(cells)
+        else:
+            start_index = self._session.index_of(self._state.cell_id)
+        index = start_index + direction
+        while 0 <= index < len(cells):
+            candidate = cells[index]
+            if (
+                candidate.kind is CellKind.HEADING
+                and candidate.heading_level is not None
+                and candidate.heading_level < scope_level
+            ):
+                return self.focus_cell(candidate.cell_id)
+            index += direction
+        return None
+
     def delete_focused_cell(self) -> Optional[Cell]:
         """Remove the focused cell and land on a sensible neighbor.
 

--- a/docs/BINDINGS.md
+++ b/docs/BINDINGS.md
@@ -31,6 +31,8 @@ Each row is one binding. The `Action` column is the handler name `InputRouter._a
 | `]` | `next_heading` |
 | `d` | `delete_cell` |
 | `y` | `duplicate_cell` |
+| `{` | `prev_parent_heading` |
+| `}` | `next_parent_heading` |
 
 ## INPUT mode
 

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -804,17 +804,19 @@ cells"). Cross-notebook paste falls out for free once F29 lands.
 
 ## F27 — Heading and text cells with hierarchy, navigation, and scope selection
 
-**Status.** Partially shipped as F61 (headings) and an F27
-text-cell slice. Heading cells, flat outline navigation (`]` /
-`[`, `1`-`6`), `:toc`, `:heading <level> <title>`, and the
-default-bank heading voice are in (see F61). Text cells now
-exist as `CellKind.TEXT` with a `:text <prose>` INPUT
-meta-command and a dedicated `focus_changed_text` narration
-binding. What is still pending from the original F27 sketch:
-the NOTEBOOK `i` keybinding for in-place text insertion,
-parent-scope navigation (`{` / `}`), `select_heading_scope()`,
-fold / collapse, and the dedicated `asat/outline.py` scope
-helper.
+**Status.** Partially shipped as F61 (headings), an F27 text-cell
+slice, and F27 parent-scope navigation. Heading cells, flat
+outline navigation (`]` / `[`, `1`-`6`), `:toc`, `:heading
+<level> <title>`, and the default-bank heading voice are in (see
+F61). Text cells now exist as `CellKind.TEXT` with a `:text
+<prose>` INPUT meta-command and a dedicated
+`focus_changed_text` narration binding. `{` / `}` in NOTEBOOK
+walk to the previous / next heading whose level is strictly
+shallower than the current scope (enclosing heading). What is
+still pending from the original F27 sketch: the NOTEBOOK `i`
+keybinding for in-place text insertion,
+`select_heading_scope()`, fold / collapse, and the dedicated
+`asat/outline.py` scope helper.
 
 **Gap.** Every cell today is an input / output pair produced by
 `ExecutionKernel` or an announce-only heading (F61). There is no
@@ -841,11 +843,14 @@ type is a narrow change.
    pending: the NOTEBOOK `i` binding for in-place insertion
    (needs an in-place editor for the text body; typing-in-line
    is not yet wired).
-2. **Parent-scope navigation.** `{` / `}` in NOTEBOOK jump to the
-   previous / next heading whose `heading_level` is *shallower*
-   than the current scope. Same module-level helper that F61 uses
-   for `]` / `[`, parameterised by "strictly less than" instead of
-   "any heading".
+2. **Parent-scope navigation.** *(Shipped.)* `{` / `}` in NOTEBOOK
+   jump to the previous / next heading whose `heading_level` is
+   strictly shallower than the current scope.
+   `NotebookCursor.move_to_{next,previous}_parent_heading` define
+   scope as "the focused heading's level, or the nearest preceding
+   heading's level for a non-heading cell". Heading narration
+   piggy-backs on FOCUS_CHANGED; no-match falls through silently
+   like the flat `]` / `[` nav.
 3. **Scope selection + fold / collapse.** A new `asat/outline.py`
    with a pure `scope_range(cells, heading_index) -> (start,
    end)` function; `NotebookCursor.select_heading_scope()` wraps

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -569,6 +569,7 @@ Every key you need, one table.
 | NOTEBOOK   | F2 / Ctrl+.       | Open actions menu                     |
 | NOTEBOOK   | `]` / `[`         | Next / previous heading (any level)   |
 | NOTEBOOK   | `1`..`6`          | Next heading of that level (F61)      |
+| NOTEBOOK   | `}` / `{`         | Next / prev parent-scope heading (F27)|
 | INPUT      | Enter             | Submit command                        |
 | INPUT      | Backspace         | Delete char before caret              |
 | INPUT      | Delete            | Delete char under caret               |

--- a/tests/test_input_router.py
+++ b/tests/test_input_router.py
@@ -1841,6 +1841,97 @@ class HeadingNavigationBindingTests(unittest.TestCase):
         self.assertEqual(invoked[-1].payload["level"], 1)
 
 
+class ParentScopeNavigationBindingTests(unittest.TestCase):
+    """F27: `{` / `}` walk to parent-scope (shallower) headings from NOTEBOOK."""
+
+    def _build(self):
+        # Index: 0=H1 Intro, 1=cmd, 2=H2 Setup, 3=cmd, 4=H3 Fixtures,
+        # 5=cmd, 6=H2 Training, 7=cmd, 8=H1 Runs
+        bus = EventBus()
+        session = Session.new()
+        session.add_cell(Cell.new_heading(1, "Intro"))
+        session.add_cell(Cell.new("ls"))
+        session.add_cell(Cell.new_heading(2, "Setup"))
+        session.add_cell(Cell.new("pip install"))
+        session.add_cell(Cell.new_heading(3, "Fixtures"))
+        session.add_cell(Cell.new("make fixtures"))
+        session.add_cell(Cell.new_heading(2, "Training"))
+        session.add_cell(Cell.new("train"))
+        session.add_cell(Cell.new_heading(1, "Runs"))
+        cursor = NotebookCursor(session, bus)
+        router = InputRouter(cursor, bus)
+        return bus, session, cursor, router
+
+    def test_right_brace_from_h3_jumps_out_to_next_h2(self) -> None:
+        _bus, session, cursor, router = self._build()
+        cursor.focus_cell(session.cells[4].cell_id)  # H3 Fixtures
+        action = router.handle_key(Key.printable("}"))
+        self.assertEqual(action, "next_parent_heading")
+        # Shallower than H3 is H2 Training at index 6.
+        self.assertEqual(cursor.focus.cell_id, session.cells[6].cell_id)
+
+    def test_left_brace_from_h3_jumps_back_to_containing_h2(self) -> None:
+        _bus, session, cursor, router = self._build()
+        cursor.focus_cell(session.cells[4].cell_id)  # H3 Fixtures
+        action = router.handle_key(Key.printable("{"))
+        self.assertEqual(action, "prev_parent_heading")
+        # Shallower-than-H3 behind us is H2 Setup at index 2.
+        self.assertEqual(cursor.focus.cell_id, session.cells[2].cell_id)
+
+    def test_right_brace_from_plain_cell_uses_enclosing_heading(self) -> None:
+        """A non-heading cell's scope is the preceding heading."""
+        _bus, session, cursor, router = self._build()
+        cursor.focus_cell(session.cells[3].cell_id)  # cmd under H2 Setup
+        router.handle_key(Key.printable("}"))
+        # Scope H2 → next shallower is H1 Runs at index 8.
+        self.assertEqual(cursor.focus.cell_id, session.cells[8].cell_id)
+
+    def test_right_brace_at_h1_reports_no_match(self) -> None:
+        bus, session, cursor, router = self._build()
+        rec = _Recorder(bus)
+        cursor.focus_cell(session.cells[0].cell_id)  # H1 Intro
+        router.handle_key(Key.printable("}"))
+        invoked = [e for e in rec.types_of(EventType.ACTION_INVOKED)
+                   if e.payload["action"] == "next_parent_heading"]
+        self.assertFalse(invoked[-1].payload["matched"])
+        # Cursor stays put.
+        self.assertEqual(cursor.focus.cell_id, session.cells[0].cell_id)
+
+    def test_parent_nav_no_enclosing_heading_is_noop(self) -> None:
+        """A cell before any heading has no scope — { / } do nothing."""
+        bus = EventBus()
+        session = Session.new()
+        session.add_cell(Cell.new("preamble"))
+        session.add_cell(Cell.new_heading(1, "First"))
+        cursor = NotebookCursor(session, bus)
+        cursor.focus_cell(session.cells[0].cell_id)
+        router = InputRouter(cursor, bus)
+        rec = _Recorder(bus)
+        router.handle_key(Key.printable("}"))
+        router.handle_key(Key.printable("{"))
+        invoked = rec.types_of(EventType.ACTION_INVOKED)
+        self.assertTrue(all(not e.payload["matched"] for e in invoked))
+        self.assertEqual(cursor.focus.cell_id, session.cells[0].cell_id)
+
+    def test_parent_nav_payload_includes_level(self) -> None:
+        bus, session, cursor, router = self._build()
+        rec = _Recorder(bus)
+        cursor.focus_cell(session.cells[4].cell_id)  # H3
+        router.handle_key(Key.printable("}"))
+        invoked = [e for e in rec.types_of(EventType.ACTION_INVOKED)
+                   if e.payload["action"] == "next_parent_heading"]
+        self.assertEqual(invoked[-1].payload["level"], 2)
+
+    def test_parent_nav_ignored_in_input_mode(self) -> None:
+        _bus, session, cursor, router = self._build()
+        cursor.focus_cell(session.cells[3].cell_id)  # cmd
+        cursor.enter_input_mode()
+        router.handle_key(Key.printable("}"))
+        # `}` is printable in INPUT mode — falls through as text.
+        self.assertEqual(cursor.focus.mode, FocusMode.INPUT)
+        self.assertTrue(cursor.focus.input_buffer.endswith("}"))
+
+
 class HeadingMetaCommandTests(unittest.TestCase):
     """F61: `:heading <level> <title>` and `:toc`."""
 

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -674,6 +674,80 @@ class HeadingNavigationTests(unittest.TestCase):
             self.assertEqual(cell_id, self.session.cells[i].cell_id)
 
 
+class ParentScopeNavigationTests(unittest.TestCase):
+    """F27: move_to_{next,previous}_parent_heading jump to shallower scopes."""
+
+    def setUp(self) -> None:
+        self.bus = EventBus()
+        self.session = Session.new()
+        # Outline:
+        #   [0] H1 Intro
+        #   [1] cmd ls
+        #   [2] H2 Setup
+        #   [3] cmd install
+        #   [4] H3 Fixtures
+        #   [5] cmd make
+        #   [6] H2 Training
+        #   [7] cmd train
+        #   [8] H1 Runs
+        self.session.add_cell(Cell.new_heading(1, "Intro"))
+        self.session.add_cell(Cell.new("ls"))
+        self.session.add_cell(Cell.new_heading(2, "Setup"))
+        self.session.add_cell(Cell.new("install"))
+        self.session.add_cell(Cell.new_heading(3, "Fixtures"))
+        self.session.add_cell(Cell.new("make"))
+        self.session.add_cell(Cell.new_heading(2, "Training"))
+        self.session.add_cell(Cell.new("train"))
+        self.session.add_cell(Cell.new_heading(1, "Runs"))
+        self.cursor = NotebookCursor(self.session, self.bus)
+
+    def test_next_parent_from_h3_finds_next_shallower(self) -> None:
+        self.cursor.focus_cell(self.session.cells[4].cell_id)
+        landed = self.cursor.move_to_next_parent_heading()
+        assert landed is not None
+        self.assertEqual(landed.heading_title, "Training")
+
+    def test_prev_parent_from_h3_finds_preceding_shallower(self) -> None:
+        self.cursor.focus_cell(self.session.cells[4].cell_id)
+        landed = self.cursor.move_to_previous_parent_heading()
+        assert landed is not None
+        self.assertEqual(landed.heading_title, "Setup")
+
+    def test_next_parent_from_plain_cell_uses_enclosing_scope(self) -> None:
+        self.cursor.focus_cell(self.session.cells[3].cell_id)  # under Setup (H2)
+        landed = self.cursor.move_to_next_parent_heading()
+        assert landed is not None
+        self.assertEqual(landed.heading_title, "Runs")  # next H1
+
+    def test_next_parent_at_top_level_returns_none(self) -> None:
+        self.cursor.focus_cell(self.session.cells[0].cell_id)  # H1
+        before = self.cursor.focus.cell_id
+        self.assertIsNone(self.cursor.move_to_next_parent_heading())
+        self.assertEqual(self.cursor.focus.cell_id, before)
+
+    def test_prev_parent_at_top_level_returns_none(self) -> None:
+        self.cursor.focus_cell(self.session.cells[-1].cell_id)  # H1 Runs
+        before = self.cursor.focus.cell_id
+        self.assertIsNone(self.cursor.move_to_previous_parent_heading())
+        self.assertEqual(self.cursor.focus.cell_id, before)
+
+    def test_no_enclosing_scope_returns_none(self) -> None:
+        bus = EventBus()
+        session = Session.new()
+        session.add_cell(Cell.new("preamble"))
+        session.add_cell(Cell.new_heading(1, "First"))
+        cursor = NotebookCursor(session, bus)
+        cursor.focus_cell(session.cells[0].cell_id)
+        self.assertIsNone(cursor.move_to_next_parent_heading())
+        self.assertIsNone(cursor.move_to_previous_parent_heading())
+
+    def test_parent_nav_noop_outside_notebook_mode(self) -> None:
+        self.cursor.focus_cell(self.session.cells[3].cell_id)
+        self.cursor.enter_input_mode()
+        self.assertIsNone(self.cursor.move_to_next_parent_heading())
+        self.assertIsNone(self.cursor.move_to_previous_parent_heading())
+
+
 class HeadingCreationTests(unittest.TestCase):
     """new_heading_cell adds a landmark without entering INPUT mode."""
 


### PR DESCRIPTION
## Summary

- `NotebookCursor.move_to_{next,previous}_parent_heading` walk to the closest heading whose level is strictly shallower than the current scope.
- Scope = the focused heading's own level, or (for a non-heading cell) the enclosing heading's level. Non-heading cells before the first heading have no scope, so `{` / `}` are no-ops there.
- NOTEBOOK binds `}` / `{` via a new `_parent_heading_action`. `matched`, `cell_id`, and `level` are reported on ACTION_INVOKED; misses fall through silently (same shape as `]` / `[`).
- Heading landings are already narrated via `focus_changed_heading`, so no new default-bank binding is needed.

## What's still pending on F27

- NOTEBOOK `i` binding for in-place text insertion (needs an in-place text editor).
- `select_heading_scope()` + `asat/outline.py` scope helper.
- Fold / collapse (`z`, `OUTLINE_FOLDED` / `OUTLINE_UNFOLDED`).

`docs/FEATURE_REQUESTS.md` reflects F27's updated partial status; `docs/USER_MANUAL.md` gains the `}` / `{` row; HELP_LINES and `docs/BINDINGS.md` are regenerated.

## Test plan

- [x] `pytest tests/test_notebook.py::ParentScopeNavigationTests` — 7 pass
- [x] `pytest tests/test_input_router.py::ParentScopeNavigationBindingTests` — 7 pass
- [x] Full suite: `pytest -q` — 1145 pass

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS