### PR TITLE
F27: fold / collapse headings via `z` keystroke

### DIFF
--- a/asat/cell.py
+++ b/asat/cell.py
@@ -97,6 +97,7 @@ class Cell:
     heading_level: Optional[int] = None
     heading_title: Optional[str] = None
     text: Optional[str] = None
+    collapsed: bool = False
 
     def __post_init__(self) -> None:
         if self.kind is CellKind.HEADING:
@@ -120,6 +121,8 @@ class Cell:
         else:
             if self.text is not None:
                 raise ValueError("text only applies to TEXT cells")
+        if self.collapsed and self.kind is not CellKind.HEADING:
+            raise ValueError("collapsed only applies to HEADING cells")
 
     @classmethod
     def new(cls, command: str, parent_id: Optional[str] = None) -> "Cell":
@@ -284,6 +287,7 @@ class Cell:
             heading_level=self.heading_level,
             heading_title=self.heading_title,
             text=self.text,
+            collapsed=self.collapsed,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -318,4 +322,5 @@ class Cell:
             heading_level=data.get("heading_level"),
             heading_title=data.get("heading_title"),
             text=data.get("text"),
+            collapsed=bool(data.get("collapsed", False)),
         )

--- a/asat/default_bank.py
+++ b/asat/default_bank.py
@@ -103,6 +103,8 @@ COVERED_EVENT_TYPES: frozenset[EventType] = frozenset({
     EventType.BANK_RELOADED,
     EventType.OUTPUT_PLAYBACK_STARTED,
     EventType.OUTPUT_PLAYBACK_STOPPED,
+    EventType.OUTLINE_FOLDED,
+    EventType.OUTLINE_UNFOLDED,
     EventType.ANSI_OSC_RECEIVED,
 })
 
@@ -437,6 +439,27 @@ def _default_bindings() -> tuple[EventBinding, ...]:
             sound_id="soft_tick",
             say_template="playback stopped",
             priority=170,
+            verbosity="minimal",
+        ),
+
+        # Outline fold / unfold cues announce the scope size so the
+        # user knows how much the collapse hid.
+        EventBinding(
+            id="outline_folded",
+            event_type=EventType.OUTLINE_FOLDED.value,
+            voice_id="narrator",
+            sound_id="nav_blip",
+            say_template="section {heading_title} collapsed, {cell_count} cells",
+            priority=160,
+            verbosity="minimal",
+        ),
+        EventBinding(
+            id="outline_unfolded",
+            event_type=EventType.OUTLINE_UNFOLDED.value,
+            voice_id="narrator",
+            sound_id="nav_blip",
+            say_template="section {heading_title} expanded",
+            priority=160,
             verbosity="minimal",
         ),
 

--- a/asat/events.py
+++ b/asat/events.py
@@ -151,6 +151,8 @@ class EventType(str, Enum):
     OUTPUT_STREAM_BEAT = "output.stream.beat"
 
     FOCUS_CHANGED = "focus.changed"
+    OUTLINE_FOLDED = "outline.folded"
+    OUTLINE_UNFOLDED = "outline.unfolded"
     KEY_PRESSED = "input.key"
     ACTION_INVOKED = "input.action"
 

--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -186,6 +186,7 @@ def default_bindings() -> BindingMap:
             Key.printable("["): "prev_heading",
             Key.printable("}"): "next_parent_heading",
             Key.printable("{"): "prev_parent_heading",
+            Key.printable("z"): "toggle_fold_heading",
             Key.printable("1"): "next_heading_1",
             Key.printable("2"): "next_heading_2",
             Key.printable("3"): "next_heading_3",
@@ -329,6 +330,7 @@ HELP_LINES: tuple[str, ...] = (
     "           d delete, y duplicate, Alt+Up/Down reorder.",
     "           ] / [ next / prev heading; 1..6 next heading of that level.",
     "           } / { next / prev heading shallower than current scope (parent).",
+    "           z on a heading toggles collapse (hides its cells from Up/Down).",
     "INPUT:     Enter submits, Escape leaves without running.",
     "           Backspace/Delete cut, Left/Right walk, Home/End jump (or Ctrl+A/E).",
     "           Up/Down walk command history (Down past newest restores your draft).",
@@ -1338,6 +1340,7 @@ class InputRouter:
             "next_heading_6": self._next_heading_action(6),
             "next_parent_heading": self._parent_heading_action(direction=+1),
             "prev_parent_heading": self._parent_heading_action(direction=-1),
+            "toggle_fold_heading": self._toggle_fold_action(),
         }
 
     def _input_handlers(self) -> dict[str, ActionHandler]:
@@ -1471,6 +1474,13 @@ class InputRouter:
             if cell is not None:
                 payload["cell_id"] = cell.cell_id
             return payload
+        return handler
+
+    def _toggle_fold_action(self) -> ActionHandler:
+        """F27: `z` on a heading toggles its collapsed flag."""
+        def handler() -> Optional[dict[str, object]]:
+            result = self._cursor.toggle_fold_focused_heading()
+            return {"toggled": result is not None, "collapsed": bool(result)}
         return handler
 
     def _parent_heading_action(self, direction: int) -> ActionHandler:

--- a/asat/notebook.py
+++ b/asat/notebook.py
@@ -26,7 +26,7 @@ from typing import Optional
 from asat.cell import Cell, CellKind
 from asat.event_bus import EventBus, publish_event
 from asat.events import EventType
-from asat.outline import enclosing_heading_index, scope_range
+from asat.outline import enclosing_heading_index, scope_range, visible_indices
 from asat.session import Session, SessionError
 
 
@@ -285,6 +285,51 @@ class NotebookCursor:
                 return cand.heading_level
             j -= 1
         return None
+
+    def toggle_fold_focused_heading(self) -> Optional[bool]:
+        """Collapse / expand the focused heading (F27).
+
+        Legal only from NOTEBOOK mode on a heading cell. Returns the
+        new `collapsed` value (True = just folded, False = just
+        unfolded) or None if the focus is not a foldable heading.
+        Publishes `OUTLINE_FOLDED` or `OUTLINE_UNFOLDED` with the
+        heading's metadata and the count of hidden cells.
+        """
+        if self._state.mode != FocusMode.NOTEBOOK:
+            return None
+        cell_id = self._state.cell_id
+        if cell_id is None:
+            return None
+        cells = self._session.cells
+        try:
+            index = self._session.index_of(cell_id)
+        except ValueError:
+            return None
+        target = cells[index]
+        if target.kind is not CellKind.HEADING or target.heading_level is None:
+            return None
+        start, end = scope_range(cells, index)
+        # A heading with no body (unit span) has nothing to fold or
+        # unfold; skip the toggle so the state and events stay
+        # meaningful.
+        if end - start <= 1:
+            return None
+        target.collapsed = not target.collapsed
+        event_type = (
+            EventType.OUTLINE_FOLDED if target.collapsed else EventType.OUTLINE_UNFOLDED
+        )
+        publish_event(
+            self._bus,
+            event_type,
+            {
+                "cell_id": target.cell_id,
+                "heading_level": target.heading_level,
+                "heading_title": target.heading_title,
+                "cell_count": end - start - 1,
+            },
+            source="cursor",
+        )
+        return target.collapsed
 
     def select_heading_scope(self) -> Optional[list[Cell]]:
         """Return the cells that belong to the focused cell's heading scope (F27).
@@ -824,19 +869,35 @@ class NotebookCursor:
         self._history_pre_browse = ""
 
     def _move(self, delta: int) -> Optional[Cell]:
-        """Move the cursor by a signed offset within the cell list."""
+        """Move the cursor by a signed offset within the cell list.
+
+        Cells hidden by a collapsed heading (F27) are skipped — pressing
+        Up/Down from the collapsed heading lands on the next visible
+        cell, not on the children hidden inside the scope.
+        """
         if self._state.mode != FocusMode.NOTEBOOK:
             return None
-        if not self._session.cells:
+        cells = self._session.cells
+        if not cells:
             return None
         current_id = self._state.cell_id
         if current_id is None:
             return None
         current_index = self._session.index_of(current_id)
-        target_index = current_index + delta
-        if target_index < 0 or target_index >= len(self._session.cells):
+        visible = visible_indices(cells)
+        if current_index in visible:
+            pos = visible.index(current_index)
+        else:
+            # Focus is hidden inside a collapsed scope — snap to the
+            # enclosing heading, then apply the delta from there.
+            heading_idx = enclosing_heading_index(cells, current_index)
+            if heading_idx is None or heading_idx not in visible:
+                return None
+            pos = visible.index(heading_idx)
+        target_pos = pos + delta
+        if target_pos < 0 or target_pos >= len(visible):
             return None
-        return self.focus_cell(self._session.cells[target_index].cell_id)
+        return self.focus_cell(cells[visible[target_pos]].cell_id)
 
     def _commit_buffer_to_cell(self) -> Cell:
         """Write the current input buffer to the focused cell."""

--- a/asat/outline.py
+++ b/asat/outline.py
@@ -61,6 +61,31 @@ def scope_range(cells: Sequence[Cell], heading_index: int) -> tuple[int, int]:
     return heading_index, end
 
 
+def visible_indices(cells: Sequence[Cell]) -> list[int]:
+    """Return the indices of cells that are not hidden by a collapsed heading.
+
+    A collapsed heading (Cell with `kind is HEADING and collapsed is True`)
+    is itself visible, but every cell inside its scope is hidden until
+    the scope ends. Nested collapsed headings are absorbed by the outer
+    scope — `visible_indices` yields each visible index exactly once.
+    """
+    hide_until: int = 0
+    out: list[int] = []
+    for idx, cell in enumerate(cells):
+        if idx < hide_until:
+            continue
+        out.append(idx)
+        if (
+            cell.kind is CellKind.HEADING
+            and cell.collapsed
+            and cell.heading_level is not None
+        ):
+            _, end = scope_range(cells, idx)
+            if end > hide_until:
+                hide_until = end
+    return out
+
+
 def enclosing_heading_index(cells: Sequence[Cell], index: int) -> int | None:
     """Walk backward from `index` to find the scope's heading.
 

