### PR TITLE
F27: in-place text-cell composition via `i` keybinding

### DIFF
--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -192,6 +192,7 @@ def default_bindings() -> BindingMap:
             Key.printable("4"): "next_heading_4",
             Key.printable("5"): "next_heading_5",
             Key.printable("6"): "next_heading_6",
+            Key.printable("i"): "begin_text_input",
             kc.F2: "open_action_menu",
             menu_open: "open_action_menu",
             repeat_narration: "repeat_last_narration",
@@ -213,6 +214,24 @@ def default_bindings() -> BindingMap:
             Key.combo("c", Modifier.CTRL): "cancel_command",
             kc.ENTER: "submit",
             kc.ESCAPE: "exit_input",
+            kc.F2: "open_action_menu",
+            menu_open: "open_action_menu",
+            repeat_narration: "repeat_last_narration",
+        },
+        FocusMode.TEXT_INPUT: {
+            kc.BACKSPACE: "backspace",
+            kc.DELETE: "delete_forward",
+            kc.LEFT: "cursor_left",
+            kc.RIGHT: "cursor_right",
+            kc.HOME: "cursor_home",
+            kc.END: "cursor_end",
+            Key.combo("a", Modifier.CTRL): "cursor_home",
+            Key.combo("e", Modifier.CTRL): "cursor_end",
+            Key.combo("w", Modifier.CTRL): "delete_word_left",
+            Key.combo("u", Modifier.CTRL): "delete_to_start",
+            Key.combo("k", Modifier.CTRL): "delete_to_end",
+            kc.ENTER: "submit_text_input",
+            kc.ESCAPE: "abandon_text_input",
             kc.F2: "open_action_menu",
             menu_open: "open_action_menu",
             repeat_narration: "repeat_last_narration",
@@ -329,11 +348,14 @@ HELP_LINES: tuple[str, ...] = (
     "           d delete, y duplicate, Alt+Up/Down reorder.",
     "           ] / [ next / prev heading; 1..6 next heading of that level.",
     "           } / { next / prev heading shallower than current scope (parent).",
+    "           i begins an in-place text cell (Enter creates, Escape abandons).",
     "INPUT:     Enter submits, Escape leaves without running.",
     "           Backspace/Delete cut, Left/Right walk, Home/End jump (or Ctrl+A/E).",
     "           Up/Down walk command history (Down past newest restores your draft).",
     "           Ctrl+W kills word, Ctrl+U kills to start, Ctrl+K kills to end.",
     "           Ctrl+C cancels the running command (publishes COMMAND_CANCELLED).",
+    "TEXT:      Enter creates a text cell from the buffer, Escape abandons.",
+    "           Buffer editing keys match INPUT (Backspace/Delete, Left/Right, Home/End, Ctrl+A/E/W/U/K).",
     "OUTPUT:    Up/Down step lines, PageUp/PageDown page, Escape leaves.",
     "           / search (type query, Enter commits), n / N next / prev hit, g jump-to-line.",
     "SETTINGS:  Up/Down walk, Right/Enter descend, Left/Escape ascend, e edit, Ctrl+S save, Ctrl+Q close.",
@@ -441,7 +463,11 @@ class InputRouter:
         if action is not None:
             self._invoke(action, key)
             return action
-        if mode == FocusMode.INPUT and key.is_printable() and key.char is not None:
+        if (
+            mode in (FocusMode.INPUT, FocusMode.TEXT_INPUT)
+            and key.is_printable()
+            and key.char is not None
+        ):
             self._cursor.insert_character(key.char)
             self._publish_action("insert_character", key, {"char": key.char})
             return "insert_character"
@@ -615,6 +641,22 @@ class InputRouter:
         handler = self._action_handler(action)
         extra = handler() or {}
         self._publish_action(action, key, extra)
+
+    def _submit_text_input(self) -> Optional[dict[str, object]]:
+        """Commit the TEXT_INPUT buffer as a new text cell (F27 `i` flow).
+
+        Reports whether a cell was created (an empty / whitespace-only
+        buffer is treated as abandonment) and, when one was, its id and
+        body so observers can narrate the insertion.
+        """
+        cell = self._cursor.submit_text_input()
+        if cell is None:
+            return {"created": False}
+        return {
+            "created": True,
+            "cell_id": cell.cell_id,
+            "text": cell.text,
+        }
 
     def _submit(self) -> Optional[dict[str, object]]:
         """Commit the current input buffer and return submission extras.
@@ -1338,6 +1380,9 @@ class InputRouter:
             "next_heading_6": self._next_heading_action(6),
             "next_parent_heading": self._parent_heading_action(direction=+1),
             "prev_parent_heading": self._parent_heading_action(direction=-1),
+            "begin_text_input": _void(self._cursor.begin_text_input),
+            "submit_text_input": self._submit_text_input,
+            "abandon_text_input": _void(self._cursor.abandon_text_input),
         }
 
     def _input_handlers(self) -> dict[str, ActionHandler]:

--- a/asat/notebook.py
+++ b/asat/notebook.py
@@ -35,6 +35,11 @@ class FocusMode(str, Enum):
 
     NOTEBOOK: arrow keys navigate between cells.
     INPUT: keystrokes edit the focused cell's command buffer.
+    TEXT_INPUT: keystrokes compose a new prose body that will become a
+        TEXT cell inserted after the current focus when submitted (F27
+        `i` keybinding). Buffer editing primitives are shared with
+        INPUT, but submission creates a cell instead of writing back
+        into an existing one, and there is no history recall.
     OUTPUT: keystrokes walk through lines of the focused cell's
         output. Reserved for a future phase; included here so code
         can already branch on it safely.
@@ -45,6 +50,7 @@ class FocusMode(str, Enum):
 
     NOTEBOOK = "notebook"
     INPUT = "input"
+    TEXT_INPUT = "text_input"
     OUTPUT = "output"
     SETTINGS = "settings"
 
@@ -55,13 +61,15 @@ class FocusState:
 
     mode: current focus mode.
     cell_id: id of the cell being looked at, or None if the session
-        is empty and nothing is focused.
-    input_buffer: the text currently being typed when in INPUT mode.
-        Empty in other modes.
+        is empty and nothing is focused. In TEXT_INPUT mode this is
+        the "anchor" cell — the new text cell will be inserted
+        immediately after it on submit (or appended if None).
+    input_buffer: the text currently being typed when in INPUT or
+        TEXT_INPUT mode. Empty in other modes.
     cursor_position: the caret offset into input_buffer (0 == before
         the first character, len(buffer) == after the last). Only
-        meaningful in INPUT mode; kept at 0 in other modes. Always
-        satisfies 0 <= cursor_position <= len(input_buffer).
+        meaningful in INPUT / TEXT_INPUT; kept at 0 in other modes.
+        Always satisfies 0 <= cursor_position <= len(input_buffer).
     """
 
     mode: FocusMode = FocusMode.NOTEBOOK
@@ -567,6 +575,105 @@ class NotebookCursor:
         )
         return self._state
 
+    def _composing_text(self) -> bool:
+        """Return True when the cursor is composing into ``input_buffer``.
+
+        True in INPUT and TEXT_INPUT — both modes share the buffer /
+        caret primitives (insert, backspace, cursor_left, …). INPUT
+        additionally supports history recall and commits on submit;
+        TEXT_INPUT has no history and creates a fresh text cell on
+        submit. Callers that must distinguish check the mode directly.
+        """
+        return self._state.mode in (FocusMode.INPUT, FocusMode.TEXT_INPUT)
+
+    def begin_text_input(self) -> Optional[FocusState]:
+        """Enter TEXT_INPUT mode to compose a prose body in-place (F27).
+
+        The currently focused cell becomes the "anchor" for insertion:
+        when the buffer is submitted, a new text cell is spliced in
+        immediately after it. On an empty session the anchor is None
+        and the text cell is simply appended. Legal only from NOTEBOOK
+        mode; silent no-op elsewhere so accidentally pressing `i` in
+        INPUT / OUTPUT / SETTINGS does not shred the user's context.
+        """
+        if self._state.mode != FocusMode.NOTEBOOK:
+            return None
+        self._transition(
+            FocusState(
+                mode=FocusMode.TEXT_INPUT,
+                cell_id=self._state.cell_id,
+                input_buffer="",
+                cursor_position=0,
+            )
+        )
+        return self._state
+
+    def submit_text_input(self) -> Optional[Cell]:
+        """Commit the TEXT_INPUT buffer as a new text cell.
+
+        An empty / whitespace-only buffer is treated as abandonment:
+        no cell is created, the cursor returns to NOTEBOOK on the
+        anchor. Otherwise a fresh TEXT cell is inserted immediately
+        after the anchor (or appended when the anchor is None / no
+        longer in the session), focus lands on the new cell, and
+        CELL_CREATED is published. Returns the new cell, or None if
+        called outside TEXT_INPUT or when nothing was created.
+        """
+        if self._state.mode != FocusMode.TEXT_INPUT:
+            return None
+        body = self._state.input_buffer.strip()
+        anchor_id = self._state.cell_id
+        if not body:
+            self._transition(
+                FocusState(
+                    mode=FocusMode.NOTEBOOK,
+                    cell_id=anchor_id,
+                    input_buffer="",
+                    cursor_position=0,
+                )
+            )
+            return None
+        cell = Cell.new_text(body)
+        position: Optional[int]
+        if anchor_id is None:
+            position = None
+        else:
+            try:
+                position = self._session.index_of(anchor_id) + 1
+            except (ValueError, SessionError):
+                position = None
+        self._session.add_cell(cell, position=position)
+        new_index = self._session.index_of(cell.cell_id)
+        self._publish_cell_created(cell, new_index)
+        self._session.set_active(cell.cell_id)
+        self._transition(
+            FocusState(
+                mode=FocusMode.NOTEBOOK,
+                cell_id=cell.cell_id,
+                input_buffer="",
+                cursor_position=0,
+            )
+        )
+        return cell
+
+    def abandon_text_input(self) -> Optional[FocusState]:
+        """Exit TEXT_INPUT mode without creating a cell.
+
+        Returns to NOTEBOOK on the anchor cell (or None focus when the
+        anchor went away mid-edit). Silent no-op outside TEXT_INPUT.
+        """
+        if self._state.mode != FocusMode.TEXT_INPUT:
+            return None
+        self._transition(
+            FocusState(
+                mode=FocusMode.NOTEBOOK,
+                cell_id=self._state.cell_id,
+                input_buffer="",
+                cursor_position=0,
+            )
+        )
+        return self._state
+
     def reset_input_buffer(self) -> None:
         """Clear the input buffer while staying in INPUT mode.
 
@@ -588,8 +695,10 @@ class NotebookCursor:
         """Insert a character at the current caret position.
 
         The caret advances by one so subsequent inserts chain naturally.
+        Accepts either INPUT (editing a command) or TEXT_INPUT
+        (composing a new prose cell) mode.
         """
-        if self._state.mode != FocusMode.INPUT:
+        if not self._composing_text():
             return
         if len(character) != 1:
             raise ValueError("insert_character expects exactly one character")
@@ -603,7 +712,7 @@ class NotebookCursor:
 
     def backspace(self) -> None:
         """Delete the character immediately before the caret."""
-        if self._state.mode != FocusMode.INPUT:
+        if not self._composing_text():
             return
         position = self._state.cursor_position
         if position == 0:
@@ -617,7 +726,7 @@ class NotebookCursor:
 
     def cursor_left(self) -> None:
         """Move the caret one character to the left; clamp at start."""
-        if self._state.mode != FocusMode.INPUT:
+        if not self._composing_text():
             return
         if self._state.cursor_position == 0:
             return
@@ -625,7 +734,7 @@ class NotebookCursor:
 
     def cursor_right(self) -> None:
         """Move the caret one character to the right; clamp at end."""
-        if self._state.mode != FocusMode.INPUT:
+        if not self._composing_text():
             return
         if self._state.cursor_position >= len(self._state.input_buffer):
             return
@@ -633,7 +742,7 @@ class NotebookCursor:
 
     def cursor_home(self) -> None:
         """Jump the caret to the start of the input buffer."""
-        if self._state.mode != FocusMode.INPUT:
+        if not self._composing_text():
             return
         if self._state.cursor_position == 0:
             return
@@ -641,7 +750,7 @@ class NotebookCursor:
 
     def cursor_end(self) -> None:
         """Jump the caret to the end of the input buffer."""
-        if self._state.mode != FocusMode.INPUT:
+        if not self._composing_text():
             return
         end = len(self._state.input_buffer)
         if self._state.cursor_position == end:
@@ -650,7 +759,7 @@ class NotebookCursor:
 
     def delete_forward(self) -> None:
         """Delete the character at the caret (Delete key)."""
-        if self._state.mode != FocusMode.INPUT:
+        if not self._composing_text():
             return
         position = self._state.cursor_position
         buffer = self._state.input_buffer
@@ -662,7 +771,7 @@ class NotebookCursor:
 
     def delete_word_left(self) -> None:
         """Delete the whitespace-delimited word preceding the caret."""
-        if self._state.mode != FocusMode.INPUT:
+        if not self._composing_text():
             return
         position = self._state.cursor_position
         if position == 0:
@@ -682,7 +791,7 @@ class NotebookCursor:
 
     def delete_to_start(self) -> None:
         """Delete everything from the start of the buffer up to the caret."""
-        if self._state.mode != FocusMode.INPUT:
+        if not self._composing_text():
             return
         position = self._state.cursor_position
         if position == 0:
@@ -693,7 +802,7 @@ class NotebookCursor:
 
     def delete_to_end(self) -> None:
         """Delete everything from the caret to the end of the buffer."""
-        if self._state.mode != FocusMode.INPUT:
+        if not self._composing_text():
             return
         position = self._state.cursor_position
         buffer = self._state.input_buffer

--- a/docs/BINDINGS.md
+++ b/docs/BINDINGS.md
@@ -30,6 +30,7 @@ Each row is one binding. The `Action` column is the handler name `InputRouter._a
 | `[` | `prev_heading` |
 | `]` | `next_heading` |
 | `d` | `delete_cell` |
+| `i` | `begin_text_input` |
 | `y` | `duplicate_cell` |
 | `{` | `prev_parent_heading` |
 | `}` | `next_parent_heading` |
@@ -57,6 +58,27 @@ Each row is one binding. The `Action` column is the handler name `InputRouter._a
 | `Left` | `cursor_left` |
 | `Right` | `cursor_right` |
 | `Up` | `history_previous` |
+
+## TEXT_INPUT mode
+
+| Keystroke | Action |
+|-----------|--------|
+| `Backspace` | `backspace` |
+| `Ctrl+.` | `open_action_menu` |
+| `Ctrl+A` | `cursor_home` |
+| `Ctrl+E` | `cursor_end` |
+| `Ctrl+K` | `delete_to_end` |
+| `Ctrl+R` | `repeat_last_narration` |
+| `Ctrl+U` | `delete_to_start` |
+| `Ctrl+W` | `delete_word_left` |
+| `Delete` | `delete_forward` |
+| `End` | `cursor_end` |
+| `Enter` | `submit_text_input` |
+| `Escape` | `abandon_text_input` |
+| `F2` | `open_action_menu` |
+| `Home` | `cursor_home` |
+| `Left` | `cursor_left` |
+| `Right` | `cursor_right` |
 
 ## OUTPUT mode
 

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -804,23 +804,23 @@ cells"). Cross-notebook paste falls out for free once F29 lands.
 
 ## F27 — Heading and text cells with hierarchy, navigation, and scope selection
 
-**Status.** Partially shipped as F61 (headings), an F27 text-cell
-slice, F27 parent-scope navigation, and the `asat/outline.py`
-scope helper with `NotebookCursor.select_heading_scope()`.
-Heading cells, flat outline navigation (`]` / `[`, `1`-`6`),
-`:toc`, `:heading <level> <title>`, and the default-bank heading
-voice are in (see F61). Text cells now exist as `CellKind.TEXT`
-with a `:text <prose>` INPUT meta-command and a dedicated
-`focus_changed_text` narration binding. `{` / `}` in NOTEBOOK
-walk to the previous / next heading whose level is strictly
-shallower than the current scope (enclosing heading).
-`asat/outline.scope_range(cells, heading_index)` returns the
-`[start, end)` span of a heading's section (children included),
-and `NotebookCursor.select_heading_scope()` returns the focused
-cell's enclosing section as a list of Cells. What is still
-pending from the original F27 sketch: the NOTEBOOK `i`
-keybinding for in-place text insertion and fold / collapse
-(`z`, `OUTLINE_FOLDED` / `OUTLINE_UNFOLDED`).
+**Status.** Shipped. Heading cells, flat outline navigation (`]` /
+`[`, `1`-`6`), `:toc`, `:heading <level> <title>`, and the default-
+bank heading voice are in (see F61). Text cells exist as
+`CellKind.TEXT` with both a `:text <prose>` INPUT meta-command and
+an in-place `i` keybinding that drops the cursor into a dedicated
+`FocusMode.TEXT_INPUT` — Enter splices the composed buffer into a
+new text cell after the anchor and returns to NOTEBOOK; Escape
+abandons. `{` / `}` in NOTEBOOK walk to the previous / next
+heading whose level is strictly shallower than the current scope
+(enclosing heading). `asat/outline.scope_range(cells,
+heading_index)` returns the `[start, end)` span of a heading's
+section (children included), and
+`NotebookCursor.select_heading_scope()` returns the focused cell's
+enclosing section as a list of Cells. Fold / collapse (`z` +
+`OUTLINE_FOLDED` / `OUTLINE_UNFOLDED`) lives on its own branch
+(PR #90) and completes the scope-collapse half of the original
+sketch.
 
 **Gap.** Every cell today is an input / output pair produced by
 `ExecutionKernel` or an announce-only heading (F61). There is no
@@ -838,15 +838,16 @@ type is a narrow change.
 
 **Sketch — remaining work after F61.**
 
-1. **Text cell kind.** *(Text-cell slice shipped.)* `CellKind.TEXT`
-   and a `text: str` field on `Cell` are in; `is_executable`
-   returns False so `Application.execute` short-circuits (same
-   guard F61 added for headings). INPUT's `:text <prose>`
-   meta-command appends a text cell and abandons INPUT (parallels
-   `:heading`), and FOCUS_CHANGED narrates "text, {text}". Still
-   pending: the NOTEBOOK `i` binding for in-place insertion
-   (needs an in-place editor for the text body; typing-in-line
-   is not yet wired).
+1. **Text cell kind.** *(Shipped.)* `CellKind.TEXT` and a
+   `text: str` field on `Cell` are in; `is_executable` returns
+   False so `Application.execute` short-circuits (same guard F61
+   added for headings). INPUT's `:text <prose>` meta-command
+   appends a text cell and abandons INPUT (parallels `:heading`),
+   and FOCUS_CHANGED narrates "text, {text}". The NOTEBOOK `i`
+   binding enters a dedicated `FocusMode.TEXT_INPUT`: Enter
+   creates a text cell after the anchor, Escape abandons, and the
+   buffer-manipulation primitives (Backspace, Delete, Left/Right,
+   Home/End, Ctrl+A/E/W/U/K) are shared with INPUT.
 2. **Parent-scope navigation.** *(Shipped.)* `{` / `}` in NOTEBOOK
    jump to the previous / next heading whose `heading_level` is
    strictly shallower than the current scope.

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -200,25 +200,27 @@ mode, save the session, resume it tomorrow with every cell intact.
 
 ## Focus modes
 
-You are always in exactly one of four modes. The current mode
+You are always in exactly one of five modes. The current mode
 decides what keys do.
 
 | Mode       | What you're doing                                  |
 |------------|----------------------------------------------------|
 | `NOTEBOOK` | Walking between cells (no keys go into a buffer). |
 | `INPUT`    | Typing a command into the active cell.             |
+| `TEXT_INPUT` | Composing a new prose cell in-place (F27). Press `i` in NOTEBOOK to enter; Enter creates, Escape abandons. |
 | `OUTPUT`   | Stepping line-by-line through captured output.     |
 | `SETTINGS` | Driving the live SoundBank editor.                 |
 
 Every mode transition announces itself: you'll hear the
 `focus_shift` cue overhead and the system voice names the new mode
-(`"input"`, `"notebook"`, `"output"`, `"settings"`). Walking between
-cells within NOTEBOOK mode plays `nav_blip` instead and the narrator
-reads the focused cell's command. Typing into the input buffer is
-silent on purpose — the `insert_character` action echoes the literal
-character instead. If you lose track of where you are, just press
-Escape — it always takes you one level out (INPUT / OUTPUT →
-NOTEBOOK, SETTINGS → close), and the narrator confirms the new mode.
+(`"input"`, `"notebook"`, `"output"`, `"settings"`, `"text_input"`).
+Walking between cells within NOTEBOOK mode plays `nav_blip` instead
+and the narrator reads the focused cell's command. Typing into any
+buffer (INPUT or TEXT_INPUT) is silent on purpose — the
+`insert_character` action echoes the literal character instead. If
+you lose track of where you are, just press Escape — it always takes
+you one level out (INPUT / OUTPUT / TEXT_INPUT → NOTEBOOK, SETTINGS
+→ close), and the narrator confirms the new mode.
 
 ---
 
@@ -235,6 +237,7 @@ NOTEBOOK, SETTINGS → close), and the narrator confirms the new mode.
 | Ctrl+,     | Open the settings editor.                         |
 | `d`        | Delete the focused cell.                          |
 | `y`        | Duplicate the focused cell (inserts a copy below).|
+| `i`        | Begin composing an in-place text cell; lands in TEXT_INPUT mode (F27). |
 | Alt+Up / Alt+Down | Move the focused cell up / down within the session. |
 
 Moving between cells plays the `nav_blip` cue and the narrator reads
@@ -264,6 +267,38 @@ or when you press Enter from NOTEBOOK mode.
 | Ctrl+R    | Repeat the most recent narration.                 |
 | Enter     | Submits the command to the execution kernel.      |
 | Escape    | Commits the buffer into the cell and returns to NOTEBOOK (does not run). |
+
+---
+
+## TEXT_INPUT mode — composing a prose cell in-place
+
+Press `i` from NOTEBOOK to begin a text cell without leaving the
+flow. The cursor enters TEXT_INPUT mode with an empty buffer; every
+printable key goes into the buffer (no meta-commands, no history
+recall). Enter splices the buffer into the notebook as a new text
+cell *immediately after the currently focused "anchor" cell* and
+focuses it in NOTEBOOK mode. Escape (or an empty / whitespace-only
+buffer on Enter) abandons without creating anything.
+
+| Key       | What it does                                      |
+|-----------|---------------------------------------------------|
+| Any char  | Inserted at the caret.                            |
+| Backspace | Deletes the character before the caret.           |
+| Delete    | Deletes the character under the caret.            |
+| Left / Right | Move the caret one character.                  |
+| Home / End | Jump the caret to the start / end of the buffer. |
+| Ctrl+A / Ctrl+E | Alias for Home / End.                       |
+| Ctrl+W    | Delete the word immediately before the caret.     |
+| Ctrl+U    | Delete from the start of the buffer up to the caret. |
+| Ctrl+K    | Delete from the caret to the end of the buffer.   |
+| Enter     | Create the text cell and return to NOTEBOOK.      |
+| Escape    | Abandon the draft (no cell is created).           |
+
+The `:text <prose>` meta-command in INPUT mode is still available
+for scripted / dictated insertion; `i` is the hands-on counterpart
+where you want the buffer to be the prose body directly.
+
+---
 
 ### Meta-commands
 
@@ -570,6 +605,14 @@ Every key you need, one table.
 | NOTEBOOK   | `]` / `[`         | Next / previous heading (any level)   |
 | NOTEBOOK   | `1`..`6`          | Next heading of that level (F61)      |
 | NOTEBOOK   | `}` / `{`         | Next / prev parent-scope heading (F27)|
+| NOTEBOOK   | `i`               | Begin an in-place text cell (F27); lands in TEXT mode |
+| TEXT       | Enter             | Create a text cell from the buffer after the anchor (F27) |
+| TEXT       | Escape            | Abandon the draft without creating a cell (F27) |
+| TEXT       | Backspace / Delete | Delete char before / at caret        |
+| TEXT       | Left / Right      | Move caret one character              |
+| TEXT       | Home / End        | Caret to start / end (also Ctrl+A / Ctrl+E) |
+| TEXT       | Ctrl+W / Ctrl+U / Ctrl+K | Kill word / to-start / to-end  |
+| TEXT       | F2 / Ctrl+.       | Open actions menu                     |
 | INPUT      | Enter             | Submit command                        |
 | INPUT      | Backspace         | Delete char before caret              |
 | INPUT      | Delete            | Delete char under caret               |

--- a/tests/test_input_router.py
+++ b/tests/test_input_router.py
@@ -2048,6 +2048,109 @@ class TextMetaCommandTests(unittest.TestCase):
         self.assertNotIn("text", AMBIENT_META_COMMANDS)
 
 
+class TextInputBindingTests(unittest.TestCase):
+    """F27 `i` flow: NOTEBOOK `i` begins TEXT_INPUT; Enter creates; Escape abandons."""
+
+    def test_i_from_notebook_enters_text_input_mode(self) -> None:
+        _bus, _session, cursor, router, _cells = _build(["ls"])
+        action = router.handle_key(Key.printable("i"))
+        self.assertEqual(action, "begin_text_input")
+        self.assertEqual(cursor.focus.mode, FocusMode.TEXT_INPUT)
+        self.assertEqual(cursor.focus.input_buffer, "")
+
+    def test_printables_in_text_input_mode_insert_into_buffer(self) -> None:
+        _bus, _session, cursor, router, _cells = _build(["ls"])
+        router.handle_key(Key.printable("i"))
+        for ch in "note":
+            router.handle_key(Key.printable(ch))
+        self.assertEqual(cursor.focus.input_buffer, "note")
+        self.assertEqual(cursor.focus.cursor_position, 4)
+
+    def test_enter_in_text_input_submits_and_creates_text_cell(self) -> None:
+        _bus, session, cursor, router, cells = _build(["ls", "pwd"])
+        # Anchor on the first cell so the new text cell should slot in at index 1.
+        cursor.focus_cell(cells[0].cell_id)
+        router.handle_key(Key.printable("i"))
+        for ch in "between":
+            router.handle_key(Key.printable(ch))
+        action = router.handle_key(ENTER)
+        self.assertEqual(action, "submit_text_input")
+        self.assertEqual(len(session.cells), 3)
+        new_cell = session.cells[1]
+        self.assertTrue(new_cell.is_text)
+        self.assertEqual(new_cell.text, "between")
+        self.assertEqual(cursor.focus.mode, FocusMode.NOTEBOOK)
+        self.assertEqual(cursor.focus.cell_id, new_cell.cell_id)
+
+    def test_escape_in_text_input_abandons_without_creating_cell(self) -> None:
+        _bus, session, cursor, router, cells = _build(["ls"])
+        initial = len(session.cells)
+        router.handle_key(Key.printable("i"))
+        for ch in "draft":
+            router.handle_key(Key.printable(ch))
+        action = router.handle_key(ESCAPE)
+        self.assertEqual(action, "abandon_text_input")
+        self.assertEqual(len(session.cells), initial)
+        self.assertEqual(cursor.focus.mode, FocusMode.NOTEBOOK)
+        self.assertEqual(cursor.focus.cell_id, cells[0].cell_id)
+
+    def test_buffer_editing_bindings_work_in_text_input(self) -> None:
+        _bus, _session, cursor, router, _cells = _build(["ls"])
+        router.handle_key(Key.printable("i"))
+        for ch in "abc":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(BACKSPACE)
+        self.assertEqual(cursor.focus.input_buffer, "ab")
+        router.handle_key(HOME)
+        self.assertEqual(cursor.focus.cursor_position, 0)
+        router.handle_key(END)
+        self.assertEqual(cursor.focus.cursor_position, 2)
+        router.handle_key(LEFT)
+        self.assertEqual(cursor.focus.cursor_position, 1)
+        router.handle_key(DELETE)
+        self.assertEqual(cursor.focus.input_buffer, "a")
+
+    def test_empty_submit_in_text_input_creates_nothing(self) -> None:
+        bus, session, cursor, router, _cells = _build(["ls"])
+        rec = _Recorder(bus)
+        router.handle_key(Key.printable("i"))
+        router.handle_key(ENTER)
+        self.assertEqual(len(session.cells), 1)
+        self.assertEqual(cursor.focus.mode, FocusMode.NOTEBOOK)
+        # ACTION_INVOKED payload should indicate no cell was created.
+        actions = rec.types_of(EventType.ACTION_INVOKED)
+        submit_events = [e for e in actions if e.payload.get("action") == "submit_text_input"]
+        self.assertTrue(submit_events)
+        self.assertEqual(submit_events[-1].payload.get("created"), False)
+
+    def test_submit_payload_carries_cell_id_and_text(self) -> None:
+        bus, _session, _cursor, router, _cells = _build(["ls"])
+        rec = _Recorder(bus)
+        router.handle_key(Key.printable("i"))
+        for ch in "hello":
+            router.handle_key(Key.printable(ch))
+        router.handle_key(ENTER)
+        actions = rec.types_of(EventType.ACTION_INVOKED)
+        submit_events = [e for e in actions if e.payload.get("action") == "submit_text_input"]
+        self.assertEqual(submit_events[-1].payload["created"], True)
+        self.assertIn("cell_id", submit_events[-1].payload)
+        self.assertEqual(submit_events[-1].payload["text"], "hello")
+
+    def test_i_is_ignored_in_input_mode(self) -> None:
+        _bus, _session, cursor, router, _cells = _build(["ls"])
+        cursor.enter_input_mode()
+        router.handle_key(Key.printable("i"))
+        # In INPUT mode `i` is a plain printable char.
+        self.assertEqual(cursor.focus.mode, FocusMode.INPUT)
+        self.assertTrue(cursor.focus.input_buffer.endswith("i"))
+
+    def test_text_input_mode_bindings_exist_in_default_map(self) -> None:
+        bindings = default_bindings()
+        self.assertIn(FocusMode.TEXT_INPUT, bindings)
+        self.assertEqual(bindings[FocusMode.TEXT_INPUT][ENTER], "submit_text_input")
+        self.assertEqual(bindings[FocusMode.TEXT_INPUT][ESCAPE], "abandon_text_input")
+
+
 class ParseHeadingArgumentTests(unittest.TestCase):
     """F61: `:heading <level> <title>` argument parser."""
 

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -928,5 +928,151 @@ class CursorCommandHistoryTests(unittest.TestCase):
         self.assertEqual(self.session.command_history, ["one", "two", "three"])
 
 
+class TextInputModeTests(unittest.TestCase):
+    """F27 `i` flow: begin / submit / abandon in-place text composition."""
+
+    def setUp(self) -> None:
+        self.bus = EventBus()
+        self.session, self.cells = _session_with(["ls", "pwd", "whoami"])
+        self.cursor = NotebookCursor(self.session, self.bus)
+        # Focus the middle cell so "after anchor" is easy to reason about.
+        self.cursor.focus_cell(self.cells[1].cell_id)
+
+    def test_begin_text_input_enters_text_input_mode(self) -> None:
+        result = self.cursor.begin_text_input()
+        assert result is not None
+        self.assertEqual(self.cursor.focus.mode, FocusMode.TEXT_INPUT)
+        self.assertEqual(self.cursor.focus.cell_id, self.cells[1].cell_id)
+        self.assertEqual(self.cursor.focus.input_buffer, "")
+        self.assertEqual(self.cursor.focus.cursor_position, 0)
+
+    def test_begin_text_input_is_noop_outside_notebook(self) -> None:
+        self.cursor.enter_input_mode()
+        self.assertEqual(self.cursor.focus.mode, FocusMode.INPUT)
+        self.assertIsNone(self.cursor.begin_text_input())
+        self.assertEqual(self.cursor.focus.mode, FocusMode.INPUT)
+
+    def test_buffer_editing_works_in_text_input_mode(self) -> None:
+        self.cursor.begin_text_input()
+        for ch in "hello":
+            self.cursor.insert_character(ch)
+        self.assertEqual(self.cursor.focus.input_buffer, "hello")
+        self.assertEqual(self.cursor.focus.cursor_position, 5)
+        self.cursor.backspace()
+        self.assertEqual(self.cursor.focus.input_buffer, "hell")
+        self.cursor.cursor_home()
+        self.assertEqual(self.cursor.focus.cursor_position, 0)
+        self.cursor.cursor_end()
+        self.assertEqual(self.cursor.focus.cursor_position, 4)
+        self.cursor.delete_to_end()
+        # At end, nothing to delete forward.
+        self.assertEqual(self.cursor.focus.input_buffer, "hell")
+
+    def test_submit_text_input_inserts_after_anchor(self) -> None:
+        self.cursor.begin_text_input()
+        for ch in "hello world":
+            self.cursor.insert_character(ch)
+        cell = self.cursor.submit_text_input()
+        assert cell is not None
+        self.assertEqual(cell.kind, CellKind.TEXT)
+        self.assertEqual(cell.text, "hello world")
+        # Anchor was cells[1] (index 1); new cell lives at index 2.
+        self.assertEqual(self.session.index_of(cell.cell_id), 2)
+        self.assertEqual(self.cursor.focus.mode, FocusMode.NOTEBOOK)
+        self.assertEqual(self.cursor.focus.cell_id, cell.cell_id)
+        self.assertEqual(self.cursor.focus.input_buffer, "")
+
+    def test_submit_text_input_publishes_cell_created_and_focus_changed(self) -> None:
+        created: list[Event] = []
+        focused: list[Event] = []
+        self.bus.subscribe(EventType.CELL_CREATED, created.append)
+        self.bus.subscribe(EventType.FOCUS_CHANGED, focused.append)
+        self.cursor.begin_text_input()
+        self.cursor.insert_character("x")
+        cell = self.cursor.submit_text_input()
+        assert cell is not None
+        self.assertEqual(len(created), 1)
+        self.assertEqual(created[0].payload["cell_id"], cell.cell_id)
+        self.assertEqual(created[0].payload["index"], 2)
+        modes_seen = [event.payload["new_mode"] for event in focused]
+        self.assertIn("text_input", modes_seen)
+        self.assertEqual(focused[-1].payload["new_mode"], "notebook")
+        self.assertEqual(focused[-1].payload["kind"], CellKind.TEXT.value)
+        self.assertEqual(focused[-1].payload["text"], "x")
+
+    def test_submit_empty_buffer_creates_nothing(self) -> None:
+        created: list[Event] = []
+        self.bus.subscribe(EventType.CELL_CREATED, created.append)
+        self.cursor.begin_text_input()
+        cell = self.cursor.submit_text_input()
+        self.assertIsNone(cell)
+        self.assertEqual(created, [])
+        self.assertEqual(self.cursor.focus.mode, FocusMode.NOTEBOOK)
+        # Focus returns to anchor.
+        self.assertEqual(self.cursor.focus.cell_id, self.cells[1].cell_id)
+
+    def test_submit_whitespace_only_buffer_creates_nothing(self) -> None:
+        self.cursor.begin_text_input()
+        for ch in "   ":
+            self.cursor.insert_character(ch)
+        self.assertIsNone(self.cursor.submit_text_input())
+        # Session cell count unchanged (no text cell appended).
+        self.assertEqual(len(self.session.cells), 3)
+
+    def test_abandon_text_input_discards_buffer(self) -> None:
+        self.cursor.begin_text_input()
+        for ch in "draft":
+            self.cursor.insert_character(ch)
+        result = self.cursor.abandon_text_input()
+        assert result is not None
+        self.assertEqual(self.cursor.focus.mode, FocusMode.NOTEBOOK)
+        self.assertEqual(self.cursor.focus.cell_id, self.cells[1].cell_id)
+        self.assertEqual(self.cursor.focus.input_buffer, "")
+        self.assertEqual(len(self.session.cells), 3)
+
+    def test_abandon_text_input_is_noop_outside_text_input(self) -> None:
+        self.assertIsNone(self.cursor.abandon_text_input())
+        self.cursor.enter_input_mode()
+        self.assertIsNone(self.cursor.abandon_text_input())
+
+    def test_submit_text_input_is_noop_outside_text_input(self) -> None:
+        self.assertIsNone(self.cursor.submit_text_input())
+
+    def test_text_input_on_empty_session_appends(self) -> None:
+        bus = EventBus()
+        session = Session.new()
+        cursor = NotebookCursor(session, bus)
+        cursor.begin_text_input()
+        for ch in "first prose":
+            cursor.insert_character(ch)
+        cell = cursor.submit_text_input()
+        assert cell is not None
+        self.assertEqual(session.cells[-1].cell_id, cell.cell_id)
+        self.assertEqual(cell.text, "first prose")
+
+    def test_history_and_submit_ignored_in_text_input(self) -> None:
+        self.session.command_history.extend(["old"])
+        self.cursor.begin_text_input()
+        # history_previous is INPUT-only; should do nothing in TEXT_INPUT.
+        self.assertFalse(self.cursor.history_previous())
+        self.assertEqual(self.cursor.focus.input_buffer, "")
+        # submit() (the command submit) should also no-op in TEXT_INPUT.
+        self.assertIsNone(self.cursor.submit())
+        self.assertEqual(self.cursor.focus.mode, FocusMode.TEXT_INPUT)
+
+    def test_anchor_removed_mid_edit_falls_back_to_append(self) -> None:
+        self.cursor.begin_text_input()
+        anchor_id = self.cursor.focus.cell_id
+        assert anchor_id is not None
+        # Delete the anchor from the session while we're still composing.
+        self.session.remove_cell(anchor_id)
+        for ch in "tail":
+            self.cursor.insert_character(ch)
+        cell = self.cursor.submit_text_input()
+        assert cell is not None
+        # Appended to the end since anchor is gone.
+        self.assertEqual(self.session.cells[-1].cell_id, cell.cell_id)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Completes the last pending slice of F27: the NOTEBOOK `i` keybinding for in-place text insertion. Pressing `i` drops the cursor into a dedicated `FocusMode.TEXT_INPUT` where every printable keystroke goes into a fresh prose buffer. Enter splices a new `CellKind.TEXT` cell immediately after the anchor cell and returns to NOTEBOOK; Escape abandons without creating anything.

- `FocusMode.TEXT_INPUT` joins NOTEBOOK / INPUT / OUTPUT / SETTINGS. The existing `cell_id` field acts as the anchor for insertion; empty-session and anchor-removed-mid-edit cases fall back to appending.
- `NotebookCursor.begin_text_input` / `submit_text_input` / `abandon_text_input`:
  - `begin_text_input` is legal only from NOTEBOOK; silent no-op elsewhere.
  - `submit_text_input` treats empty / whitespace-only buffers as abandonment (no cell created) so accidentally hitting Enter never leaves a ghost cell. Non-empty buffers land as a new TEXT cell right after the anchor and publish `CELL_CREATED`.
  - `abandon_text_input` returns to NOTEBOOK with the buffer discarded.
- Buffer-manipulation helpers (`insert_character`, `backspace`, `cursor_*`, `delete_*`) now accept either INPUT or TEXT_INPUT via a single `_composing_text` predicate, so the existing readline-style keymap (Backspace/Delete, Left/Right, Home/End, Ctrl+A/E/W/U/K) is shared with no duplication. History recall (`history_previous` / `history_next`), `submit()`, and `set_input_buffer` stay INPUT-only on purpose.
- `InputRouter`: NOTEBOOK gains `i` → `begin_text_input`. A new `FocusMode.TEXT_INPUT` binding table mirrors INPUT for editing but binds Enter → `submit_text_input` and Escape → `abandon_text_input`. Printable-character dispatch in `handle_key` now reaches TEXT_INPUT alongside INPUT. `submit_text_input`'s ACTION_INVOKED payload reports `created: bool` and, when a cell was created, `cell_id` + `text` so observers can narrate the insertion.
- HELP_LINES gains a TEXT row; `docs/BINDINGS.md` regenerated.

## What this means for F27

F27's original sketch had three remaining items after the F61 heading work: text cells, parent-scope nav, and scope selection / fold. Text cells themselves landed in PR #87; parent-scope nav in PR #88; `asat/outline.py` + `select_heading_scope` in PR #89. This PR delivers the in-place text-insertion UX that pairs with the `:text` meta-command, so the `FEATURE_REQUESTS.md` F27 status now reads **Shipped**. (Fold / collapse, the separate `z` slice, is PR #90 on its own branch.)

## Test plan

- [x] `pytest tests/test_notebook.py::TextInputModeTests` — 13 pass (begin / submit / abandon semantics, buffer editing, empty-buffer handling, FOCUS_CHANGED + CELL_CREATED payloads, empty-session append, anchor-removed-mid-edit fallback, history/submit INPUT-only)
- [x] `pytest tests/test_input_router.py::TextInputBindingTests` — 9 pass (NOTEBOOK `i` enters TEXT_INPUT, printables insert, Enter submits, Escape abandons, readline keys work, empty submit creates nothing, ACTION_INVOKED payload shape, `i` is inert in INPUT, default binding map sanity)
- [x] Full suite: `pytest -q` — 1188 pass (was 1166).

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS