### PR TITLE
F27: asat/outline.py + NotebookCursor.select_heading_scope

### DIFF
--- a/asat/notebook.py
+++ b/asat/notebook.py
@@ -26,6 +26,7 @@ from typing import Optional
 from asat.cell import Cell, CellKind
 from asat.event_bus import EventBus, publish_event
 from asat.events import EventType
+from asat.outline import enclosing_heading_index, scope_range
 from asat.session import Session, SessionError
 
 
@@ -284,6 +285,35 @@ class NotebookCursor:
                 return cand.heading_level
             j -= 1
         return None
+
+    def select_heading_scope(self) -> Optional[list[Cell]]:
+        """Return the cells that belong to the focused cell's heading scope (F27).
+
+        "Scope" is the section governed by the nearest enclosing
+        heading — the heading itself plus every following cell up to
+        (but not including) the next same-or-shallower heading. When
+        the focus is a heading, its own section is returned. When the
+        focus is a non-heading cell, the enclosing heading's section
+        is returned. Returns None if there is no focused cell or no
+        enclosing heading.
+
+        The returned list is a fresh list (callers may mutate it
+        freely) but the cells inside are the session's actual Cell
+        instances — same sharing contract as `Session.cells`. For a
+        defensive copy, call `.snapshot()` on each cell.
+        """
+        if self._state.cell_id is None:
+            return None
+        cells = self._session.cells
+        try:
+            index = self._session.index_of(self._state.cell_id)
+        except ValueError:
+            return None
+        heading_index = enclosing_heading_index(cells, index)
+        if heading_index is None:
+            return None
+        start, end = scope_range(cells, heading_index)
+        return list(cells[start:end])
 
     def _move_to_parent_heading(self, direction: int) -> Optional[Cell]:
         if self._state.mode != FocusMode.NOTEBOOK:

--- a/asat/outline.py
+++ b/asat/outline.py
@@ -1,0 +1,81 @@
+"""Pure helpers for reasoning about heading scopes in a cell list (F27).
+
+A "scope" is the contiguous run of cells that belong to a heading: the
+heading itself, followed by every cell up to (but not including) the
+next heading whose level is the same as or shallower than the
+heading's. These helpers are intentionally framework-free — they take
+plain lists of `Cell` and return index ranges — so the notebook, the
+clipboard, and any future outline view can share one canonical
+definition of "what does this section contain".
+
+Typical use:
+
+    from asat.outline import scope_range
+
+    start, end = scope_range(session.cells, heading_index)
+    section = session.cells[start:end]
+
+All functions are safe on empty inputs and raise only when given an
+index that is out of range or not a heading.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from asat.cell import Cell, CellKind
+
+
+def scope_range(cells: Sequence[Cell], heading_index: int) -> tuple[int, int]:
+    """Return [start, end) for the section headed by `cells[heading_index]`.
+
+    `start` is always `heading_index`. `end` is the index of the next
+    heading whose level is <= the heading's level, or `len(cells)` if
+    no such heading exists. Children (headings with a *strictly
+    greater* level) remain inside the returned span.
+
+    Raises `IndexError` if `heading_index` is out of range and
+    `ValueError` if the target cell is not a heading.
+    """
+    if not 0 <= heading_index < len(cells):
+        raise IndexError(
+            f"heading_index {heading_index} out of range for {len(cells)} cells"
+        )
+    head = cells[heading_index]
+    if head.kind is not CellKind.HEADING or head.heading_level is None:
+        raise ValueError(
+            f"cells[{heading_index}] is not a heading "
+            f"(kind={head.kind.value})"
+        )
+    level = head.heading_level
+    end = len(cells)
+    for j in range(heading_index + 1, len(cells)):
+        cand = cells[j]
+        if (
+            cand.kind is CellKind.HEADING
+            and cand.heading_level is not None
+            and cand.heading_level <= level
+        ):
+            end = j
+            break
+    return heading_index, end
+
+
+def enclosing_heading_index(cells: Sequence[Cell], index: int) -> int | None:
+    """Walk backward from `index` to find the scope's heading.
+
+    If `cells[index]` is itself a heading, returns `index`. If `index`
+    sits under a heading, returns that heading's index. Returns None
+    when no preceding heading exists (i.e. the cell lives before any
+    outline entry) or when `index` is out of range.
+    """
+    if not 0 <= index < len(cells):
+        return None
+    if cells[index].kind is CellKind.HEADING:
+        return index
+    j = index - 1
+    while j >= 0:
+        if cells[j].kind is CellKind.HEADING:
+            return j
+        j -= 1
+    return None

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -805,18 +805,22 @@ cells"). Cross-notebook paste falls out for free once F29 lands.
 ## F27 — Heading and text cells with hierarchy, navigation, and scope selection
 
 **Status.** Partially shipped as F61 (headings), an F27 text-cell
-slice, and F27 parent-scope navigation. Heading cells, flat
-outline navigation (`]` / `[`, `1`-`6`), `:toc`, `:heading
-<level> <title>`, and the default-bank heading voice are in (see
-F61). Text cells now exist as `CellKind.TEXT` with a `:text
-<prose>` INPUT meta-command and a dedicated
+slice, F27 parent-scope navigation, and the `asat/outline.py`
+scope helper with `NotebookCursor.select_heading_scope()`.
+Heading cells, flat outline navigation (`]` / `[`, `1`-`6`),
+`:toc`, `:heading <level> <title>`, and the default-bank heading
+voice are in (see F61). Text cells now exist as `CellKind.TEXT`
+with a `:text <prose>` INPUT meta-command and a dedicated
 `focus_changed_text` narration binding. `{` / `}` in NOTEBOOK
 walk to the previous / next heading whose level is strictly
-shallower than the current scope (enclosing heading). What is
-still pending from the original F27 sketch: the NOTEBOOK `i`
-keybinding for in-place text insertion,
-`select_heading_scope()`, fold / collapse, and the dedicated
-`asat/outline.py` scope helper.
+shallower than the current scope (enclosing heading).
+`asat/outline.scope_range(cells, heading_index)` returns the
+`[start, end)` span of a heading's section (children included),
+and `NotebookCursor.select_heading_scope()` returns the focused
+cell's enclosing section as a list of Cells. What is still
+pending from the original F27 sketch: the NOTEBOOK `i`
+keybinding for in-place text insertion and fold / collapse
+(`z`, `OUTLINE_FOLDED` / `OUTLINE_UNFOLDED`).
 
 **Gap.** Every cell today is an input / output pair produced by
 `ExecutionKernel` or an announce-only heading (F61). There is no
@@ -851,13 +855,17 @@ type is a narrow change.
    heading's level for a non-heading cell". Heading narration
    piggy-backs on FOCUS_CHANGED; no-match falls through silently
    like the flat `]` / `[` nav.
-3. **Scope selection + fold / collapse.** A new `asat/outline.py`
-   with a pure `scope_range(cells, heading_index) -> (start,
-   end)` function; `NotebookCursor.select_heading_scope()` wraps
-   it for F26's clipboard, and a `z` keystroke on a heading
-   toggles a `collapsed` flag so Up/Down skip the scope. Publish
-   `OUTLINE_FOLDED` / `OUTLINE_UNFOLDED` so the default bank can
-   narrate "section setup, four cells, collapsed".
+3. **Scope selection + fold / collapse.** *(Scope-selection
+   slice shipped.)* `asat/outline.py` provides the pure
+   `scope_range(cells, heading_index) -> (start, end)` function
+   and `enclosing_heading_index(cells, index)` helper.
+   `NotebookCursor.select_heading_scope()` returns the focused
+   cell's enclosing section as a list of Cells, ready for F26's
+   clipboard or any future outline-aware action. Still pending:
+   the `z` keystroke on a heading that toggles a `collapsed`
+   flag so Up/Down skip the scope, and the
+   `OUTLINE_FOLDED` / `OUTLINE_UNFOLDED` events the default bank
+   would use to narrate "section setup, four cells, collapsed".
 
 **See also.** F51 (notebook file format) persists the heading
 fields F61 added; populating `"text"` piggy-backs on the same

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -748,6 +748,67 @@ class ParentScopeNavigationTests(unittest.TestCase):
         self.assertIsNone(self.cursor.move_to_previous_parent_heading())
 
 
+class SelectHeadingScopeTests(unittest.TestCase):
+    """F27: select_heading_scope returns the enclosing section's cells."""
+
+    def setUp(self) -> None:
+        self.bus = EventBus()
+        self.session = Session.new()
+        self.session.add_cell(Cell.new_heading(1, "Intro"))      # 0
+        self.session.add_cell(Cell.new("ls"))                    # 1
+        self.session.add_cell(Cell.new_heading(2, "Setup"))      # 2
+        self.session.add_cell(Cell.new("install"))               # 3
+        self.session.add_cell(Cell.new_heading(3, "Fixtures"))   # 4
+        self.session.add_cell(Cell.new("make"))                  # 5
+        self.session.add_cell(Cell.new_heading(2, "Training"))   # 6
+        self.session.add_cell(Cell.new("train"))                 # 7
+        self.cursor = NotebookCursor(self.session, self.bus)
+
+    def test_from_heading_returns_its_own_section(self) -> None:
+        self.cursor.focus_cell(self.session.cells[2].cell_id)  # H2 Setup
+        scope = self.cursor.select_heading_scope()
+        assert scope is not None
+        titles = [c.heading_title or c.command for c in scope]
+        self.assertEqual(titles, ["Setup", "install", "Fixtures", "make"])
+
+    def test_from_plain_cell_walks_back_to_enclosing_heading(self) -> None:
+        self.cursor.focus_cell(self.session.cells[5].cell_id)  # under H3
+        scope = self.cursor.select_heading_scope()
+        assert scope is not None
+        self.assertEqual(len(scope), 2)
+        self.assertEqual(scope[0].heading_title, "Fixtures")
+
+    def test_from_top_level_h1_spans_through_nested_children(self) -> None:
+        self.cursor.focus_cell(self.session.cells[0].cell_id)  # H1 Intro
+        scope = self.cursor.select_heading_scope()
+        assert scope is not None
+        self.assertEqual(len(scope), 8)  # everything — no later H1 exists
+
+    def test_no_enclosing_heading_returns_none(self) -> None:
+        bus = EventBus()
+        session = Session.new()
+        session.add_cell(Cell.new("preamble"))
+        session.add_cell(Cell.new_heading(1, "First"))
+        cursor = NotebookCursor(session, bus)
+        cursor.focus_cell(session.cells[0].cell_id)
+        self.assertIsNone(cursor.select_heading_scope())
+
+    def test_empty_session_returns_none(self) -> None:
+        bus = EventBus()
+        session = Session.new()
+        cursor = NotebookCursor(session, bus)
+        self.assertIsNone(cursor.select_heading_scope())
+
+    def test_returned_list_is_fresh_copy(self) -> None:
+        self.cursor.focus_cell(self.session.cells[2].cell_id)
+        first = self.cursor.select_heading_scope()
+        second = self.cursor.select_heading_scope()
+        assert first is not None and second is not None
+        self.assertIsNot(first, second)
+        # But they share the underlying Cell objects (documented contract).
+        self.assertIs(first[0], second[0])
+
+
 class HeadingCreationTests(unittest.TestCase):
     """new_heading_cell adds a landmark without entering INPUT mode."""
 

--- a/tests/test_outline.py
+++ b/tests/test_outline.py
@@ -1,0 +1,126 @@
+"""Unit tests for asat.outline (F27 scope helpers)."""
+
+from __future__ import annotations
+
+import unittest
+
+from asat.cell import Cell
+from asat.outline import enclosing_heading_index, scope_range
+
+
+def _outline() -> list[Cell]:
+    """A mixed outline used by most tests:
+      [0] H1 Intro
+      [1] cmd ls
+      [2] H2 Setup
+      [3] cmd install
+      [4] H3 Fixtures
+      [5] cmd make
+      [6] H2 Training
+      [7] cmd train
+      [8] H1 Runs
+      [9] cmd run
+    """
+    return [
+        Cell.new_heading(1, "Intro"),
+        Cell.new("ls"),
+        Cell.new_heading(2, "Setup"),
+        Cell.new("install"),
+        Cell.new_heading(3, "Fixtures"),
+        Cell.new("make"),
+        Cell.new_heading(2, "Training"),
+        Cell.new("train"),
+        Cell.new_heading(1, "Runs"),
+        Cell.new("run"),
+    ]
+
+
+class ScopeRangeTests(unittest.TestCase):
+    """scope_range returns a [start, end) span that includes children."""
+
+    def test_h1_spans_through_nested_children_until_next_h1(self) -> None:
+        cells = _outline()
+        start, end = scope_range(cells, 0)  # H1 Intro
+        self.assertEqual((start, end), (0, 8))
+
+    def test_h2_spans_its_h3_child_and_stops_at_sibling_h2(self) -> None:
+        cells = _outline()
+        start, end = scope_range(cells, 2)  # H2 Setup
+        self.assertEqual((start, end), (2, 6))
+
+    def test_h3_spans_only_its_own_tail(self) -> None:
+        cells = _outline()
+        start, end = scope_range(cells, 4)  # H3 Fixtures
+        self.assertEqual((start, end), (4, 6))
+
+    def test_trailing_h1_spans_to_end_of_list(self) -> None:
+        cells = _outline()
+        start, end = scope_range(cells, 8)  # H1 Runs
+        self.assertEqual((start, end), (8, 10))
+
+    def test_heading_with_no_following_cells_has_unit_span(self) -> None:
+        cells = [Cell.new_heading(1, "Alone")]
+        self.assertEqual(scope_range(cells, 0), (0, 1))
+
+    def test_same_level_sibling_terminates_scope(self) -> None:
+        cells = [
+            Cell.new_heading(2, "A"),
+            Cell.new("x"),
+            Cell.new_heading(2, "B"),
+        ]
+        self.assertEqual(scope_range(cells, 0), (0, 2))
+
+    def test_shallower_sibling_terminates_scope(self) -> None:
+        cells = [
+            Cell.new_heading(3, "Deep"),
+            Cell.new("x"),
+            Cell.new_heading(1, "Shallow"),
+        ]
+        self.assertEqual(scope_range(cells, 0), (0, 2))
+
+    def test_non_heading_index_raises_value_error(self) -> None:
+        cells = _outline()
+        with self.assertRaises(ValueError):
+            scope_range(cells, 1)  # cmd cell
+
+    def test_out_of_range_index_raises_index_error(self) -> None:
+        cells = _outline()
+        with self.assertRaises(IndexError):
+            scope_range(cells, 99)
+        with self.assertRaises(IndexError):
+            scope_range(cells, -1)
+
+    def test_empty_cells_list_raises_index_error(self) -> None:
+        with self.assertRaises(IndexError):
+            scope_range([], 0)
+
+
+class EnclosingHeadingIndexTests(unittest.TestCase):
+    """enclosing_heading_index walks backward from the target index."""
+
+    def test_heading_cell_returns_itself(self) -> None:
+        cells = _outline()
+        self.assertEqual(enclosing_heading_index(cells, 0), 0)
+        self.assertEqual(enclosing_heading_index(cells, 4), 4)
+
+    def test_non_heading_finds_nearest_preceding_heading(self) -> None:
+        cells = _outline()
+        self.assertEqual(enclosing_heading_index(cells, 3), 2)  # under H2 Setup
+        self.assertEqual(enclosing_heading_index(cells, 5), 4)  # under H3
+        self.assertEqual(enclosing_heading_index(cells, 7), 6)  # under H2 Training
+
+    def test_cell_before_any_heading_has_no_scope(self) -> None:
+        cells = [Cell.new("preamble"), Cell.new_heading(1, "First")]
+        self.assertIsNone(enclosing_heading_index(cells, 0))
+
+    def test_out_of_range_returns_none(self) -> None:
+        cells = _outline()
+        self.assertIsNone(enclosing_heading_index(cells, 99))
+        self.assertIsNone(enclosing_heading_index(cells, -1))
+
+    def test_empty_cells_returns_none(self) -> None:
+        self.assertIsNone(enclosing_heading_index([], 0))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

- New `asat/outline.py` with pure helpers:
  - `scope_range(cells, heading_index) -> (start, end)` — returns the `[start, end)` span of the section headed by `cells[heading_index]`. Walks until the next heading whose level is `<=` the heading's level; children (strictly-greater levels) stay inside.
  - `enclosing_heading_index(cells, index)` — walks backward to find the heading that owns a cell's scope. `None` when the cell lives before any heading.
- `NotebookCursor.select_heading_scope()` wraps these to return the focused cell's enclosing section as a fresh list of `Cell` objects. `None` when there's no focused cell or no enclosing heading.

Framework-free module — takes plain `Sequence[Cell]`, no bus / session coupling. Ready for F26's clipboard copy or any future outline-aware action.

## What's still pending on F27

- NOTEBOOK `i` binding for in-place text insertion (needs an in-place text editor).
- Fold / collapse (`z`, `OUTLINE_FOLDED` / `OUTLINE_UNFOLDED`).

## Test plan

- [x] `pytest tests/test_outline.py` — 15 new tests pass
- [x] `pytest tests/test_notebook.py::SelectHeadingScopeTests` — 6 pass
- [x] Full suite: `pytest -q` — 1166 pass

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS