### PR TITLE
PR 1: pluggable TTS registry and POSIX live audio sink

### DIFF
--- a/asat/__main__.py
+++ b/asat/__main__.py
@@ -1,17 +1,22 @@
 """Launch the Accessible Spatial Audio Terminal from the command line.
 
 `python -m asat` assembles an Application with sensible defaults and
-drives it from real keystrokes. By default the session narrates to an
-in-memory sink (so every platform starts cleanly) and prints a small
-text trace to stdout (so sighted viewers and anyone debugging can
-follow along). The flags below switch the two knobs:
+drives it from real keystrokes. When stdout is a terminal and no
+audio flag was passed, the CLI opts into live audio automatically
+(``--live``) so a first-time user hears speech without reading any
+docs. Piped / captured output keeps the safe ``MemorySink`` default.
 
-    --live          play audio through the platform live-speaker sink
-                    (Windows today; POSIX falls back to MemorySink
-                    with an explanation).
-    --wav-dir DIR   additionally write every rendered buffer to a
-                    numbered WAV file under DIR.
-    --quiet         suppress the text trace on stdout (audio only).
+    --live / --no-live  explicitly opt into or out of the platform
+                        live-speaker sink. ``--live`` on a host with
+                        no backend falls back to MemorySink with an
+                        explanation.
+    --wav-dir DIR       additionally write every rendered buffer to a
+                        numbered WAV file under DIR.
+    --tts ENGINE_ID     pick a TTS backend by id (``pyttsx3``,
+                        ``espeak-ng``, ``say``, ``tone``). Omit to
+                        auto-select the first available engine in
+                        priority order. Tests pin ``tone``.
+    --quiet             suppress the text trace on stdout (audio only).
 
 Exit with the `:quit` meta-command (type `:quit` in INPUT mode then
 press Enter) or by sending EOF (Ctrl+D on POSIX, Ctrl+Z then Enter on
@@ -45,6 +50,8 @@ from asat.self_check import run_self_check
 from asat.session import Session
 from asat.shell_backend import shell_backend_or_none
 from asat.sound_bank import SoundBank
+from asat.tts import TTSEngine
+from asat.tts_registry import TTSEngineRegistry, TTSRegistryError
 from asat.workspace import (
     WORKSPACE_NOTEBOOK_EXTENSION,
     Workspace,
@@ -74,20 +81,32 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             )
             return 2
         args.session = workspace_session_path
-    sink = _make_sink(args.wav_dir, args.live, quiet=args.quiet)
+    registry = TTSEngineRegistry.default()
+    try:
+        tts_engine = _resolve_tts(registry, args.tts)
+    except TTSRegistryError as exc:
+        print(f"[asat] --tts: {exc}", file=sys.stderr)
+        return 2
+    effective_live = _resolve_live_preference(args)
+    sink = _make_sink(args.wav_dir, effective_live, quiet=args.quiet)
     if (
         not args.quiet
         and not args.check
         and not args.live
         and args.wav_dir is None
+        and isinstance(sink, MemorySink)
     ):
         # Tell first-time users why they are hearing silence without
-        # forcing them to read the docs. Suppressed once any audio
-        # destination is requested explicitly, and when --check is
+        # forcing them to read the docs. Suppressed when --live was
+        # requested (the `--live unavailable` line already explained
+        # why audio isn't reaching speakers) or when --check is
         # printing its own diagnostic report.
         print(
             "[asat] audio is going to the in-memory sink. Pass --live "
-            "(Windows) or --wav-dir DIR to hear or capture it.",
+            "or --wav-dir DIR to hear or capture it. "
+            "On Linux install a player (apt install pulseaudio-utils OR "
+            "alsa-utils) and a TTS engine (pip install pyttsx3 OR "
+            "apt install espeak-ng).",
             file=sys.stderr,
         )
     try:
@@ -129,6 +148,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         runner=runner,
         async_execution=async_execution,
         workspace=workspace,
+        tts=tts_engine,
     )
     if args.check:
         exit_code = _print_check_report(app, args)
@@ -160,11 +180,13 @@ def _print_check_report(app: Application, args: argparse.Namespace) -> int:
     case where the user passed ``--live`` but the host had no live
     backend, when ``MemorySink`` ends up active despite the request).
     """
+    tts_name = type(app.sound_engine.tts).__name__
     lines = [
         f"asat {__version__}",
         f"platform       {sys.platform}",
         f"stdin tty      {sys.stdin.isatty()}",
         f"sink           {type(app.sink).__name__}",
+        f"tts            {tts_name}",
         f"runner         {type(app.runner).__name__}",
         f"bank path      {args.bank if args.bank is not None else '(built-in default)'}",
         f"session path   {args.session if args.session is not None else '(fresh)'}",
@@ -235,9 +257,30 @@ def _parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
         "--live",
         action="store_true",
         help=(
-            "Play audio on the platform live-speaker sink. Today this "
-            "means winsound on Windows; POSIX hosts fall back to the "
-            "in-memory sink with an explanation."
+            "Play audio on the platform live-speaker sink. Windows "
+            "uses winsound; Linux/macOS use whichever of paplay, aplay, "
+            "or afplay is installed. On a TTY this is the default — "
+            "pass --no-live to override."
+        ),
+    )
+    parser.add_argument(
+        "--no-live",
+        action="store_true",
+        help=(
+            "Opt out of the auto-live default when stdout is a TTY. "
+            "The session falls back to MemorySink (or --wav-dir DIR "
+            "if provided) so audio never reaches the speakers."
+        ),
+    )
+    parser.add_argument(
+        "--tts",
+        default=None,
+        help=(
+            "Pick the TTS engine by id (pyttsx3, espeak-ng, say, tone). "
+            "Omit to auto-select the first available engine in priority "
+            "order. Tests and scripts that need deterministic output "
+            "pass `--tts tone`. Respect ASAT_TTS_ENGINE env var as the "
+            "user-level default when this flag is absent."
         ),
     )
     parser.add_argument(
@@ -509,6 +552,44 @@ def _load_session(path: Optional[Path]) -> Optional[Session]:
     if path is None or not path.exists():
         return None
     return Session.load(path)
+
+
+def _resolve_tts(
+    registry: TTSEngineRegistry, engine_id: Optional[str]
+) -> TTSEngine:
+    """Build a TTS engine: explicit id if given, else registry default.
+
+    Explicit flags always win over auto-selection so scripts and
+    tests can pin a deterministic engine. A missing engine id raises
+    ``TTSRegistryError`` which the caller surfaces as a friendly exit.
+    """
+    if engine_id is None:
+        return registry.select_default()
+    return registry.build(engine_id)
+
+
+def _resolve_live_preference(args: argparse.Namespace) -> bool:
+    """Decide whether the sink-builder should try the live backend.
+
+    Explicit wins over implicit: ``--no-live`` always returns False,
+    ``--live`` always returns True. Otherwise auto-live engages when
+    we are attached to a real TTY and the user hasn't asked for
+    ``--quiet`` or ``--check``. Piped / captured runs keep the safe
+    MemorySink default, which is what the test suite relies on.
+    """
+    if args.no_live:
+        return False
+    if args.live:
+        return True
+    if args.quiet or args.check or args.wav_dir is not None:
+        return False
+    # Gate on stdout.isatty so pytest runs with mocked StringIO stdout
+    # stay deterministic. An interactive shell passes this check and
+    # gets live audio out of the box.
+    try:
+        return bool(sys.stdout.isatty())
+    except (AttributeError, ValueError):
+        return False
 
 
 def _make_sink(

--- a/asat/app.py
+++ b/asat/app.py
@@ -54,6 +54,8 @@ from asat.session import Session
 from asat.settings_controller import SettingsController
 from asat.sound_bank import SoundBank
 from asat.sound_engine import SoundEngine
+from asat.tts import TTSEngine
+from asat.tts_registry import TTSEngineRegistry, TTSRegistryError
 from asat.streaming_monitor import StreamingMonitor
 from asat.terminal import TerminalRenderer
 from asat.workspace import Workspace, WorkspaceError
@@ -111,6 +113,15 @@ class Application:
     def __post_init__(self) -> None:
         """Wire subscriptions that need the fully-constructed Application."""
         self._pending: list[str] = []
+        # Per-session TTS state for the `:tts` meta-command. The
+        # registry is the single source of engine-id → factory; the
+        # id + parameter dict remember how the current engine was
+        # built so `:tts set` can rebuild with one parameter changed.
+        self._tts_registry: TTSEngineRegistry = TTSEngineRegistry.default()
+        self._tts_engine_id: Optional[str] = _classify_tts_engine(
+            self.sound_engine.tts, self._tts_registry
+        )
+        self._tts_parameters: dict[str, object] = {}
         self.bus.subscribe(EventType.ACTION_INVOKED, self._on_action_invoked)
         self.bus.subscribe(EventType.FOCUS_CHANGED, self._on_focus_changed)
 
@@ -136,6 +147,7 @@ class Application:
         runner: Optional[object] = None,
         async_execution: bool = False,
         workspace: Optional[Workspace] = None,
+        tts: Optional[TTSEngine] = None,
     ) -> "Application":
         """Wire every collaborator with sensible defaults.
 
@@ -242,7 +254,7 @@ class Application:
             output_recorder=recorder,
         )
         resolved_sink: AudioSink = sink if sink is not None else MemorySink()
-        sound_engine = SoundEngine(bus, resolved_bank, resolved_sink)
+        sound_engine = SoundEngine(bus, resolved_bank, resolved_sink, tts=tts)
         # PromptContext must subscribe BEFORE TerminalRenderer so that
         # when the user transitions into INPUT mode post-command, the
         # PROMPT_REFRESH event it publishes reaches the renderer in
@@ -491,6 +503,8 @@ class Application:
                 self._set_verbosity(str(payload.get("meta_argument", "")))
             elif meta == "reload-bank":
                 self._reload_bank()
+            elif meta == "tts":
+                self._handle_meta_tts(str(payload.get("meta_argument", "")))
 
     def _cancel_running_command(self) -> None:
         """`cancel_command` (Ctrl+C in INPUT mode) — F1.
@@ -802,3 +816,174 @@ class Application:
             },
             source="app",
         )
+
+    def _handle_meta_tts(self, argument: str) -> None:
+        """Dispatch `:tts list | use <id> | set <param> <value>`.
+
+        The command is the user-facing knob for the pluggable TTS
+        registry (``asat/tts_registry.py``). All three sub-commands
+        narrate their outcome via ``HELP_REQUESTED`` so the user
+        always hears confirmation — no silent state changes.
+        """
+        parts = argument.strip().split(maxsplit=2)
+        subcommand = parts[0].lower() if parts else "list"
+        if subcommand == "list":
+            description = self._tts_registry.describe()
+            active = self._tts_engine_id or "(custom)"
+            params_summary = (
+                ", ".join(f"{k}={v}" for k, v in self._tts_parameters.items())
+                or "(defaults)"
+            )
+            lines = [
+                f"active: {active}; parameters: {params_summary}",
+                *description.splitlines(),
+                "Use `:tts use <id>` to switch, `:tts set <param> <value>` to tune.",
+            ]
+            publish_event(
+                self.bus,
+                EventType.HELP_REQUESTED,
+                {"lines": lines},
+                source="app",
+            )
+            return
+        if subcommand == "use":
+            if len(parts) < 2:
+                publish_event(
+                    self.bus,
+                    EventType.HELP_REQUESTED,
+                    {
+                        "lines": [
+                            "`:tts use <id>` — id is one of: "
+                            f"{', '.join(self._tts_registry.available_ids()) or 'none'}."
+                        ]
+                    },
+                    source="app",
+                )
+                return
+            engine_id = parts[1]
+            try:
+                engine = self._tts_registry.build(engine_id)
+            except TTSRegistryError as exc:
+                publish_event(
+                    self.bus,
+                    EventType.HELP_REQUESTED,
+                    {"lines": [f"`:tts use {engine_id}` — {exc}"]},
+                    source="app",
+                )
+                return
+            self.sound_engine.set_tts(engine)
+            self._tts_engine_id = engine_id
+            self._tts_parameters = {}
+            publish_event(
+                self.bus,
+                EventType.HELP_REQUESTED,
+                {"lines": [f"TTS engine switched to {engine_id}."]},
+                source="app",
+            )
+            return
+        if subcommand == "set":
+            if self._tts_engine_id is None:
+                publish_event(
+                    self.bus,
+                    EventType.HELP_REQUESTED,
+                    {
+                        "lines": [
+                            "`:tts set` is only available for registry-managed "
+                            "engines. Run `:tts use <id>` first."
+                        ]
+                    },
+                    source="app",
+                )
+                return
+            if len(parts) < 3:
+                publish_event(
+                    self.bus,
+                    EventType.HELP_REQUESTED,
+                    {"lines": ["`:tts set <param> <value>` — see `:tts list` for params."]},
+                    source="app",
+                )
+                return
+            param_name, raw_value = parts[1], parts[2]
+            new_params = dict(self._tts_parameters)
+            new_params[param_name] = _coerce_tts_value(raw_value)
+            try:
+                engine = self._tts_registry.build(
+                    self._tts_engine_id, parameters=new_params
+                )
+            except TTSRegistryError as exc:
+                publish_event(
+                    self.bus,
+                    EventType.HELP_REQUESTED,
+                    {"lines": [f"`:tts set` failed: {exc}"]},
+                    source="app",
+                )
+                return
+            self.sound_engine.set_tts(engine)
+            self._tts_parameters = new_params
+            publish_event(
+                self.bus,
+                EventType.HELP_REQUESTED,
+                {
+                    "lines": [
+                        f"TTS {self._tts_engine_id}: set {param_name}={raw_value}."
+                    ]
+                },
+                source="app",
+            )
+            return
+        publish_event(
+            self.bus,
+            EventType.HELP_REQUESTED,
+            {
+                "lines": [
+                    f"`:tts {subcommand}` is not recognised. Try `:tts list`, "
+                    "`:tts use <id>`, or `:tts set <param> <value>`."
+                ]
+            },
+            source="app",
+        )
+
+
+_TTS_CLASS_TO_ID: dict[str, str] = {
+    "ToneTTSEngine": "tone",
+    "Pyttsx3Engine": "pyttsx3",
+    "EspeakNgEngine": "espeak-ng",
+    "SystemSayEngine": "say",
+}
+
+
+def _classify_tts_engine(
+    engine: TTSEngine, registry: TTSEngineRegistry
+) -> Optional[str]:
+    """Map a live TTS engine object back to its registry id, or None.
+
+    Used to seed ``Application._tts_engine_id`` so the ``:tts`` meta-
+    command knows which knob to rebuild when the user says ``:tts set
+    <param> <value>``. Returns ``None`` for engines not registered
+    (custom plug-ins passed via ``Application.build(tts=...)``), which
+    makes ``:tts set`` refuse cleanly.
+    """
+    engine_id = _TTS_CLASS_TO_ID.get(type(engine).__name__)
+    if engine_id is None or not registry.has(engine_id):
+        return None
+    return engine_id
+
+
+def _coerce_tts_value(raw: str) -> object:
+    """Parse a ``:tts set`` value into the most natural Python type.
+
+    Integers and floats parse via ``int``/``float``; everything else
+    stays a string. Keeping the grammar this small matches the rest
+    of ASAT's meta-commands — there is no need for a full expression
+    parser when ``voice en-us`` and ``rate 220`` cover the useful
+    knobs.
+    """
+    try:
+        return int(raw)
+    except ValueError:
+        pass
+    try:
+        return float(raw)
+    except ValueError:
+        pass
+    return raw

--- a/asat/audio_sink.py
+++ b/asat/audio_sink.py
@@ -16,24 +16,32 @@ The shipping sinks are:
   debugging and for listening to the output when no audio device is
   available.
 - WindowsLiveAudioSink plays buffers through `winsound.PlaySound` on
-  Windows. It is the first sink that produces actual audio on real
-  speakers; call `pick_live_sink()` from the CLI to select it on the
-  target platform.
+  Windows.
+- PosixLiveAudioSink pipes each buffer as a WAV blob to a local
+  audio player binary — ``aplay`` / ``paplay`` on Linux, ``afplay``
+  on macOS — so ``pick_live_sink()`` returns a working live sink on
+  every supported platform (F6). Install one of the binaries with
+  your package manager; PulseAudio, PipeWire, and ALSA are all fine
+  so long as a command-line player is on PATH.
 
-POSIX live playback is still on the roadmap (see
-docs/FEATURE_REQUESTS.md, F6). `pick_live_sink()` raises
-`LiveAudioUnavailable` on non-Windows hosts so the CLI can fall back
-to `MemorySink` with a clear message.
+``pick_live_sink()`` tries these in order: Windows first (existing
+``winsound`` path), then ``PosixLiveAudioSink.probe()`` which picks
+whichever POSIX player is available. Only when none are installable
+does it raise ``LiveAudioUnavailable`` — and even then the CLI falls
+back to ``MemorySink`` with a message that names the player binaries
+to install.
 """
 
 from __future__ import annotations
 
 import io
+import shutil
 import struct
+import subprocess
 import sys
 import wave
 from pathlib import Path
-from typing import Protocol
+from typing import Optional, Protocol
 
 from asat.audio import AudioBuffer, ChannelLayout
 
@@ -204,17 +212,170 @@ class WindowsLiveAudioSink:
         self._winsound.PlaySound(None, self._winsound.SND_PURGE)
 
 
+class PosixLiveAudioSink:
+    """Play each buffer through a local audio player subprocess.
+
+    POSIX live audio (F6) routes through whatever command-line player
+    the host has installed. The sink probes a small list in priority
+    order and uses the first one it finds:
+
+    * ``paplay`` — PulseAudio / PipeWire's native player, common on
+      modern Linux desktops.
+    * ``aplay`` — ALSA's stock player, present on essentially every
+      Linux install.
+    * ``afplay`` — macOS' built-in player (requires Darwin).
+
+    ``play`` spawns one ``Popen`` per buffer, streams the in-memory
+    WAV bytes in on stdin, and does NOT block: audio mixes on the
+    player's own thread. A new ``play`` call kills the previous
+    process so the latest cue always wins over a still-going clip —
+    the same "latest event wins" semantics as the Windows sink.
+
+    Use :class:`pick_live_sink` to construct one; direct construction
+    raises :class:`LiveAudioUnavailable` when no player is present so
+    callers never end up with a zombie sink that silently drops every
+    buffer.
+    """
+
+    DEFAULT_CANDIDATES: tuple[tuple[str, tuple[str, ...]], ...] = (
+        ("paplay", ()),
+        ("aplay", ("-q",)),  # -q silences aplay's per-buffer header chatter.
+        ("afplay", ()),
+    )
+
+    def __init__(
+        self,
+        *,
+        binary: Optional[str] = None,
+        extra_args: tuple[str, ...] = (),
+        candidates: Optional[tuple[tuple[str, tuple[str, ...]], ...]] = None,
+    ) -> None:
+        """Probe for a player binary and remember how to invoke it.
+
+        ``binary`` pins a specific player (e.g. ``"aplay"``); when
+        ``None`` we walk ``candidates`` (default: pulse, alsa, afplay)
+        and pick the first one on PATH. Raises ``LiveAudioUnavailable``
+        when nothing matches so the CLI can fall back cleanly.
+        """
+        probe_list = candidates if candidates is not None else self.DEFAULT_CANDIDATES
+        if binary is not None:
+            resolved = shutil.which(binary)
+            if resolved is None:
+                raise LiveAudioUnavailable(
+                    f"requested live-audio binary {binary!r} is not on PATH"
+                )
+            self._binary = resolved
+            self._args: tuple[str, ...] = extra_args
+        else:
+            pick = self._probe(probe_list)
+            if pick is None:
+                names = ", ".join(name for name, _ in probe_list)
+                raise LiveAudioUnavailable(
+                    f"no POSIX live-audio player found on PATH "
+                    f"(tried: {names}). Install one via your package manager — "
+                    "for example `apt install pulseaudio-utils` or "
+                    "`apt install alsa-utils` on Linux."
+                )
+            self._binary, player_args = pick
+            self._args = tuple(player_args) + tuple(extra_args)
+        self._process: Optional[subprocess.Popen[bytes]] = None
+
+    @classmethod
+    def probe(cls) -> bool:
+        """Return True iff at least one supported player is installed."""
+        return cls._probe(cls.DEFAULT_CANDIDATES) is not None
+
+    @staticmethod
+    def _probe(
+        candidates: tuple[tuple[str, tuple[str, ...]], ...]
+    ) -> Optional[tuple[str, tuple[str, ...]]]:
+        """Return the first (resolved-path, args) pair whose binary is on PATH."""
+        for name, args in candidates:
+            resolved = shutil.which(name)
+            if resolved is not None:
+                return resolved, args
+        return None
+
+    @property
+    def binary(self) -> str:
+        """Path of the player binary this sink uses (for diagnostics)."""
+        return self._binary
+
+    def play(self, buffer: AudioBuffer) -> None:
+        """Render the buffer to WAV bytes and pipe them to the player."""
+        self._kill_previous()
+        data = buffer_to_wav_bytes(buffer)
+        try:
+            self._process = subprocess.Popen(
+                [self._binary, *self._args],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except FileNotFoundError as exc:
+            # The probe passed at __init__ but the binary vanished —
+            # surface as a recoverable unavailability so the caller
+            # can choose to swap the sink rather than crash.
+            raise LiveAudioUnavailable(
+                f"{self._binary} disappeared between probe and play"
+            ) from exc
+        if self._process.stdin is None:
+            return  # pragma: no cover - Popen with stdin=PIPE always sets it.
+        try:
+            self._process.stdin.write(data)
+            self._process.stdin.close()
+        except (BrokenPipeError, ValueError):
+            # The player exited before we could finish writing — this
+            # can happen when the next `play()` kills the prior one
+            # mid-write, or when the device is suddenly unavailable.
+            # Neither case is fatal: the subsequent play() will try
+            # fresh.
+            pass
+
+    def close(self) -> None:
+        """Stop any in-flight clip so the process exits quietly."""
+        self._kill_previous()
+
+    def _kill_previous(self) -> None:
+        """Terminate the previous player process if one is still running."""
+        prev = self._process
+        if prev is None:
+            return
+        if prev.poll() is None:
+            try:
+                prev.terminate()
+            except ProcessLookupError:
+                pass
+            try:
+                prev.wait(timeout=0.2)
+            except subprocess.TimeoutExpired:
+                try:
+                    prev.kill()
+                except ProcessLookupError:
+                    pass
+                try:
+                    prev.wait(timeout=0.2)
+                except subprocess.TimeoutExpired:
+                    pass
+        self._process = None
+
+
 def pick_live_sink() -> AudioSink:
     """Return the live sink that fits this host, or raise.
 
-    Today only Windows has a live implementation. POSIX hosts get a
-    clear `LiveAudioUnavailable` so the CLI can tell the user what to
-    do (use `--wav-dir DIR` today; live POSIX is F6).
+    Prefers the platform-native backend: ``WindowsLiveAudioSink`` on
+    Windows (winsound), ``PosixLiveAudioSink`` on POSIX hosts that
+    have a command-line player installed. Raises
+    ``LiveAudioUnavailable`` only when none of those are usable so
+    the CLI can drop down to ``MemorySink`` with a clear hint about
+    which binary to install (F6).
     """
     if sys.platform.startswith("win"):
         return WindowsLiveAudioSink()
-    raise LiveAudioUnavailable(
-        "no live audio sink is available on this platform yet — "
-        "use --wav-dir DIR to capture the output as WAV files "
-        "(tracked as FEATURE_REQUESTS.md F6)",
-    )
+    try:
+        return PosixLiveAudioSink()
+    except LiveAudioUnavailable as exc:
+        raise LiveAudioUnavailable(
+            "no live audio sink is available on this host — "
+            f"{exc} Alternative: capture audio with --wav-dir DIR.",
+        ) from exc

--- a/asat/input_router.py
+++ b/asat/input_router.py
@@ -303,6 +303,7 @@ META_COMMANDS: tuple[str, ...] = (
     "jump",
     "verbosity",
     "reload-bank",
+    "tts",
 )
 
 # "Ambient" meta-commands do their job without taking focus away from
@@ -331,6 +332,7 @@ AMBIENT_META_COMMANDS: frozenset[str] = frozenset(
         "bookmarks",
         "verbosity",
         "reload-bank",
+        "tts",
     }
 )
 
@@ -363,7 +365,7 @@ HELP_LINES: tuple[str, ...] = (
     "           Ctrl+Z undo, Ctrl+Y redo edits in the order you made them.",
     "           Ctrl+R resets to defaults at cursor scope (Enter confirms, Escape cancels).",
     "Menu:      F2 (or Ctrl+.) opens contextual actions; Up/Down walk, Enter invokes, Escape closes.",
-    "Meta:      :help, :settings, :save, :quit, :delete, :duplicate, :pwd, :state, :commands, :reset, :welcome, :repeat, :heading, :text, :toc, :workspace, :list-notebooks, :new-notebook, :bindings, :bookmark, :unbookmark, :bookmarks, :jump, :verbosity, :reload-bank.",
+    "Meta:      :help, :settings, :save, :quit, :delete, :duplicate, :pwd, :state, :commands, :reset, :welcome, :repeat, :heading, :text, :toc, :workspace, :list-notebooks, :new-notebook, :bindings, :bookmark, :unbookmark, :bookmarks, :jump, :verbosity, :reload-bank, :tts.",
     "           `:help topics` lists focused tours; `:help <topic>` narrates one (navigation, cells, settings, audio, search, meta).",
     "           `:welcome` replays the first-run tour; `:repeat` (or Ctrl+R in notebook/input) re-speaks the last narration.",
     "           Meta-commands are case-insensitive and accept a trailing argument.",

--- a/asat/self_check.py
+++ b/asat/self_check.py
@@ -43,6 +43,7 @@ from asat.events import EventType
 from asat.sample_payloads import SAMPLE_PAYLOADS
 from asat.sound_bank import SoundBank
 from asat.sound_engine import SoundEngine
+from asat.tts_registry import TTSEngineRegistry
 
 
 @dataclass(frozen=True)
@@ -62,6 +63,7 @@ class SelfCheckStep:
 
 _SLUGS = (
     "bank_validates",
+    "tts_engine",
     "voices_speak",
     "event_cues",
     "live_playback",
@@ -90,6 +92,7 @@ def run_self_check(
     steps: list[SelfCheckStep] = []
     steps.append(_step_bank_validates(bank))
     bank_ok = steps[-1].status == "pass"
+    steps.append(_step_tts_engine())
     # Only build the engine when the bank is structurally sound;
     # ``SoundEngine.__init__`` calls ``bank.validate()`` and would
     # raise on a broken bank, taking the diagnostic down with it.
@@ -141,6 +144,34 @@ def _step_bank_validates(bank: SoundBank) -> SelfCheckStep:
             f"{len(bank.voices)} voices, {len(bank.sounds)} sounds, "
             f"{len(bank.bindings)} bindings"
         ),
+    )
+
+
+def _step_tts_engine() -> SelfCheckStep:
+    """Step 2: report which TTS engine the default registry resolves to.
+
+    The resolved engine is the one ``__main__`` will instantiate when
+    the user runs ``python -m asat`` with no ``--tts`` flag. Reporting
+    it here tells the operator at a glance whether they are about to
+    hear pyttsx3, espeak-ng, macOS ``say``, or the deterministic tone
+    fallback — a frequent source of "why is my audio beeping?"
+    confusion. ``tone`` is always available, so this step cannot
+    ``fail`` in practice; it is effectively an informational probe.
+    """
+    registry = TTSEngineRegistry.default()
+    available = registry.available_ids()
+    resolved = registry.resolve_default_id()
+    if not available:
+        return SelfCheckStep(
+            slug="tts_engine",
+            status="fail",
+            detail="no TTS engines available (expected at least 'tone')",
+        )
+    alternatives = ", ".join(available)
+    return SelfCheckStep(
+        slug="tts_engine",
+        status="pass",
+        detail=f"resolved engine: {resolved}; available: {alternatives}",
     )
 
 

--- a/asat/sound_engine.py
+++ b/asat/sound_engine.py
@@ -159,6 +159,26 @@ class SoundEngine:
         return self._bank
 
     @property
+    def tts(self) -> TTSEngine:
+        """Return the TTS engine the pipeline is currently rendering through.
+
+        Exposed so ``--check`` and the ``:tts`` meta-command can name
+        the live backend. Read-only — swap engines by constructing a
+        new ``SoundEngine`` or via ``set_tts`` (below).
+        """
+        return self._tts
+
+    def set_tts(self, tts: TTSEngine) -> None:
+        """Hot-swap the TTS engine live (``:tts use <id>``).
+
+        The new engine takes effect on the next ``AUDIO_SPOKEN``
+        render. Existing narration history is kept so
+        ``repeat_last_narration`` still works and will replay through
+        the *new* engine's voice.
+        """
+        self._tts = tts
+
+    @property
     def narration_history(self) -> tuple[NarrationHistoryEntry, ...]:
         """Return the ring buffer of recently-spoken phrases (oldest first)."""
         return tuple(self._history)

--- a/asat/tts.py
+++ b/asat/tts.py
@@ -1,38 +1,59 @@
 """Text-to-speech abstraction.
 
-TTSEngine is a Protocol that any speech backend can satisfy. This keeps
-the rest of the audio pipeline independent of which engine synthesizes
-the words. ASAT ships with one reference implementation:
+``TTSEngine`` is a Protocol that any speech backend can satisfy. This
+keeps the rest of the audio pipeline independent of which engine
+synthesizes the words. ASAT ships with several reference
+implementations so users can pick the one that best suits their
+platform and accessibility preferences:
 
-- ToneTTSEngine produces a deterministic tonal waveform. It is not
-  intelligible speech; it is a pipeline placeholder that proves the
-  flow end to end without depending on a real speech synthesizer.
-  Tests use it because it generates the same output for the same
-  input every time, and a real TTS engine would need audio hardware
-  and a system speech library.
+- ``ToneTTSEngine`` — deterministic tonal waveform, never intelligible
+  speech. It is the floor of the engine stack: it runs in headless
+  CI, has no dependencies, and is what tests rely on because its
+  output is reproducible bit-for-bit.
+- ``Pyttsx3Engine`` — wraps the ``pyttsx3`` Python package which
+  routes to Windows SAPI5, macOS NSSpeechSynthesizer, and Linux
+  ``espeak-ng``. One code path delivers real speech on every platform
+  ASAT supports.
+- ``EspeakNgEngine`` — direct subprocess to ``espeak-ng --stdout``.
+  Linux-first and also available on macOS (``brew install espeak-ng``)
+  and Windows builds. Exposes more low-level parameters (voice,
+  speed, pitch, amplitude) than the pyttsx3 wrapper.
+- ``SystemSayEngine`` — subprocess to macOS' ``say(1)`` binary.
+  Native high-quality voices without a Python dep.
 
-Future backends (espeak-ng via subprocess, pyttsx3, SAPI, AVFoundation)
-drop in under the same protocol. Per the project's security posture,
-any new backend should be a thin, auditable wrapper around a
-well-known local engine, never a network call.
+Each real engine exposes an ``available()`` classmethod so the
+``TTSEngineRegistry`` (``asat/tts_registry.py``) can pick the best
+installed backend without actually constructing one. Every subprocess
+call is short and synchronous; per the project's security posture
+each backend is a thin, auditable wrapper around a well-known local
+engine, never a network call.
 """
 
 from __future__ import annotations
 
+import io
 import math
-from typing import Protocol
+import os
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+import wave
+from pathlib import Path
+from typing import Optional, Protocol
 
-from asat.audio import AudioBuffer, DEFAULT_SAMPLE_RATE, VoiceProfile
+from asat.audio import AudioBuffer, ChannelLayout, DEFAULT_SAMPLE_RATE, VoiceProfile
 
 
 class TTSEngine(Protocol):
     """Synthesizes a line of text into a mono AudioBuffer.
 
-    Single in-tree implementation today: ``ToneTTSEngine`` (a
-    deterministic tone-based stand-in). Pluggable: real TTS
-    backends (Windows SAPI, macOS NSSpeechSynthesizer, Piper, etc.)
-    can be swapped in via ``SoundEngine(..., tts=...)`` without
-    touching the rest of the pipeline.
+    In-tree implementations: ``ToneTTSEngine`` (deterministic tonal
+    stand-in, zero deps), ``Pyttsx3Engine``, ``EspeakNgEngine``,
+    ``SystemSayEngine`` (real speech via pluggable backends). Pluggable:
+    a new backend drops in by implementing ``synthesize`` and is
+    registered via ``TTSEngineRegistry``.
     """
 
     def synthesize(self, text: str, voice: VoiceProfile) -> AudioBuffer:
@@ -104,3 +125,360 @@ class ToneTTSEngine:
         gain = max(0.0, min(1.0, volume))
         for n in range(sample_count):
             waveform.append(gain * math.sin(angular * n))
+
+
+class TTSEngineError(RuntimeError):
+    """Raised when a real TTS backend fails to render the given text.
+
+    Callers higher up (``SoundEngine._synthesise_speech``) catch this
+    and fall back to a short silence so one bad utterance never kills
+    the pipeline.
+    """
+
+
+class Pyttsx3Engine:
+    """Cross-platform TTS via the ``pyttsx3`` Python package.
+
+    ``pyttsx3`` is an adapter that routes to SAPI5 on Windows,
+    NSSpeechSynthesizer on macOS, and ``espeak-ng`` on Linux. A single
+    code path therefore delivers real speech on every platform ASAT
+    supports, which is what the user asked for ("consistent across
+    Windows and POSIX, customisable").
+
+    Each ``synthesize`` call:
+
+    1. Writes the utterance to a temporary WAV file via
+       ``engine.save_to_file(text, path); engine.runAndWait()``.
+    2. Reads the WAV back, downmixes to mono, resamples if needed, and
+       returns an ``AudioBuffer`` at ``self.sample_rate``.
+
+    The temp file is cleaned up immediately after read so even a very
+    chatty session does not litter ``/tmp``.
+    """
+
+    def __init__(
+        self,
+        sample_rate: int = DEFAULT_SAMPLE_RATE,
+        *,
+        voice: Optional[str] = None,
+        rate: Optional[float] = None,
+        volume: Optional[float] = None,
+        pitch: Optional[float] = None,
+    ) -> None:
+        """Create an engine handle; defer backend init to first synth."""
+        self._sample_rate = sample_rate
+        self._voice = voice
+        self._rate = rate
+        self._volume = volume
+        self._pitch = pitch
+        self._backend: Optional[object] = None
+
+    @classmethod
+    def available(cls) -> bool:
+        """Return True when the ``pyttsx3`` package is importable."""
+        try:
+            import pyttsx3  # noqa: F401
+        except Exception:
+            return False
+        return True
+
+    @property
+    def sample_rate(self) -> int:
+        """Return the sample rate of the buffers this engine emits."""
+        return self._sample_rate
+
+    def synthesize(self, text: str, voice: VoiceProfile) -> AudioBuffer:
+        """Render ``text`` through pyttsx3 and return a mono AudioBuffer."""
+        if not text or text.isspace():
+            return AudioBuffer.silence(0.05, self._sample_rate)
+        backend = self._ensure_backend()
+        self._apply_voice(backend, voice)
+        with tempfile.NamedTemporaryFile(
+            suffix=".wav", delete=False
+        ) as tmp:
+            tmp_path = Path(tmp.name)
+        try:
+            try:
+                backend.save_to_file(text, str(tmp_path))
+                backend.runAndWait()
+            except Exception as exc:
+                raise TTSEngineError(
+                    f"pyttsx3 synthesis failed: {exc}"
+                ) from exc
+            if not tmp_path.exists() or tmp_path.stat().st_size == 0:
+                raise TTSEngineError(
+                    "pyttsx3 produced no audio; the backend may be missing a voice"
+                )
+            return _wav_to_mono_buffer(tmp_path.read_bytes(), self._sample_rate)
+        finally:
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+
+    def _ensure_backend(self) -> object:
+        """Import and construct the underlying pyttsx3 engine once."""
+        if self._backend is not None:
+            return self._backend
+        try:
+            import pyttsx3
+        except Exception as exc:  # pragma: no cover - tested via available()
+            raise TTSEngineError(
+                "pyttsx3 is not installed. Run `pip install pyttsx3`."
+            ) from exc
+        try:
+            self._backend = pyttsx3.init()
+        except Exception as exc:
+            raise TTSEngineError(
+                f"pyttsx3 failed to initialise a backend: {exc}"
+            ) from exc
+        return self._backend
+
+    def _apply_voice(self, backend: object, voice: VoiceProfile) -> None:
+        """Push the VoiceProfile + user overrides into the pyttsx3 engine."""
+        if self._voice is not None:
+            _try_set(backend, "voice", self._voice)
+        rate = self._rate if self._rate is not None else voice.speed_wpm
+        _try_set(backend, "rate", float(rate))
+        volume = self._volume if self._volume is not None else voice.volume
+        _try_set(backend, "volume", max(0.0, min(1.0, float(volume))))
+        if self._pitch is not None:
+            _try_set(backend, "pitch", float(self._pitch))
+
+
+class EspeakNgEngine:
+    """Direct ``espeak-ng --stdout`` subprocess adapter.
+
+    ``espeak-ng`` is the most portable open-source speech synthesizer
+    and ships in every major Linux distribution's package manager,
+    plus ``brew install espeak-ng`` on macOS and downloadable Windows
+    builds. Exposing it directly (rather than via ``pyttsx3``) gives
+    access to the full parameter surface: ``-v`` (voice), ``-s``
+    (speed), ``-p`` (pitch), ``-a`` (amplitude).
+    """
+
+    DEFAULT_VOICE = "en-us"
+
+    def __init__(
+        self,
+        sample_rate: int = DEFAULT_SAMPLE_RATE,
+        *,
+        voice: Optional[str] = None,
+        speed: Optional[float] = None,
+        pitch: Optional[float] = None,
+        amplitude: Optional[float] = None,
+        binary: Optional[str] = None,
+    ) -> None:
+        """Remember override defaults; binary defaults to ``espeak-ng``."""
+        self._sample_rate = sample_rate
+        self._voice = voice or self.DEFAULT_VOICE
+        self._speed = speed
+        self._pitch = pitch
+        self._amplitude = amplitude
+        self._binary = binary or "espeak-ng"
+
+    @classmethod
+    def available(cls) -> bool:
+        """Return True iff ``espeak-ng`` is on PATH."""
+        return shutil.which("espeak-ng") is not None
+
+    @property
+    def sample_rate(self) -> int:
+        """Return the sample rate of buffers produced by this engine."""
+        return self._sample_rate
+
+    def synthesize(self, text: str, voice: VoiceProfile) -> AudioBuffer:
+        """Shell out to ``espeak-ng`` and decode its WAV stdout."""
+        if not text or text.isspace():
+            return AudioBuffer.silence(0.05, self._sample_rate)
+        cmd = [self._binary, "--stdout", "-v", self._voice]
+        speed = self._speed if self._speed is not None else voice.speed_wpm
+        cmd.extend(["-s", str(int(speed))])
+        if self._pitch is not None:
+            cmd.extend(["-p", str(int(self._pitch))])
+        amplitude = (
+            self._amplitude
+            if self._amplitude is not None
+            else int(max(0.0, min(1.0, voice.volume)) * 200)
+        )
+        cmd.extend(["-a", str(int(amplitude))])
+        # `--` terminates option processing so stray leading hyphens in
+        # the text are not parsed as flags.
+        cmd.extend(["--", text])
+        try:
+            result = subprocess.run(
+                cmd,
+                check=True,
+                capture_output=True,
+                timeout=10.0,
+            )
+        except FileNotFoundError as exc:
+            raise TTSEngineError(
+                f"espeak-ng binary not found on PATH: {exc}"
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise TTSEngineError("espeak-ng timed out after 10s") from exc
+        except subprocess.CalledProcessError as exc:
+            raise TTSEngineError(
+                f"espeak-ng failed (exit {exc.returncode}): "
+                f"{exc.stderr.decode(errors='replace').strip()}"
+            ) from exc
+        if not result.stdout:
+            raise TTSEngineError("espeak-ng returned empty WAV on stdout")
+        return _wav_to_mono_buffer(result.stdout, self._sample_rate)
+
+
+class SystemSayEngine:
+    """macOS ``say`` binary adapter.
+
+    ``say`` ships on every macOS host and exposes the system-wide
+    voice library (``say -v '?'`` to list). Emits LEI16 PCM at 22050
+    Hz into a WAV wrapper so the resulting file drops into the same
+    decode path as pyttsx3 and espeak-ng.
+    """
+
+    DATA_FORMAT = "LEI16@22050"
+
+    def __init__(
+        self,
+        sample_rate: int = DEFAULT_SAMPLE_RATE,
+        *,
+        voice: Optional[str] = None,
+        rate: Optional[float] = None,
+        binary: Optional[str] = None,
+    ) -> None:
+        """Remember override defaults; binary defaults to ``say``."""
+        self._sample_rate = sample_rate
+        self._voice = voice
+        self._rate = rate
+        self._binary = binary or "say"
+
+    @classmethod
+    def available(cls) -> bool:
+        """Return True on Darwin with ``say`` on PATH."""
+        if not sys.platform.startswith("darwin"):
+            return False
+        return shutil.which("say") is not None
+
+    @property
+    def sample_rate(self) -> int:
+        """Return the sample rate of buffers produced by this engine."""
+        return self._sample_rate
+
+    def synthesize(self, text: str, voice: VoiceProfile) -> AudioBuffer:
+        """Invoke ``say`` to write a temp WAV, then decode it."""
+        if not text or text.isspace():
+            return AudioBuffer.silence(0.05, self._sample_rate)
+        with tempfile.NamedTemporaryFile(
+            suffix=".wav", delete=False
+        ) as tmp:
+            tmp_path = Path(tmp.name)
+        try:
+            cmd = [self._binary, "--data-format", self.DATA_FORMAT, "-o", str(tmp_path)]
+            if self._voice is not None:
+                cmd.extend(["-v", self._voice])
+            rate = self._rate if self._rate is not None else voice.speed_wpm
+            cmd.extend(["-r", str(int(rate)), "--", text])
+            try:
+                subprocess.run(
+                    cmd,
+                    check=True,
+                    capture_output=True,
+                    timeout=10.0,
+                )
+            except FileNotFoundError as exc:
+                raise TTSEngineError(
+                    f"say binary not found on PATH: {exc}"
+                ) from exc
+            except subprocess.TimeoutExpired as exc:
+                raise TTSEngineError("say timed out after 10s") from exc
+            except subprocess.CalledProcessError as exc:
+                raise TTSEngineError(
+                    f"say failed (exit {exc.returncode}): "
+                    f"{exc.stderr.decode(errors='replace').strip()}"
+                ) from exc
+            if not tmp_path.exists() or tmp_path.stat().st_size == 0:
+                raise TTSEngineError("say produced no audio")
+            return _wav_to_mono_buffer(tmp_path.read_bytes(), self._sample_rate)
+        finally:
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+
+
+def _try_set(backend: object, key: str, value: object) -> None:
+    """Call ``backend.setProperty(key, value)`` but tolerate old stubs."""
+    try:
+        backend.setProperty(key, value)  # type: ignore[attr-defined]
+    except Exception:
+        # Some pyttsx3 drivers (Linux espeak) raise on unknown keys.
+        # Swallow so a missing pitch control doesn't take narration down.
+        pass
+
+
+def _wav_to_mono_buffer(blob: bytes, target_sample_rate: int) -> AudioBuffer:
+    """Decode a PCM16 WAV blob into a mono AudioBuffer at the target rate.
+
+    Downmixes stereo to mono by averaging the two channels, then
+    linearly resamples to ``target_sample_rate`` if the source rate
+    differs. Any decode error raises ``TTSEngineError`` so callers can
+    fall back gracefully.
+    """
+    try:
+        with wave.open(io.BytesIO(blob), "rb") as reader:
+            channels = reader.getnchannels()
+            sample_rate = reader.getframerate()
+            sample_width = reader.getsampwidth()
+            frame_count = reader.getnframes()
+            raw = reader.readframes(frame_count)
+    except (wave.Error, EOFError) as exc:
+        raise TTSEngineError(f"could not decode WAV output: {exc}") from exc
+    if sample_width != 2:
+        raise TTSEngineError(
+            f"expected 16-bit PCM, got {sample_width * 8}-bit samples"
+        )
+    total_samples = len(raw) // sample_width
+    ints = struct.unpack("<" + "h" * total_samples, raw)
+    floats = tuple(value / 32768.0 for value in ints)
+    if channels == 1:
+        mono = floats
+    elif channels == 2:
+        mono = tuple(
+            (floats[i] + floats[i + 1]) / 2.0 for i in range(0, len(floats), 2)
+        )
+    else:
+        # N-channel is unusual in TTS output but easy to average.
+        mono = tuple(
+            sum(floats[i : i + channels]) / channels
+            for i in range(0, len(floats), channels)
+        )
+    if sample_rate == target_sample_rate or sample_rate <= 0:
+        return AudioBuffer.mono(mono, target_sample_rate)
+    return AudioBuffer.mono(_linear_resample(mono, sample_rate, target_sample_rate), target_sample_rate)
+
+
+def _linear_resample(
+    samples: tuple[float, ...],
+    source_rate: int,
+    target_rate: int,
+) -> tuple[float, ...]:
+    """Linearly resample a mono sample tuple from ``source_rate`` to ``target_rate``.
+
+    Linear interpolation is crude but dependency-free and perfectly
+    adequate for speech narration, where sub-sample phase fidelity
+    does not affect intelligibility. Real-time production use with
+    high-quality music would want a polyphase filter; speech does not.
+    """
+    if not samples or source_rate == target_rate:
+        return tuple(samples)
+    ratio = source_rate / float(target_rate)
+    out_len = max(1, int(round(len(samples) * target_rate / source_rate)))
+    out: list[float] = []
+    for index in range(out_len):
+        position = index * ratio
+        lower = int(position)
+        upper = min(lower + 1, len(samples) - 1)
+        frac = position - lower
+        out.append(samples[lower] * (1.0 - frac) + samples[upper] * frac)
+    return tuple(out)

--- a/asat/tts_registry.py
+++ b/asat/tts_registry.py
@@ -1,0 +1,291 @@
+"""Pluggable TTS engine registry.
+
+The audio pipeline treats every TTS backend as an anonymous
+`TTSEngine` protocol implementer; the registry is what actually lets
+the user pick between them at runtime. Each engine ships with a stable
+``id`` (e.g. ``"pyttsx3"``, ``"espeak-ng"``, ``"say"``, ``"tone"``), a
+``describe`` string, and a ``Spec`` that carries:
+
+- a ``factory`` that builds a live ``TTSEngine`` for the given sample
+  rate and parameter dict,
+- an ``available()`` callable that reports whether the backend can run
+  on this host (binary installed, Python dep importable, etc.), and
+- a ``parameters`` tuple describing the tunable knobs so the
+  ``:tts set`` meta-command can list them and the settings editor can
+  expose them.
+
+The default priority order when nothing is configured is the one that
+matches the user's own directive: "whichever works consistently across
+Windows and POSIX, with the most customisation". That means
+``Pyttsx3Engine`` first (one Python dep, routes to SAPI5 / espeak /
+NSSpeechSynthesizer automatically), ``EspeakNgEngine`` second (Linux
+native), ``SystemSayEngine`` third (macOS native), and finally the
+deterministic ``ToneTTSEngine`` fallback that always works — even in
+headless CI with no audio libraries installed.
+
+Calling ``select_default()`` walks the priority list top-to-bottom and
+returns the first engine whose ``available()`` says yes. The function
+never raises — ``ToneTTSEngine`` is the last-resort floor.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+from asat.audio import DEFAULT_SAMPLE_RATE
+from asat.tts import (
+    EspeakNgEngine,
+    Pyttsx3Engine,
+    SystemSayEngine,
+    ToneTTSEngine,
+    TTSEngine,
+)
+
+
+@dataclass(frozen=True)
+class TTSParameter:
+    """One tunable knob on a TTS engine adapter.
+
+    ``name`` is the key the user types after ``:tts set`` (e.g.
+    ``rate``, ``voice``, ``pitch``, ``volume``). ``description`` is a
+    short blurb read aloud by ``:tts list`` / ``:tts set`` so the user
+    knows what the knob does without opening the docs.
+    """
+
+    name: str
+    description: str
+
+
+@dataclass(frozen=True)
+class TTSEngineSpec:
+    """Registry entry describing how to build and probe one engine."""
+
+    id: str
+    describe: str
+    factory: Callable[[int, dict[str, Any]], TTSEngine]
+    available: Callable[[], bool]
+    parameters: tuple[TTSParameter, ...] = field(default_factory=tuple)
+
+
+def _always_available() -> bool:
+    """Sentinel for engines that never fail to construct (the tone fallback)."""
+    return True
+
+
+DEFAULT_PRIORITY: tuple[str, ...] = (
+    "pyttsx3",
+    "espeak-ng",
+    "say",
+    "tone",
+)
+
+
+def _build_pyttsx3(sample_rate: int, params: dict[str, Any]) -> TTSEngine:
+    return Pyttsx3Engine(sample_rate=sample_rate, **_coerce(params))
+
+
+def _build_espeak_ng(sample_rate: int, params: dict[str, Any]) -> TTSEngine:
+    return EspeakNgEngine(sample_rate=sample_rate, **_coerce(params))
+
+
+def _build_system_say(sample_rate: int, params: dict[str, Any]) -> TTSEngine:
+    return SystemSayEngine(sample_rate=sample_rate, **_coerce(params))
+
+
+def _build_tone(sample_rate: int, params: dict[str, Any]) -> TTSEngine:
+    _ = params  # tone engine ignores every parameter by design.
+    return ToneTTSEngine(sample_rate=sample_rate)
+
+
+def _coerce(params: dict[str, Any]) -> dict[str, Any]:
+    """Drop ``None`` values so adapters rely on their defaults."""
+    return {k: v for k, v in params.items() if v is not None}
+
+
+_BUILTIN_SPECS: tuple[TTSEngineSpec, ...] = (
+    TTSEngineSpec(
+        id="pyttsx3",
+        describe=(
+            "pyttsx3 — cross-platform (Windows SAPI, macOS NSSpeechSynthesizer, "
+            "Linux espeak). Adjustable voice / rate / volume / pitch."
+        ),
+        factory=_build_pyttsx3,
+        available=Pyttsx3Engine.available,
+        parameters=(
+            TTSParameter("voice", "Backend voice id (platform-specific)."),
+            TTSParameter("rate", "Words per minute (default ~200)."),
+            TTSParameter("volume", "Linear gain in [0.0, 1.0]."),
+            TTSParameter("pitch", "Pitch multiplier (some backends ignore)."),
+        ),
+    ),
+    TTSEngineSpec(
+        id="espeak-ng",
+        describe=(
+            "espeak-ng — small, fast, ubiquitous on Linux. Works through a "
+            "subprocess pipe; highly configurable pitch / speed / amplitude."
+        ),
+        factory=_build_espeak_ng,
+        available=EspeakNgEngine.available,
+        parameters=(
+            TTSParameter("voice", "espeak-ng -v voice code, e.g. en-us, en-gb."),
+            TTSParameter("speed", "Words per minute (espeak -s, 80..500)."),
+            TTSParameter("pitch", "Pitch 0..99 (espeak -p, default 50)."),
+            TTSParameter("amplitude", "Amplitude 0..200 (espeak -a, default 100)."),
+        ),
+    ),
+    TTSEngineSpec(
+        id="say",
+        describe=(
+            "macOS say(1) — native high-quality voices. Requires Darwin. "
+            "Adjustable voice name and rate."
+        ),
+        factory=_build_system_say,
+        available=SystemSayEngine.available,
+        parameters=(
+            TTSParameter("voice", "say -v voice name, e.g. Samantha."),
+            TTSParameter("rate", "Words per minute (say -r)."),
+        ),
+    ),
+    TTSEngineSpec(
+        id="tone",
+        describe=(
+            "Deterministic tone stand-in. Always available. Used by tests "
+            "and as the last-resort fallback when no speech engine is "
+            "installed."
+        ),
+        factory=_build_tone,
+        available=_always_available,
+        parameters=(),
+    ),
+)
+
+
+class TTSRegistryError(ValueError):
+    """Raised when the registry is asked for an engine it does not know."""
+
+
+class TTSEngineRegistry:
+    """Pluggable catalogue of TTS engine adapters.
+
+    ``default()`` returns the registry preloaded with every in-tree
+    adapter and the standard priority order. Custom callers can build a
+    registry with a tailored list of specs and priority.
+    """
+
+    def __init__(
+        self,
+        specs: tuple[TTSEngineSpec, ...] = _BUILTIN_SPECS,
+        priority: tuple[str, ...] = DEFAULT_PRIORITY,
+    ) -> None:
+        """Wrap a pre-built tuple of specs plus a priority order."""
+        self._specs: dict[str, TTSEngineSpec] = {spec.id: spec for spec in specs}
+        self._priority = priority
+
+    @classmethod
+    def default(cls) -> "TTSEngineRegistry":
+        """Return a registry loaded with every in-tree adapter."""
+        return cls()
+
+    @property
+    def specs(self) -> tuple[TTSEngineSpec, ...]:
+        """Return every registered spec in declaration order."""
+        return tuple(self._specs[engine_id] for engine_id in self._priority if engine_id in self._specs)
+
+    @property
+    def priority(self) -> tuple[str, ...]:
+        """Return the id-order select_default() walks top-to-bottom."""
+        return self._priority
+
+    def has(self, engine_id: str) -> bool:
+        """Return True when an engine with that id is registered."""
+        return engine_id in self._specs
+
+    def spec_for(self, engine_id: str) -> TTSEngineSpec:
+        """Return the spec for an engine id or raise ``TTSRegistryError``."""
+        try:
+            return self._specs[engine_id]
+        except KeyError as exc:
+            raise TTSRegistryError(
+                f"unknown TTS engine id: {engine_id!r}. Known ids: "
+                f"{', '.join(sorted(self._specs))}"
+            ) from exc
+
+    def available_ids(self) -> tuple[str, ...]:
+        """Return the ids of every engine whose backend is usable here."""
+        return tuple(
+            engine_id
+            for engine_id in self._priority
+            if engine_id in self._specs and self._specs[engine_id].available()
+        )
+
+    def select_default(
+        self,
+        sample_rate: int = DEFAULT_SAMPLE_RATE,
+        *,
+        parameters: Optional[dict[str, Any]] = None,
+    ) -> TTSEngine:
+        """Build the first available engine in priority order.
+
+        Honours ``ASAT_TTS_ENGINE`` when set to a known id — the env
+        var is the lowest-friction override for users and for test
+        sandboxes that want to pin the backend without a config file.
+        """
+        override = os.environ.get("ASAT_TTS_ENGINE")
+        if override:
+            return self.build(override, sample_rate=sample_rate, parameters=parameters)
+        chosen_id = self.resolve_default_id()
+        return self.build(chosen_id, sample_rate=sample_rate, parameters=parameters)
+
+    def resolve_default_id(self) -> str:
+        """Return the engine id ``select_default`` would pick right now.
+
+        Useful for diagnostics (``--check``, the ``:tts list`` readout)
+        that want to name the engine without actually constructing one.
+        """
+        override = os.environ.get("ASAT_TTS_ENGINE")
+        if override and self.has(override):
+            return override
+        for engine_id in self._priority:
+            spec = self._specs.get(engine_id)
+            if spec is not None and spec.available():
+                return engine_id
+        # DEFAULT_PRIORITY ends in "tone" which is always available, so
+        # this fallthrough is only reachable with a pathological custom
+        # registry that dropped the tone adapter.
+        return next(iter(self._priority), "tone")
+
+    def build(
+        self,
+        engine_id: str,
+        *,
+        sample_rate: int = DEFAULT_SAMPLE_RATE,
+        parameters: Optional[dict[str, Any]] = None,
+    ) -> TTSEngine:
+        """Build an engine by id; raise ``TTSRegistryError`` when unknown."""
+        spec = self.spec_for(engine_id)
+        return spec.factory(sample_rate, dict(parameters or {}))
+
+    def describe(self, engine_id: Optional[str] = None) -> str:
+        """Return a one-line description of one engine or the full list.
+
+        With ``engine_id`` None, returns a newline-joined block starting
+        with the resolved default (so the reader hears what's live
+        before the alternatives). With an id, returns only that engine's
+        description prefixed with availability (``[available]`` /
+        ``[not installed]``).
+        """
+        if engine_id is not None:
+            spec = self.spec_for(engine_id)
+            marker = "available" if spec.available() else "not installed"
+            return f"[{marker}] {spec.id}: {spec.describe}"
+        default_id = self.resolve_default_id()
+        lines = [f"default: {default_id}"]
+        for engine_id in self._priority:
+            spec = self._specs.get(engine_id)
+            if spec is None:
+                continue
+            marker = "available" if spec.available() else "not installed"
+            lines.append(f"  [{marker}] {spec.id}: {spec.describe}")
+        return "\n".join(lines)

--- a/docs/AUDIO.md
+++ b/docs/AUDIO.md
@@ -26,6 +26,90 @@ see [EVENTS.md](EVENTS.md); for the overall module map see
 
 ---
 
+## Speech backends (TTS engines)
+
+ASAT ships a pluggable TTS registry (`asat/tts_registry.py`). Every
+backend implements the tiny `TTSEngine` protocol
+(`synthesize(text, voice) -> AudioBuffer`) and is registered as a
+`TTSEngineSpec` with a stable id, an `available()` probe, and the
+tunable parameters that `:tts set` exposes.
+
+On launch the registry walks this priority chain and picks the first
+one whose `available()` says yes:
+
+1. `pyttsx3` — cross-platform Python package that routes to SAPI5 on
+   Windows, NSSpeechSynthesizer on macOS, and espeak on Linux.
+2. `espeak-ng` — subprocess to the `espeak-ng` binary. Fastest, most
+   portable open-source synthesizer; exposes pitch / speed / amplitude.
+3. `say` — macOS' built-in `say` command (Darwin only).
+4. `tone` — deterministic tone stand-in. Always available; used by
+   tests and as the last-resort fallback when no speech engine is
+   installed.
+
+### Install recipes
+
+| Platform | Recommended install                                                                   |
+|----------|---------------------------------------------------------------------------------------|
+| Linux    | `sudo apt install espeak-ng pulseaudio-utils` *or* `pip install pyttsx3` + `alsa-utils` |
+| macOS    | Built-in `say` works out of the box. For espeak-ng: `brew install espeak-ng`.         |
+| Windows  | `pip install pyttsx3` (routes to SAPI5 via Windows' bundled voices).                  |
+
+If none are installed, ASAT falls back to the `tone` engine — you'll
+hear a beep pattern rather than speech — and the startup banner prints
+a one-line hint naming the packages to install.
+
+### Runtime controls
+
+| Command                           | Effect                                                     |
+|-----------------------------------|------------------------------------------------------------|
+| `python -m asat --tts ENGINE_ID`  | Pin a specific engine for this run.                        |
+| `ASAT_TTS_ENGINE=ID python -m asat` | Same, via environment (handy for fish / zsh aliases).     |
+| `:tts list` (inside the app)      | List installed engines and the current default.            |
+| `:tts use <id>`                   | Hot-swap the live engine without restarting.               |
+| `:tts set <param> <value>`        | Tune the current engine (e.g. `:tts set rate 180`).        |
+| `python -m asat --check`          | Print the resolved engine ids in the self-test report.     |
+
+Each adapter declares the params it accepts:
+
+| Engine     | Params                                                 |
+|------------|--------------------------------------------------------|
+| `pyttsx3`  | `voice` (backend voice id), `rate` (wpm), `volume` (0–1), `pitch` |
+| `espeak-ng`| `voice` (e.g. `en-us`), `speed` (wpm), `pitch` (0–99), `amplitude` (0–200) |
+| `say`      | `voice` (e.g. `Samantha`), `rate` (wpm)                |
+| `tone`     | — (parameter-free on purpose; used for determinism)    |
+
+Add your own by constructing a `TTSEngineSpec`, passing a custom
+`TTSEngineRegistry(specs=..., priority=...)` into `Application.build`,
+or subclassing `TTSEngine` and handing the instance directly to
+`SoundEngine(tts=...)`.
+
+---
+
+## Live audio sinks
+
+`AudioSink` is the last stage of the pipeline. Three shipping
+implementations:
+
+| Sink                    | When used                                            |
+|-------------------------|------------------------------------------------------|
+| `MemorySink`            | Default under `--check`, piped stdout, or when no live player is available. Buffers are kept in memory for tests and CI. |
+| `WavFileSink`           | Selected by `--wav-dir DIR`. Every buffer writes one `.wav` in the directory — handy for offline review. |
+| `WindowsLiveAudioSink`  | Windows default. Pipes PCM WAV into `winsound.PlaySound` on a background thread. |
+| `PosixLiveAudioSink`    | Linux / macOS default. Probes `paplay` → `aplay` → `afplay` in priority order and pipes WAV into the first one it finds. |
+
+`pick_live_sink()` (`asat/audio_sink.py`) returns the right sink for
+the host and raises `LiveAudioUnavailable` with an install hint when no
+live player exists. The CLI catches that and falls back to
+`MemorySink` with the hint printed to stderr — audio will be buffered
+silently, but the session still starts.
+
+On Linux the most common fix is `sudo apt install pulseaudio-utils`
+(for `paplay`) or `sudo apt install alsa-utils` (for `aplay`). On
+macOS `afplay` ships in the base system, so the POSIX sink works
+without any install.
+
+---
+
 ## Data model
 
 Everything persistable lives in `asat/sound_bank.py`. All four records

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -335,6 +335,9 @@ discarded and the cell is not modified.
 | `:jump <name>` | Move focus to the cell registered under `<name>` (F35). Leaves you in NOTEBOOK mode at the target cell. |
 | `:verbosity <level>` | Set the bank-wide narration ceiling to `minimal`, `normal`, or `verbose` (F31). Chattier tiers are silenced when the level drops. Plain `:verbosity` narrates the allowed values and the current setting. |
 | `:reload-bank` | Discard any in-memory bank edits and re-read the on-disk bank from the configured `bank_path` (F3). Refuses while the settings editor is open; emits a hint when no bank path is configured or the file fails to parse. |
+| `:tts list` | Describe every TTS engine registered in the pluggable registry (`docs/AUDIO.md`) and mark which ones are installed on this host. |
+| `:tts use <id>` | Hot-swap the live TTS engine (`pyttsx3`, `espeak-ng`, `say`, `tone`). The next narration is rendered through the new backend without restarting ASAT. |
+| `:tts set <param> <value>` | Tune the current engine — e.g. `:tts set rate 180` or `:tts set voice en-us`. Parameter names are engine-specific; `:tts list` enumerates them. |
 
 Meta-command names are **case-insensitive** — `:HELP`, `:Help`, and
 `:help` all do the same thing. A single trailing argument is

--- a/tests/test_posix_live_sink.py
+++ b/tests/test_posix_live_sink.py
@@ -1,0 +1,206 @@
+"""Unit tests for ``PosixLiveAudioSink`` (F6, PR 1).
+
+POSIX live audio is routed through whatever command-line player
+happens to be on PATH (paplay, aplay, afplay). These tests keep the
+spawning end of that pipe honest without ever launching a real player:
+
+* Probe logic: ``pick_live_sink`` / ``PosixLiveAudioSink()`` must pick
+  the first available candidate in priority order, and raise
+  ``LiveAudioUnavailable`` when none of them are present.
+* ``play`` must render the buffer to WAV bytes, spawn the player with
+  the right argv, and pipe the data in on stdin without blocking.
+* Consecutive ``play()`` calls must kill the prior process so the most
+  recent cue wins (matches the Windows sink's "latest event wins"
+  semantics).
+* ``close`` must terminate any still-running subprocess so tests and
+  real shutdowns are clean.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import unittest
+from unittest import mock
+
+from asat.audio import AudioBuffer
+from asat.audio_sink import (
+    LiveAudioUnavailable,
+    PosixLiveAudioSink,
+    pick_live_sink,
+)
+
+
+def _buffer() -> AudioBuffer:
+    """Return a tiny deterministic buffer for pipe-write assertions."""
+    return AudioBuffer.mono([0.1, -0.1, 0.2, -0.2], sample_rate=8000)
+
+
+class _RecordingStdin:
+    """BytesIO wrapper that retains written bytes after ``close()``.
+
+    The sink closes stdin right after writing, which collapses
+    ``io.BytesIO.getvalue()``. Snapshotting into ``written`` on close
+    keeps the payload visible to the test.
+    """
+
+    def __init__(self) -> None:
+        self._buf = io.BytesIO()
+        self.written = b""
+        self.closed = False
+
+    def write(self, data: bytes) -> int:
+        return self._buf.write(data)
+
+    def close(self) -> None:
+        self.written = self._buf.getvalue()
+        self._buf.close()
+        self.closed = True
+
+
+class _FakeProcess:
+    """Stand-in for ``subprocess.Popen`` that records what was written."""
+
+    def __init__(self, argv: list[str], **_kwargs: object) -> None:
+        self.argv = argv
+        self.stdin = _RecordingStdin()
+        self.terminated = False
+        self.killed = False
+        self.wait_called = 0
+        self._poll_result: "int | None" = None
+
+    def poll(self) -> "int | None":
+        return self._poll_result
+
+    def terminate(self) -> None:
+        self.terminated = True
+        # After terminate() the process is "still running" until wait()
+        # observes the exit — leave poll() returning None so the sink
+        # progresses into the wait branch.
+
+    def kill(self) -> None:
+        self.killed = True
+        self._poll_result = -9
+
+    def wait(self, timeout: float = 0.0) -> int:
+        self.wait_called += 1
+        self._poll_result = 0
+        return 0
+
+
+class ProbeTests(unittest.TestCase):
+
+    def test_picks_first_available_candidate(self) -> None:
+        def fake_which(name: str) -> "str | None":
+            return "/usr/bin/paplay" if name == "paplay" else None
+
+        with mock.patch("asat.audio_sink.shutil.which", side_effect=fake_which):
+            sink = PosixLiveAudioSink()
+        self.assertEqual(sink.binary, "/usr/bin/paplay")
+
+    def test_falls_through_to_aplay_when_pulse_absent(self) -> None:
+        def fake_which(name: str) -> "str | None":
+            return "/usr/bin/aplay" if name == "aplay" else None
+
+        with mock.patch("asat.audio_sink.shutil.which", side_effect=fake_which):
+            sink = PosixLiveAudioSink()
+        self.assertEqual(sink.binary, "/usr/bin/aplay")
+
+    def test_raises_when_nothing_installed(self) -> None:
+        with mock.patch("asat.audio_sink.shutil.which", return_value=None):
+            with self.assertRaises(LiveAudioUnavailable):
+                PosixLiveAudioSink()
+
+    def test_probe_classmethod_reports_availability(self) -> None:
+        with mock.patch("asat.audio_sink.shutil.which", return_value=None):
+            self.assertFalse(PosixLiveAudioSink.probe())
+        with mock.patch(
+            "asat.audio_sink.shutil.which",
+            lambda name: "/usr/bin/paplay" if name == "paplay" else None,
+        ):
+            self.assertTrue(PosixLiveAudioSink.probe())
+
+    def test_explicit_binary_is_validated(self) -> None:
+        with mock.patch("asat.audio_sink.shutil.which", return_value=None):
+            with self.assertRaises(LiveAudioUnavailable):
+                PosixLiveAudioSink(binary="aplay")
+
+
+class PlayTests(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.which_patcher = mock.patch(
+            "asat.audio_sink.shutil.which",
+            lambda name: f"/usr/bin/{name}" if name == "aplay" else None,
+        )
+        self.which_patcher.start()
+        self.addCleanup(self.which_patcher.stop)
+        self.processes: list[_FakeProcess] = []
+
+        def fake_popen(argv: list[str], **kwargs: object) -> _FakeProcess:
+            proc = _FakeProcess(argv, **kwargs)
+            self.processes.append(proc)
+            return proc
+
+        self.popen_patcher = mock.patch(
+            "asat.audio_sink.subprocess.Popen", side_effect=fake_popen
+        )
+        self.popen_patcher.start()
+        self.addCleanup(self.popen_patcher.stop)
+
+    def test_play_spawns_player_with_args(self) -> None:
+        sink = PosixLiveAudioSink()
+        sink.play(_buffer())
+        self.assertEqual(len(self.processes), 1)
+        proc = self.processes[0]
+        # aplay is invoked with `-q` to keep stderr quiet.
+        self.assertEqual(proc.argv[0], "/usr/bin/aplay")
+        self.assertIn("-q", proc.argv)
+
+    def test_play_writes_wav_bytes_to_stdin(self) -> None:
+        sink = PosixLiveAudioSink()
+        sink.play(_buffer())
+        written = self.processes[0].stdin.written
+        self.assertTrue(written.startswith(b"RIFF"))
+        self.assertIn(b"WAVE", written)
+        self.assertTrue(self.processes[0].stdin.closed)
+
+    def test_consecutive_plays_kill_previous_process(self) -> None:
+        sink = PosixLiveAudioSink()
+        sink.play(_buffer())
+        sink.play(_buffer())
+        self.assertEqual(len(self.processes), 2)
+        # The first process must have been terminated once the second
+        # play started — "latest cue wins".
+        self.assertTrue(self.processes[0].terminated)
+        self.assertFalse(self.processes[1].terminated)
+
+    def test_close_terminates_running_process(self) -> None:
+        sink = PosixLiveAudioSink()
+        sink.play(_buffer())
+        sink.close()
+        self.assertTrue(self.processes[0].terminated)
+
+    def test_close_on_idle_sink_is_safe(self) -> None:
+        sink = PosixLiveAudioSink()
+        # No play() yet — close() must be a no-op that does not spawn
+        # or touch any process.
+        sink.close()
+        self.assertEqual(self.processes, [])
+
+
+class PickLiveSinkTests(unittest.TestCase):
+
+    def test_raises_with_install_hint_on_posix_without_player(self) -> None:
+        with mock.patch.object(sys, "platform", "linux"), mock.patch(
+            "asat.audio_sink.shutil.which", return_value=None
+        ):
+            with self.assertRaises(LiveAudioUnavailable) as ctx:
+                pick_live_sink()
+        # The outer error must mention --wav-dir so the CLI user sees
+        # a usable fallback.
+        self.assertIn("--wav-dir", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_self_check.py
+++ b/tests/test_self_check.py
@@ -56,15 +56,24 @@ class RunSelfCheckHappyPathTests(unittest.TestCase):
         slugs = [payload["step"] for payload in captured]
         self.assertEqual(
             slugs,
-            ["bank_validates", "voices_speak", "event_cues", "live_playback"],
+            [
+                "bank_validates",
+                "tts_engine",
+                "voices_speak",
+                "event_cues",
+                "live_playback",
+            ],
         )
         for payload in captured:
             self.assertEqual(payload["status"], "pass", payload)
             self.assertIn("detail", payload)
-            self.assertEqual(payload["total"], 4)
-        self.assertEqual([payload["index"] for payload in captured], [1, 2, 3, 4])
+            self.assertEqual(payload["total"], 5)
+        self.assertEqual(
+            [payload["index"] for payload in captured], [1, 2, 3, 4, 5]
+        )
         text = stdout.getvalue()
         self.assertIn("PASS bank_validates", text)
+        self.assertIn("PASS tts_engine", text)
         self.assertIn("PASS voices_speak", text)
         self.assertIn("PASS event_cues", text)
         self.assertIn("PASS live_playback", text)
@@ -164,10 +173,10 @@ class SelfCheckEventEmissionTests(unittest.TestCase):
 
         run_self_check(default_sound_bank(), sink, bus=bus, stdout=io.StringIO())
 
-        self.assertEqual(len(captured), 4)
+        self.assertEqual(len(captured), 5)
         for index, payload in enumerate(captured, start=1):
             self.assertEqual(payload["index"], index)
-            self.assertEqual(payload["total"], 4)
+            self.assertEqual(payload["total"], 5)
             self.assertIn(payload["status"], {"pass", "fail", "skip"})
             self.assertIsInstance(payload["step"], str)
             self.assertIsInstance(payload["detail"], str)

--- a/tests/test_tts_registry.py
+++ b/tests/test_tts_registry.py
@@ -1,0 +1,202 @@
+"""Unit tests for the pluggable TTS engine registry (F28, PR 1).
+
+The registry is the user-facing surface for picking a TTS backend. The
+tests here pin down four behaviours:
+
+* ``available_ids()`` reflects live ``available()`` probes so tests can
+  predict exactly which engines show up on a given host.
+* The default priority order walks from the most-featureful backend
+  (``pyttsx3``) down to the deterministic ``tone`` fallback.
+* ``ASAT_TTS_ENGINE`` pins the selected engine without touching code.
+* ``build()`` forwards parameters to the adapter factory so
+  ``:tts set`` can re-build a live engine with one knob changed.
+
+The registry never actually talks to the backends during these tests;
+the heavy-weight synthesizers are covered elsewhere (or not at all —
+``pyttsx3`` / ``espeak-ng`` are integration-only).
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from asat.tts import ToneTTSEngine
+from asat.tts_registry import (
+    DEFAULT_PRIORITY,
+    TTSEngineRegistry,
+    TTSEngineSpec,
+    TTSParameter,
+    TTSRegistryError,
+)
+
+
+class RegistryDefaultsTests(unittest.TestCase):
+
+    def test_default_registry_exposes_all_builtin_ids(self) -> None:
+        registry = TTSEngineRegistry.default()
+        ids = {spec.id for spec in registry.specs}
+        self.assertEqual(ids, {"pyttsx3", "espeak-ng", "say", "tone"})
+
+    def test_default_priority_order_matches_plan(self) -> None:
+        registry = TTSEngineRegistry.default()
+        self.assertEqual(
+            registry.priority,
+            ("pyttsx3", "espeak-ng", "say", "tone"),
+        )
+        self.assertEqual(DEFAULT_PRIORITY, registry.priority)
+
+    def test_tone_is_always_available(self) -> None:
+        registry = TTSEngineRegistry.default()
+        # The tone engine has no external dependencies; it must always
+        # be reachable even in headless CI with no speech libs.
+        self.assertIn("tone", registry.available_ids())
+
+
+class ResolveDefaultIdTests(unittest.TestCase):
+
+    def _registry_with_availability(
+        self, **availability: bool
+    ) -> TTSEngineRegistry:
+        """Build a registry whose specs report fixed availability."""
+        specs = []
+        priority = []
+        for engine_id, available in availability.items():
+            specs.append(
+                TTSEngineSpec(
+                    id=engine_id,
+                    describe=f"{engine_id} test spec",
+                    factory=lambda sr, params, _id=engine_id: ToneTTSEngine(
+                        sample_rate=sr
+                    ),
+                    available=lambda _flag=available: _flag,
+                )
+            )
+            priority.append(engine_id)
+        return TTSEngineRegistry(specs=tuple(specs), priority=tuple(priority))
+
+    def test_picks_first_available_in_priority_order(self) -> None:
+        registry = self._registry_with_availability(
+            pyttsx3=False, espeak=True, tone=True
+        )
+        self.assertEqual(registry.resolve_default_id(), "espeak")
+
+    def test_skips_unavailable_engines(self) -> None:
+        registry = self._registry_with_availability(
+            pyttsx3=False, espeak=False, tone=True
+        )
+        self.assertEqual(registry.resolve_default_id(), "tone")
+
+    def test_env_var_override_pins_the_engine(self) -> None:
+        registry = self._registry_with_availability(
+            pyttsx3=True, espeak=True, tone=True
+        )
+        with mock.patch.dict(os.environ, {"ASAT_TTS_ENGINE": "tone"}):
+            self.assertEqual(registry.resolve_default_id(), "tone")
+
+    def test_env_var_override_is_ignored_when_unknown(self) -> None:
+        registry = self._registry_with_availability(
+            pyttsx3=True, espeak=True, tone=True
+        )
+        with mock.patch.dict(os.environ, {"ASAT_TTS_ENGINE": "bogus"}):
+            # Unknown override falls back to priority resolution so a
+            # typo in the env does not brick the session.
+            self.assertEqual(registry.resolve_default_id(), "pyttsx3")
+
+    def test_available_ids_filters_unavailable(self) -> None:
+        registry = self._registry_with_availability(
+            pyttsx3=False, espeak=True, tone=True
+        )
+        self.assertEqual(registry.available_ids(), ("espeak", "tone"))
+
+
+class BuildTests(unittest.TestCase):
+
+    def test_build_tone_returns_tone_engine(self) -> None:
+        registry = TTSEngineRegistry.default()
+        engine = registry.build("tone", sample_rate=22050)
+        self.assertIsInstance(engine, ToneTTSEngine)
+        self.assertEqual(engine.sample_rate, 22050)
+
+    def test_build_unknown_id_raises(self) -> None:
+        registry = TTSEngineRegistry.default()
+        with self.assertRaises(TTSRegistryError):
+            registry.build("does-not-exist")
+
+    def test_build_forwards_parameters_to_factory(self) -> None:
+        captured: dict[str, object] = {}
+
+        def factory(sample_rate: int, params: dict[str, object]) -> ToneTTSEngine:
+            captured["sample_rate"] = sample_rate
+            captured["params"] = params
+            return ToneTTSEngine(sample_rate=sample_rate)
+
+        spec = TTSEngineSpec(
+            id="probe",
+            describe="probe spec",
+            factory=factory,
+            available=lambda: True,
+            parameters=(TTSParameter("rate", "words per minute"),),
+        )
+        registry = TTSEngineRegistry(specs=(spec,), priority=("probe",))
+        registry.build("probe", sample_rate=16000, parameters={"rate": 180})
+        self.assertEqual(captured["sample_rate"], 16000)
+        self.assertEqual(captured["params"], {"rate": 180})
+
+    def test_select_default_honours_env_var(self) -> None:
+        registry = TTSEngineRegistry.default()
+        with mock.patch.dict(os.environ, {"ASAT_TTS_ENGINE": "tone"}):
+            engine = registry.select_default(sample_rate=8000)
+        self.assertIsInstance(engine, ToneTTSEngine)
+        self.assertEqual(engine.sample_rate, 8000)
+
+    def test_select_default_walks_priority_when_no_env(self) -> None:
+        # pyttsx3 and espeak-ng likely aren't installed in CI, so the
+        # tone fallback is the expected pick; either way the call must
+        # succeed because `tone` always reports available=True.
+        registry = TTSEngineRegistry.default()
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ASAT_TTS_ENGINE", None)
+            engine = registry.select_default()
+        # At minimum we got *some* TTS engine back.
+        self.assertTrue(hasattr(engine, "synthesize"))
+        self.assertTrue(hasattr(engine, "sample_rate"))
+
+
+class DescribeTests(unittest.TestCase):
+
+    def test_describe_all_lists_every_engine(self) -> None:
+        registry = TTSEngineRegistry.default()
+        text = registry.describe()
+        self.assertIn("default:", text)
+        for engine_id in ("pyttsx3", "espeak-ng", "say", "tone"):
+            self.assertIn(engine_id, text)
+
+    def test_describe_one_engine_includes_availability_marker(self) -> None:
+        registry = TTSEngineRegistry.default()
+        line = registry.describe("tone")
+        self.assertIn("available", line)
+        self.assertIn("tone", line)
+
+
+class SpecForTests(unittest.TestCase):
+
+    def test_spec_for_returns_registered_spec(self) -> None:
+        registry = TTSEngineRegistry.default()
+        spec = registry.spec_for("tone")
+        self.assertEqual(spec.id, "tone")
+
+    def test_spec_for_unknown_raises(self) -> None:
+        registry = TTSEngineRegistry.default()
+        with self.assertRaises(TTSRegistryError):
+            registry.spec_for("nope")
+
+    def test_has_reports_membership(self) -> None:
+        registry = TTSEngineRegistry.default()
+        self.assertTrue(registry.has("tone"))
+        self.assertFalse(registry.has("nope"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Real speech on every platform ASAT supports, not just Windows. A fresh Linux/macOS `python -m asat` now says "session ready" out loud when a speech backend is installed, instead of silently piling buffers into MemorySink.

- asat/tts.py: Pyttsx3Engine, EspeakNgEngine, SystemSayEngine adapters sharing a WAV-decode / mono-downmix / linear-resample path. ToneTTSEngine kept unchanged as the deterministic fallback tests depend on.
- asat/tts_registry.py: TTSEngineRegistry with a priority chain (pyttsx3 -> espeak-ng -> say -> tone) and ASAT_TTS_ENGINE override.
- asat/audio_sink.py: PosixLiveAudioSink probes paplay / aplay / afplay and pipes WAV into the first on PATH; pick_live_sink() returns it on POSIX hosts with a install-hint on miss.
- asat/__main__.py: --tts flag, --no-live opt-out, hint only fires when the user hasn't already asked for live audio, new tts line in --check.
- asat/app.py + asat/input_router.py: :tts list / use / set meta- command dispatches to the registry and hot-swaps via SoundEngine.set_tts.
- asat/self_check.py: new tts_engine step names the resolved backend in --check output.
- docs/AUDIO.md, docs/USER_MANUAL.md: install recipes per-OS and the new meta-command row.
- tests/test_tts_registry.py + tests/test_posix_live_sink.py: registry resolution, env-var override, Popen invocation, kill- previous semantics. Full suite 1217 passing.

https://claude.ai/code/session_01HZS4VXTWkCieZ8LS5KyoBS