--- a/asat/sample_payloads.py
+++ b/asat/sample_payloads.py
@@ -203,6 +203,18 @@ SAMPLE_PAYLOADS: dict[EventType, dict[str, object]] = {
         "cell_id": "c1",
         "reason": "end",
     },
+    EventType.OUTLINE_FOLDED: {
+        "cell_id": "c1",
+        "heading_level": 2,
+        "heading_title": "Setup",
+        "cell_count": 4,
+    },
+    EventType.OUTLINE_UNFOLDED: {
+        "cell_id": "c1",
+        "heading_level": 2,
+        "heading_title": "Setup",
+        "cell_count": 4,
+    },
     EventType.ANSI_OSC_RECEIVED: {
         "cell_id": "c1",
         "body": "133;A",

--- a/docs/BINDINGS.md
+++ b/docs/BINDINGS.md
@@ -31,6 +31,7 @@ Each row is one binding. The `Action` column is the handler name `InputRouter._a
 | `]` | `next_heading` |
 | `d` | `delete_cell` |
 | `y` | `duplicate_cell` |
+| `z` | `toggle_fold_heading` |
 | `{` | `prev_parent_heading` |
 | `}` | `next_parent_heading` |
 

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -433,6 +433,22 @@ every `interval_sec` seconds. Each tick publishes the usual
 | `OUTPUT_PLAYBACK_STARTED`   | `cell_id`, `interval_sec`         |
 | `OUTPUT_PLAYBACK_STOPPED`   | `cell_id`, `reason`               |
 
+## Outline fold / collapse
+
+Producer: `asat.notebook.NotebookCursor.toggle_fold_focused_heading`
+(`source="cursor"`). Pressing `z` on a heading flips its `collapsed`
+flag and publishes `OUTLINE_FOLDED` (now collapsed) or
+`OUTLINE_UNFOLDED` (now expanded). Cells whose nearest enclosing
+heading is collapsed are skipped by `move_up` / `move_down` — the
+heading itself stays visible so the user can toggle it back. The
+`cell_count` payload field is the number of hidden cells
+(`scope_range.end - scope_range.start - 1`).
+
+| EventType            | Payload keys                                                      |
+|----------------------|-------------------------------------------------------------------|
+| `OUTLINE_FOLDED`     | `cell_id`, `heading_level`, `heading_title`, `cell_count`         |
+| `OUTLINE_UNFOLDED`   | `cell_id`, `heading_level`, `heading_title`, `cell_count`         |
+
 ## Self-check
 
 Producer: `asat.self_check.run_self_check` (`source="self_check"`),

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -804,23 +804,27 @@ cells"). Cross-notebook paste falls out for free once F29 lands.
 
 ## F27 — Heading and text cells with hierarchy, navigation, and scope selection
 
-**Status.** Partially shipped as F61 (headings), an F27 text-cell
-slice, F27 parent-scope navigation, and the `asat/outline.py`
-scope helper with `NotebookCursor.select_heading_scope()`.
-Heading cells, flat outline navigation (`]` / `[`, `1`-`6`),
-`:toc`, `:heading <level> <title>`, and the default-bank heading
-voice are in (see F61). Text cells now exist as `CellKind.TEXT`
-with a `:text <prose>` INPUT meta-command and a dedicated
+**Status.** Partially shipped as F61 (headings), an F27
+text-cell slice, F27 parent-scope navigation, the
+`asat/outline.py` scope helper with
+`NotebookCursor.select_heading_scope()`, and F27 fold / collapse
+(`z`, `OUTLINE_FOLDED` / `OUTLINE_UNFOLDED`). Heading cells,
+flat outline navigation (`]` / `[`, `1`-`6`), `:toc`, `:heading
+<level> <title>`, and the default-bank heading voice are in
+(see F61). Text cells now exist as `CellKind.TEXT` with a
+`:text <prose>` INPUT meta-command and a dedicated
 `focus_changed_text` narration binding. `{` / `}` in NOTEBOOK
 walk to the previous / next heading whose level is strictly
 shallower than the current scope (enclosing heading).
 `asat/outline.scope_range(cells, heading_index)` returns the
 `[start, end)` span of a heading's section (children included),
 and `NotebookCursor.select_heading_scope()` returns the focused
-cell's enclosing section as a list of Cells. What is still
-pending from the original F27 sketch: the NOTEBOOK `i`
-keybinding for in-place text insertion and fold / collapse
-(`z`, `OUTLINE_FOLDED` / `OUTLINE_UNFOLDED`).
+cell's enclosing section as a list of Cells. `z` on a heading
+toggles a `collapsed` flag — Up/Down skip over the hidden
+scope, and `OUTLINE_FOLDED` / `OUTLINE_UNFOLDED` carry the
+heading's metadata and hidden-cell count. What is still pending
+from the original F27 sketch: the NOTEBOOK `i` keybinding for
+in-place text insertion.
 
 **Gap.** Every cell today is an input / output pair produced by
 `ExecutionKernel` or an announce-only heading (F61). There is no
@@ -855,17 +859,22 @@ type is a narrow change.
    heading's level for a non-heading cell". Heading narration
    piggy-backs on FOCUS_CHANGED; no-match falls through silently
    like the flat `]` / `[` nav.
-3. **Scope selection + fold / collapse.** *(Scope-selection
-   slice shipped.)* `asat/outline.py` provides the pure
-   `scope_range(cells, heading_index) -> (start, end)` function
-   and `enclosing_heading_index(cells, index)` helper.
+3. **Scope selection + fold / collapse.** *(Shipped.)*
+   `asat/outline.py` provides the pure
+   `scope_range(cells, heading_index) -> (start, end)` function,
+   `enclosing_heading_index(cells, index)`, and `visible_indices(cells)`
+   (the index list not hidden by any collapsed heading).
    `NotebookCursor.select_heading_scope()` returns the focused
    cell's enclosing section as a list of Cells, ready for F26's
-   clipboard or any future outline-aware action. Still pending:
-   the `z` keystroke on a heading that toggles a `collapsed`
-   flag so Up/Down skip the scope, and the
-   `OUTLINE_FOLDED` / `OUTLINE_UNFOLDED` events the default bank
-   would use to narrate "section setup, four cells, collapsed".
+   clipboard or any future outline-aware action. `Cell.collapsed`
+   is a HEADING-only boolean flag; `NotebookCursor.toggle_fold_focused_heading`
+   flips it and publishes `OUTLINE_FOLDED` /
+   `OUTLINE_UNFOLDED` with the heading's id, level, title, and
+   hidden-cell count (`scope_range.end - start - 1`). The `z`
+   keystroke from NOTEBOOK invokes the toggle, and `move_up` /
+   `move_down` consult `visible_indices` so keyboard navigation
+   skips over the hidden scope. Default-bank bindings narrate
+   "section X collapsed, N cells" / "section X expanded".
 
 **See also.** F51 (notebook file format) persists the heading
 fields F61 added; populating `"text"` piggy-backs on the same

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -570,6 +570,7 @@ Every key you need, one table.
 | NOTEBOOK   | `]` / `[`         | Next / previous heading (any level)   |
 | NOTEBOOK   | `1`..`6`          | Next heading of that level (F61)      |
 | NOTEBOOK   | `}` / `{`         | Next / prev parent-scope heading (F27)|
+| NOTEBOOK   | `z`               | Toggle collapse on focused heading (F27)|
 | INPUT      | Enter             | Submit command                        |
 | INPUT      | Backspace         | Delete char before caret              |
 | INPUT      | Delete            | Delete char under caret               |

--- a/tests/test_input_router.py
+++ b/tests/test_input_router.py
@@ -1932,6 +1932,58 @@ class ParentScopeNavigationBindingTests(unittest.TestCase):
         self.assertTrue(cursor.focus.input_buffer.endswith("}"))
 
 
+class FoldCollapseBindingTests(unittest.TestCase):
+    """F27: `z` on a heading toggles collapse; Up/Down skips hidden cells."""
+
+    def _build(self):
+        bus = EventBus()
+        session = Session.new()
+        session.add_cell(Cell.new_heading(1, "Intro"))
+        session.add_cell(Cell.new("ls"))
+        session.add_cell(Cell.new_heading(2, "Setup"))
+        session.add_cell(Cell.new("install"))
+        session.add_cell(Cell.new_heading(2, "Training"))
+        cursor = NotebookCursor(session, bus)
+        router = InputRouter(cursor, bus)
+        return bus, session, cursor, router
+
+    def test_z_on_heading_folds_and_unfolds(self) -> None:
+        _bus, session, cursor, router = self._build()
+        cursor.focus_cell(session.cells[2].cell_id)  # H2 Setup
+        action = router.handle_key(Key.printable("z"))
+        self.assertEqual(action, "toggle_fold_heading")
+        self.assertTrue(session.cells[2].collapsed)
+        router.handle_key(Key.printable("z"))
+        self.assertFalse(session.cells[2].collapsed)
+
+    def test_z_on_command_cell_reports_not_toggled(self) -> None:
+        bus, session, cursor, router = self._build()
+        rec = _Recorder(bus)
+        cursor.focus_cell(session.cells[1].cell_id)  # cmd
+        router.handle_key(Key.printable("z"))
+        invoked = [e for e in rec.types_of(EventType.ACTION_INVOKED)
+                   if e.payload["action"] == "toggle_fold_heading"]
+        self.assertFalse(invoked[-1].payload["toggled"])
+        self.assertFalse(session.cells[1].collapsed)
+
+    def test_down_after_fold_skips_hidden_cells(self) -> None:
+        _bus, session, cursor, router = self._build()
+        cursor.focus_cell(session.cells[2].cell_id)  # H2 Setup
+        router.handle_key(Key.printable("z"))  # fold Setup
+        router.handle_key(DOWN)
+        # install (index 3) is hidden; next visible is Training (index 4).
+        self.assertEqual(cursor.focus.cell_id, session.cells[4].cell_id)
+
+    def test_z_noop_in_input_mode_falls_through_as_text(self) -> None:
+        _bus, session, cursor, router = self._build()
+        cursor.focus_cell(session.cells[1].cell_id)
+        cursor.enter_input_mode()
+        router.handle_key(Key.printable("z"))
+        self.assertEqual(cursor.focus.mode, FocusMode.INPUT)
+        self.assertTrue(cursor.focus.input_buffer.endswith("z"))
+        self.assertFalse(session.cells[2].collapsed)
+
+
 class HeadingMetaCommandTests(unittest.TestCase):
     """F61: `:heading <level> <title>` and `:toc`."""
 

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -809,6 +809,101 @@ class SelectHeadingScopeTests(unittest.TestCase):
         self.assertIs(first[0], second[0])
 
 
+class FoldCollapseTests(unittest.TestCase):
+    """F27: toggle_fold + collapsed-aware Up/Down navigation."""
+
+    def setUp(self) -> None:
+        self.bus = EventBus()
+        self.session = Session.new()
+        # [0] H1 Intro  [1] ls   [2] H2 Setup   [3] install
+        # [4] H3 Fixt   [5] make [6] H2 Train   [7] train  [8] H1 Runs
+        self.session.add_cell(Cell.new_heading(1, "Intro"))
+        self.session.add_cell(Cell.new("ls"))
+        self.session.add_cell(Cell.new_heading(2, "Setup"))
+        self.session.add_cell(Cell.new("install"))
+        self.session.add_cell(Cell.new_heading(3, "Fixtures"))
+        self.session.add_cell(Cell.new("make"))
+        self.session.add_cell(Cell.new_heading(2, "Training"))
+        self.session.add_cell(Cell.new("train"))
+        self.session.add_cell(Cell.new_heading(1, "Runs"))
+        self.cursor = NotebookCursor(self.session, self.bus)
+
+    def _folded_events(self, etype: EventType) -> list[Event]:
+        captured: list[Event] = []
+        self.bus.subscribe(etype, captured.append)
+        return captured
+
+    def test_toggle_fold_on_heading_returns_true_then_false(self) -> None:
+        self.cursor.focus_cell(self.session.cells[2].cell_id)  # H2 Setup
+        self.assertTrue(self.cursor.toggle_fold_focused_heading())
+        self.assertTrue(self.session.cells[2].collapsed)
+        self.assertFalse(self.cursor.toggle_fold_focused_heading())
+        self.assertFalse(self.session.cells[2].collapsed)
+
+    def test_toggle_fold_publishes_outline_folded_with_cell_count(self) -> None:
+        folded = self._folded_events(EventType.OUTLINE_FOLDED)
+        self.cursor.focus_cell(self.session.cells[2].cell_id)  # H2 Setup: [2,6)
+        self.cursor.toggle_fold_focused_heading()
+        self.assertEqual(len(folded), 1)
+        p = folded[0].payload
+        self.assertEqual(p["cell_id"], self.session.cells[2].cell_id)
+        self.assertEqual(p["heading_level"], 2)
+        self.assertEqual(p["heading_title"], "Setup")
+        self.assertEqual(p["cell_count"], 3)  # end - start - 1
+
+    def test_toggle_fold_publishes_outline_unfolded_on_expand(self) -> None:
+        unfolded = self._folded_events(EventType.OUTLINE_UNFOLDED)
+        self.cursor.focus_cell(self.session.cells[2].cell_id)
+        self.cursor.toggle_fold_focused_heading()  # fold
+        self.cursor.toggle_fold_focused_heading()  # unfold
+        self.assertEqual(len(unfolded), 1)
+        self.assertEqual(unfolded[0].payload["cell_id"], self.session.cells[2].cell_id)
+
+    def test_toggle_fold_refuses_on_command_cell(self) -> None:
+        self.cursor.focus_cell(self.session.cells[1].cell_id)
+        self.assertIsNone(self.cursor.toggle_fold_focused_heading())
+
+    def test_toggle_fold_refuses_on_empty_scope_heading(self) -> None:
+        """A heading with no following cells has nothing to fold."""
+        bus = EventBus()
+        session = Session.new()
+        session.add_cell(Cell.new_heading(1, "Alone"))
+        cursor = NotebookCursor(session, bus)
+        cursor.focus_cell(session.cells[0].cell_id)
+        self.assertIsNone(cursor.toggle_fold_focused_heading())
+        self.assertFalse(session.cells[0].collapsed)
+
+    def test_move_down_skips_collapsed_scope(self) -> None:
+        self.cursor.focus_cell(self.session.cells[2].cell_id)  # H2 Setup
+        self.cursor.toggle_fold_focused_heading()  # fold [2,6)
+        landed = self.cursor.move_down()
+        assert landed is not None
+        # Next visible after H2 Setup is H2 Training (index 6).
+        self.assertEqual(landed.heading_title, "Training")
+
+    def test_move_up_from_after_collapsed_scope_skips_back_to_heading(self) -> None:
+        self.cursor.focus_cell(self.session.cells[2].cell_id)
+        self.cursor.toggle_fold_focused_heading()  # fold [2,6)
+        self.cursor.focus_cell(self.session.cells[6].cell_id)  # H2 Training
+        landed = self.cursor.move_up()
+        assert landed is not None
+        # Previous visible is the collapsed H2 Setup itself.
+        self.assertEqual(landed.heading_title, "Setup")
+
+    def test_collapsed_h1_absorbs_all_children_on_navigation(self) -> None:
+        self.cursor.focus_cell(self.session.cells[0].cell_id)  # H1 Intro
+        self.cursor.toggle_fold_focused_heading()  # fold [0,8)
+        landed = self.cursor.move_down()
+        assert landed is not None
+        # Everything from H1 Intro's scope is hidden; next is H1 Runs.
+        self.assertEqual(landed.heading_title, "Runs")
+
+    def test_toggle_fold_noop_outside_notebook_mode(self) -> None:
+        self.cursor.focus_cell(self.session.cells[1].cell_id)
+        self.cursor.enter_input_mode()
+        self.assertIsNone(self.cursor.toggle_fold_focused_heading())
+
+
 class HeadingCreationTests(unittest.TestCase):
     """new_heading_cell adds a landmark without entering INPUT mode."""
 

--- a/tests/test_outline.py
+++ b/tests/test_outline.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import unittest
 
 from asat.cell import Cell
-from asat.outline import enclosing_heading_index, scope_range
+from asat.outline import enclosing_heading_index, scope_range, visible_indices
 
 
 def _outline() -> list[Cell]:
@@ -120,6 +120,46 @@ class EnclosingHeadingIndexTests(unittest.TestCase):
 
     def test_empty_cells_returns_none(self) -> None:
         self.assertIsNone(enclosing_heading_index([], 0))
+
+
+class VisibleIndicesTests(unittest.TestCase):
+    """visible_indices skips cells inside collapsed heading scopes."""
+
+    def test_uncollapsed_session_returns_every_index(self) -> None:
+        cells = _outline()
+        self.assertEqual(visible_indices(cells), list(range(len(cells))))
+
+    def test_collapsed_heading_hides_its_children(self) -> None:
+        cells = _outline()
+        cells[2].collapsed = True  # H2 Setup [2, 6)
+        # Indices 3, 4, 5 are hidden; the H2 itself stays visible.
+        self.assertEqual(visible_indices(cells), [0, 1, 2, 6, 7, 8, 9])
+
+    def test_collapsed_h1_absorbs_nested_headings(self) -> None:
+        cells = _outline()
+        cells[0].collapsed = True  # H1 Intro [0, 8)
+        # Only the collapsed H1, the trailing H1, and its body survive.
+        self.assertEqual(visible_indices(cells), [0, 8, 9])
+
+    def test_nested_collapses_yield_each_index_once(self) -> None:
+        cells = _outline()
+        cells[0].collapsed = True  # H1 Intro
+        cells[2].collapsed = True  # H2 Setup (nested inside H1)
+        # H2 is hidden by H1; only the H1 heading, the trailing H1,
+        # and its body are visible.
+        self.assertEqual(visible_indices(cells), [0, 8, 9])
+
+    def test_heading_without_body_does_not_hide_anything(self) -> None:
+        cells = [
+            Cell.new_heading(1, "A"),
+            Cell.new_heading(1, "B"),
+            Cell.new("x"),
+        ]
+        cells[0].collapsed = True  # span is [0, 1) — nothing to hide
+        self.assertEqual(visible_indices(cells), [0, 1, 2])
+
+    def test_empty_cells_returns_empty_list(self) -> None:
+        self.assertEqual(visible_indices([]), [])
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary

- `Cell.collapsed` — HEADING-only boolean field; round-trips through `to_dict` / `from_dict` / `snapshot`, validated in `__post_init__`.
- `asat/outline.visible_indices(cells)` returns the list of cell indices not hidden by any collapsed heading. Nested collapses are absorbed by the outer scope so each visible index is yielded once.
- `NotebookCursor.toggle_fold_focused_heading()` flips `collapsed` on the focused heading (no-op on command cells or empty-scope headings) and publishes `OUTLINE_FOLDED` / `OUTLINE_UNFOLDED` with the heading's id, level, title, and hidden-cell count.
- `NotebookCursor._move` consults `visible_indices` so `Up` / `Down` skip over hidden scopes — land on the collapsed heading, then on the next visible cell.
- NOTEBOOK binding: `z` → `toggle_fold_heading`.
- Default-bank narration at minimal verbosity:
  - `OUTLINE_FOLDED` → "section X collapsed, N cells"
  - `OUTLINE_UNFOLDED` → "section X expanded"
- Sample payloads, `EVENTS.md`, `USER_MANUAL.md`, `BINDINGS.md`, and `HELP_LINES` all updated.

## What's still pending on F27

- NOTEBOOK `i` binding for in-place text insertion (needs an in-place text editor).

## Test plan

- [x] `pytest tests/test_outline.py` — 21 pass (6 new `VisibleIndicesTests`)
- [x] `pytest tests/test_notebook.py::FoldCollapseTests` — 9 pass
- [x] `pytest tests/test_input_router.py::FoldCollapseBindingTests` — 4 pass
- [x] Full suite: `pytest -q` — 1185 pass

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS