### PR TITLE
PR 4: scripted first-run tour + :welcome replay

### DIFF
--- a/asat/app.py
+++ b/asat/app.py
@@ -405,14 +405,18 @@ class Application:
                 },
                 source="app",
             )
-        # F43: on the very first launch of ASAT, pre-populate the
-        # notebook's first cell with a known-good command so the
-        # newcomer can press Enter and immediately hear the
-        # submit → start → complete → exit-code arc. We check the
+        # F43 + PR 4: on the very first launch of ASAT, seed a
+        # three-cell demo notebook (H1 + H2 + command) so the outline
+        # pane renders on-screen, then run the scripted tour so a
+        # newcomer hears what each surface sounds like. We check the
         # sentinel BEFORE `onboarding.run()` flips it, then publish
-        # the tour step AFTER the welcome fires so the audio order
-        # is: welcome → "press Enter to run your first command".
-        from asat.onboarding import FIRST_RUN_TOUR_COMMAND
+        # the beats AFTER the welcome fires so the audio order is:
+        # welcome → "press Enter to run" → event log preview → log
+        # path → tour completed.
+        from asat.onboarding import (
+            FIRST_RUN_OUTLINE_HEADINGS,
+            FIRST_RUN_TOUR_COMMAND,
+        )
 
         first_run_tour = (
             seeded
@@ -420,11 +424,16 @@ class Application:
             and onboarding.is_first_run()
         )
         if seeded:
-            cursor.new_cell(FIRST_RUN_TOUR_COMMAND if first_run_tour else "")
+            if first_run_tour:
+                for level, title in FIRST_RUN_OUTLINE_HEADINGS:
+                    cursor.new_heading_cell(level, title)
+                cursor.new_cell(FIRST_RUN_TOUR_COMMAND)
+            else:
+                cursor.new_cell("")
         if onboarding is not None:
             onboarding.run()
         if first_run_tour and onboarding is not None:
-            onboarding.publish_tour_step()
+            app._run_scripted_tour(replay=False)
         return app
 
     def handle_key(self, key: Key) -> Optional[str]:
@@ -604,15 +613,43 @@ class Application:
         """Re-invoke the onboarding tour on `:welcome` (F44).
 
         Re-publishes `FIRST_RUN_DETECTED` with `replay=True` through
-        the same coordinator that ran at launch, so every existing
-        subscriber (audio bank, renderer) reacts just as it did on
-        the first boot. Silently no-ops when onboarding was
-        disabled (`--quiet`, `--check`) so the meta-command stays a
-        harmless tab-completion hit in those modes.
+        the same coordinator that ran at launch, then re-fires the
+        four PR 4 scripted beats so every existing subscriber (audio
+        bank, renderer) reacts just as it did on the first boot.
+        Seeding is NOT repeated — that would destroy the user's
+        notebook. Silently no-ops when onboarding was disabled
+        (`--quiet`, `--check`) so the meta-command stays a harmless
+        tab-completion hit in those modes.
         """
         if self.onboarding is None:
             return
         self.onboarding.run(force=True)
+        self._run_scripted_tour(replay=True)
+
+    def _run_scripted_tour(self, *, replay: bool) -> None:
+        """Publish the four post-welcome tour beats in order.
+
+        Called in two places: Application.build on a genuine first
+        run (`replay=False`) and `_replay_welcome` on `:welcome`
+        (`replay=True`). The `replay` flag is forwarded to every
+        beat so subscribers + tests can tell the two paths apart.
+
+        The event-log path beat carries the live path from
+        `event_log_file.current_path()` when a file logger is
+        attached; otherwise an empty string tells the narration to
+        skip the mention rather than invent a fictional path.
+        """
+        if self.onboarding is None:
+            return
+        self.onboarding.publish_tour_step(replay=replay)
+        self.onboarding.publish_event_log_preview_beat(replay=replay)
+        log_path = (
+            str(self.event_log_file.current_path())
+            if self.event_log_file is not None
+            else None
+        )
+        self.onboarding.publish_log_path_beat(log_path, replay=replay)
+        self.onboarding.publish_tour_completed_beat(replay=replay)
 
     def _save_session(self) -> None:
         """Persist the session to `session_path` if one was configured.

--- a/asat/default_bank.py
+++ b/asat/default_bank.py
@@ -111,6 +111,9 @@ COVERED_EVENT_TYPES: frozenset[EventType] = frozenset({
     EventType.EVENT_LOG_FOCUSED,
     EventType.EVENT_LOG_QUICK_EDIT_COMMITTED,
     EventType.EVENT_LOG_REPLAYED,
+    EventType.FIRST_RUN_TOUR_EVENT_LOG_PREVIEW,
+    EventType.FIRST_RUN_TOUR_LOG_PATH,
+    EventType.FIRST_RUN_TOUR_COMPLETED,
 })
 
 
@@ -901,6 +904,50 @@ def _default_bindings() -> tuple[EventBinding, ...]:
                 "Press Enter to run it."
             ),
             priority=245,
+        ),
+
+        # PR 4: third tour beat introduces the event log viewer. Narrates
+        # the Ctrl+E keystroke and the Up/Down/t affordances so a new
+        # user knows how to rewind narrations without hunting through
+        # the manual.
+        EventBinding(
+            id="first_run_tour_event_log_preview",
+            event_type=EventType.FIRST_RUN_TOUR_EVENT_LOG_PREVIEW.value,
+            voice_id="narrator",
+            say_template=(
+                "Press Control E any time to open the event log. "
+                "Up and Down walk recent events; press t to replay one."
+            ),
+            priority=240,
+        ),
+
+        # PR 4: fourth tour beat — tell the user where the grouped text
+        # log is being written so they can `tail -f` it. Empty path
+        # means no file logger is attached (no workspace, no explicit
+        # directory); the predicate drops the beat in that case so the
+        # narrator doesn't announce an empty string.
+        EventBinding(
+            id="first_run_tour_log_path",
+            event_type=EventType.FIRST_RUN_TOUR_LOG_PATH.value,
+            voice_id="narrator",
+            say_template=(
+                "The grouped event log is being written to {path}."
+            ),
+            predicate="path != ''",
+            priority=235,
+        ),
+
+        # PR 4: final tour beat — tour complete. Sends the user back to
+        # the prompt with one last instruction they can act on so the
+        # audio sequence ends on a callable cue.
+        EventBinding(
+            id="first_run_tour_completed",
+            event_type=EventType.FIRST_RUN_TOUR_COMPLETED.value,
+            voice_id="narrator",
+            say_template=(
+                "First-run tour complete. Press Enter to run your first command."
+            ),
+            priority=230,
         ),
 
         # Prompt context: when the user lands in INPUT mode AFTER a

--- a/asat/events.py
+++ b/asat/events.py
@@ -224,6 +224,10 @@ class EventType(str, Enum):
     EVENT_LOG_QUICK_EDIT_COMMITTED = "event_log.quick_edit.committed"
     EVENT_LOG_REPLAYED = "event_log.replayed"
 
+    FIRST_RUN_TOUR_EVENT_LOG_PREVIEW = "first_run.tour.event_log_preview"
+    FIRST_RUN_TOUR_LOG_PATH = "first_run.tour.log_path"
+    FIRST_RUN_TOUR_COMPLETED = "first_run.tour.completed"
+
 
 @dataclass(frozen=True)
 class Event:

--- a/asat/onboarding.py
+++ b/asat/onboarding.py
@@ -55,6 +55,42 @@ FIRST_RUN_TOUR_LINES: tuple[str, ...] = (
 )
 
 
+# PR 4: the scripted tour seeds a three-cell demo notebook so the
+# outline pane (PR 2) has something to render on first launch. Two
+# heading cells + one command cell produces a two-level hierarchy
+# the newcomer can scroll with `]` / `[`.
+FIRST_RUN_OUTLINE_HEADINGS: tuple[tuple[int, str], ...] = (
+    (1, "Welcome to ASAT"),
+    (2, "Your first command"),
+)
+
+
+# PR 4: the third tour beat introduces the event log viewer. We
+# narrate the keystroke and what pressing `t` does — enough that a
+# curious user can open it themselves without us thrashing focus.
+FIRST_RUN_EVENT_LOG_LINES: tuple[str, ...] = (
+    "Press Control E any time to open the event log.",
+    "Up and Down walk recent events; press t to replay one.",
+)
+
+
+# PR 4: fourth beat — announce the on-disk log file path so the user
+# knows where to `tail -f`. Empty lines signal "no workspace attached,
+# no file logger" so the renderer / audio bank can skip the beat.
+FIRST_RUN_LOG_PATH_LINES: tuple[str, ...] = (
+    "Every event is also written to a grouped text log on disk.",
+)
+
+
+# PR 4: final beat — tour complete; hand the user back a notebook
+# they can type into. Keeps "press Enter to run" as the final cue so
+# a first-time user has a next step they can't miss.
+FIRST_RUN_COMPLETED_LINES: tuple[str, ...] = (
+    "First-run tour complete.",
+    "Press Enter to run your first command, or colon h e l p for more.",
+)
+
+
 SILENT_SINK_HINT = (
     "[asat] First-run welcome is narrating into an in-memory sink so "
     "you will not hear it. Pass --live (Windows) or --wav-dir DIR to "
@@ -144,6 +180,7 @@ class OnboardingCoordinator:
         *,
         command: str = FIRST_RUN_TOUR_COMMAND,
         lines: Iterable[str] = FIRST_RUN_TOUR_LINES,
+        replay: bool = False,
     ) -> None:
         """Publish F43's `FIRST_RUN_TOUR_STEP` event.
 
@@ -152,11 +189,79 @@ class OnboardingCoordinator:
         Kept here (rather than inlined in Application) so the tour's
         command + narration live next to the rest of the onboarding
         vocabulary and can be reused by future tour variants.
+
+        `replay=True` marks the event so subscribers (and tests) can
+        distinguish a `:welcome` replay from the genuine first launch.
         """
         publish_event(
             self._bus,
             EventType.FIRST_RUN_TOUR_STEP,
-            {"command": command, "lines": list(lines)},
+            {"command": command, "lines": list(lines), "replay": replay},
+            source=self.SOURCE,
+        )
+
+    def publish_event_log_preview_beat(
+        self,
+        *,
+        lines: Iterable[str] = FIRST_RUN_EVENT_LOG_LINES,
+        replay: bool = False,
+    ) -> None:
+        """Third tour beat: introduce the event log viewer (F39).
+
+        Narrates the Ctrl+E keystroke and the Up/Down/`t` affordances
+        without actually pulsing the viewer — opening it under the user
+        mid-tour would thrash focus and leave them in EVENT_LOG mode
+        waiting for input. A narration-only beat teaches the keystroke
+        without hijacking the notebook.
+        """
+        publish_event(
+            self._bus,
+            EventType.FIRST_RUN_TOUR_EVENT_LOG_PREVIEW,
+            {"lines": list(lines), "replay": replay},
+            source=self.SOURCE,
+        )
+
+    def publish_log_path_beat(
+        self,
+        path: Optional[str] = None,
+        *,
+        lines: Iterable[str] = FIRST_RUN_LOG_PATH_LINES,
+        replay: bool = False,
+    ) -> None:
+        """Fourth tour beat: tell the user where the grouped log file lives.
+
+        ``path=None`` (or empty string) means no file logger is
+        attached — happens when ASAT was launched without a workspace
+        and without an explicit log directory. The event still fires
+        (so subscribers can notice the beat) but with an empty path
+        string so the default narration can skip the announcement.
+        """
+        publish_event(
+            self._bus,
+            EventType.FIRST_RUN_TOUR_LOG_PATH,
+            {
+                "path": path or "",
+                "lines": list(lines),
+                "replay": replay,
+            },
+            source=self.SOURCE,
+        )
+
+    def publish_tour_completed_beat(
+        self,
+        *,
+        lines: Iterable[str] = FIRST_RUN_COMPLETED_LINES,
+        replay: bool = False,
+    ) -> None:
+        """Final tour beat: tour complete, return the user to the prompt.
+
+        Fires exactly once per run. Tests assert on the terminator so
+        fixtures can wait for the tour to finish without sleeping.
+        """
+        publish_event(
+            self._bus,
+            EventType.FIRST_RUN_TOUR_COMPLETED,
+            {"lines": list(lines), "replay": replay},
             source=self.SOURCE,
         )
 

--- a/asat/sample_payloads.py
+++ b/asat/sample_payloads.py
@@ -243,4 +243,25 @@ SAMPLE_PAYLOADS: dict[EventType, dict[str, object]] = {
         "binding_id": "command_completed",
         "narration": "command completed, exit 0",
     },
+    EventType.FIRST_RUN_TOUR_EVENT_LOG_PREVIEW: {
+        "lines": [
+            "Press Control E any time to open the event log.",
+            "Up and Down walk recent events; press t to replay one.",
+        ],
+        "replay": False,
+    },
+    EventType.FIRST_RUN_TOUR_LOG_PATH: {
+        "path": "/tmp/proj/.asat/log/events-2026-04-20.log",
+        "lines": [
+            "Every event is also written to a grouped text log on disk.",
+        ],
+        "replay": False,
+    },
+    EventType.FIRST_RUN_TOUR_COMPLETED: {
+        "lines": [
+            "First-run tour complete.",
+            "Press Enter to run your first command, or colon h e l p for more.",
+        ],
+        "replay": False,
+    },
 }

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -341,10 +341,13 @@ Producer: `asat.onboarding.OnboardingCoordinator` (`source="onboarding"`).
 file) when ASAT launches for the first time, and again on demand via
 the `:welcome` meta-command with `replay=True`.
 
-| EventType              | Payload keys                                         |
-|------------------------|------------------------------------------------------|
-| `FIRST_RUN_DETECTED`   | `lines`, `sentinel_path`, `replay`                   |
-| `FIRST_RUN_TOUR_STEP`  | `command`, `lines`                                   |
+| EventType                           | Payload keys                                         |
+|-------------------------------------|------------------------------------------------------|
+| `FIRST_RUN_DETECTED`                | `lines`, `sentinel_path`, `replay`                   |
+| `FIRST_RUN_TOUR_STEP`               | `command`, `lines`, `replay`                         |
+| `FIRST_RUN_TOUR_EVENT_LOG_PREVIEW`  | `lines`, `replay`                                    |
+| `FIRST_RUN_TOUR_LOG_PATH`           | `path`, `lines`, `replay`                            |
+| `FIRST_RUN_TOUR_COMPLETED`          | `lines`, `replay`                                    |
 
 `replay` is `True` when the event is a `:welcome` re-invocation and
 `False` on the genuine first run; a binding that wants to sound
@@ -354,6 +357,19 @@ different on replay can key off it.
 `FIRST_RUN_DETECTED` on a first launch. `command` is the pre-populated
 first-cell command (default `echo hello, ASAT`); `lines` is a short
 spoken prompt telling the user Enter runs it and Escape clears it.
+
+The PR 4 scripted tour adds three post-welcome beats that fire in
+order: `FIRST_RUN_TOUR_EVENT_LOG_PREVIEW` teaches the Ctrl+E
+keystroke; `FIRST_RUN_TOUR_LOG_PATH` announces the on-disk grouped
+event log (with `path=""` when no file logger is attached — the
+default binding's `path != ''` predicate gates the narration so no
+empty announcement ever fires); `FIRST_RUN_TOUR_COMPLETED` is the
+terminator so subscribers and tests can wait for the tour to
+finish without sleeping. All four beats (including
+`FIRST_RUN_TOUR_STEP`) re-fire on `:welcome` with `replay=True`,
+but the three seed cells are NOT re-seeded on replay — overwriting
+the user's notebook would violate the F20 once-per-machine
+contract.
 
 ## Workspace
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -120,17 +120,34 @@ only the outline, or `--view both` (the TTY default) for both panes.
 ### First-run onboarding
 
 The **very first** time ASAT starts on a given machine you will
-also hear a short spoken welcome ("Welcome to ASAT. Type colon
-help to hear the keystroke cheat sheet.") and the text trace prints
-a four-line tour explaining the key meta-commands (`:help`,
-`:commands`, Escape, `:quit`). The tour plays from the narrator
-voice, on the left, and is spelled letter-by-letter
-(`"h, e, l, p"`) so the TTS pronounces each character.
+hear a scripted four-beat tour that proves every surface is working:
+
+1. **Welcome banner** — "Welcome to ASAT. Type colon help to hear
+   the keystroke cheat sheet." Spelled letter-by-letter
+   (`"h, e, l, p"`) so the TTS pronounces each character.
+2. **Three-cell demo notebook** — two headings (`H1 Welcome to
+   ASAT`, `H2 Your first command`) and a pre-populated command cell
+   (`echo hello, ASAT`) land in the session so the outline pane
+   renders a two-level hierarchy the moment you scroll. The narrator
+   then says "Your first cell has echo hello, ASAT ready to go.
+   Press Enter to run it."
+3. **Event log preview** — "Press Control E any time to open the
+   event log. Up and Down walk recent events; press t to replay
+   one." No focus hijack — the tour just teaches the keystroke.
+4. **Log-file path** — when a workspace is attached (or
+   `--log-events DIR` was passed), the narrator announces the
+   current grouped-log path so you know where to `tail -f`. Skipped
+   silently when no file logger is wired.
+5. **Tour complete** — the narrator hands you back the prompt with
+   one last cue: "First-run tour complete. Press Enter to run your
+   first command."
 
 A sentinel file at `~/.asat/first-run-done` records that you've
 seen the tour; subsequent launches skip it. `--quiet` and
-`--check` also skip the tour. Delete the sentinel file and re-launch
-if you ever want to hear the welcome again.
+`--check` also skip the tour. Delete the sentinel file and
+re-launch if you ever want to hear the welcome again. Type
+`:welcome` any time to replay the full tour (without re-seeding
+the demo cells, so your notebook is safe).
 
 ---
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -161,14 +161,20 @@ class ApplicationBuildTests(unittest.TestCase):
             self.assertTrue(sentinel.exists())
 
     def test_first_run_tour_prefills_cell_and_fires_tour_step(self) -> None:
-        """F43: a first-run Application.build pre-populates the seeded
-        notebook's first cell with `echo hello, ASAT` and publishes
+        """F43 + PR 4: a first-run Application.build seeds a three-cell
+        demo notebook (H1 + H2 + command) so the outline pane has a
+        two-level hierarchy to render, and publishes
         FIRST_RUN_TOUR_STEP right after FIRST_RUN_DETECTED."""
         import tempfile
         from pathlib import Path
 
+        from asat.cell import CellKind
         from asat.event_bus import EventBus
-        from asat.onboarding import FIRST_RUN_TOUR_COMMAND, OnboardingCoordinator
+        from asat.onboarding import (
+            FIRST_RUN_OUTLINE_HEADINGS,
+            FIRST_RUN_TOUR_COMMAND,
+            OnboardingCoordinator,
+        )
 
         with tempfile.TemporaryDirectory() as td:
             sentinel = Path(td) / "first-run-done"
@@ -180,9 +186,18 @@ class ApplicationBuildTests(unittest.TestCase):
 
             app = Application.build(onboarding_factory=_factory)
 
-            self.assertEqual(len(app.session.cells), 1)
             self.assertEqual(
-                app.session.cells[0].command, FIRST_RUN_TOUR_COMMAND
+                len(app.session.cells), len(FIRST_RUN_OUTLINE_HEADINGS) + 1
+            )
+            for cell, (level, title) in zip(
+                app.session.cells, FIRST_RUN_OUTLINE_HEADINGS
+            ):
+                self.assertEqual(cell.kind, CellKind.HEADING)
+                self.assertEqual(cell.heading_level, level)
+                self.assertEqual(cell.heading_title, title)
+            self.assertEqual(app.session.cells[-1].kind, CellKind.COMMAND)
+            self.assertEqual(
+                app.session.cells[-1].command, FIRST_RUN_TOUR_COMMAND
             )
             welcome_idx = seen.index(EventType.FIRST_RUN_DETECTED)
             tour_idx = seen.index(EventType.FIRST_RUN_TOUR_STEP)

--- a/tests/test_onboarding_tour.py
+++ b/tests/test_onboarding_tour.py
@@ -1,0 +1,251 @@
+"""Unit tests for the PR 4 scripted first-run tour."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from asat.app import Application
+from asat.cell import CellKind
+from asat.event_bus import EventBus
+from asat.events import Event, EventType
+from asat.onboarding import (
+    FIRST_RUN_COMPLETED_LINES,
+    FIRST_RUN_EVENT_LOG_LINES,
+    FIRST_RUN_LOG_PATH_LINES,
+    FIRST_RUN_OUTLINE_HEADINGS,
+    FIRST_RUN_TOUR_COMMAND,
+    OnboardingCoordinator,
+)
+
+
+SCRIPTED_TOUR_EVENTS = (
+    EventType.FIRST_RUN_TOUR_STEP,
+    EventType.FIRST_RUN_TOUR_EVENT_LOG_PREVIEW,
+    EventType.FIRST_RUN_TOUR_LOG_PATH,
+    EventType.FIRST_RUN_TOUR_COMPLETED,
+)
+
+
+class _Recorder:
+    """Collect every event so tests can filter by type."""
+
+    def __init__(self, bus: EventBus) -> None:
+        self.events: list[Event] = []
+        bus.subscribe("*", self.events.append)
+
+    def of(self, event_type: EventType) -> list[Event]:
+        return [e for e in self.events if e.event_type == event_type]
+
+    def types_in_order(self) -> list[EventType]:
+        return [e.event_type for e in self.events]
+
+
+class OnboardingBeatPublisherTests(unittest.TestCase):
+    """The new beat-publishing methods on OnboardingCoordinator."""
+
+    def setUp(self) -> None:
+        self._tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tempdir.cleanup)
+        self.sentinel = Path(self._tempdir.name) / "first-run-done"
+
+    def test_event_log_preview_beat_publishes_default_lines(self) -> None:
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        coordinator = OnboardingCoordinator(bus, self.sentinel)
+
+        coordinator.publish_event_log_preview_beat()
+
+        events = recorder.of(EventType.FIRST_RUN_TOUR_EVENT_LOG_PREVIEW)
+        self.assertEqual(len(events), 1)
+        payload = events[0].payload
+        self.assertEqual(payload["lines"], list(FIRST_RUN_EVENT_LOG_LINES))
+        self.assertFalse(payload["replay"])
+
+    def test_log_path_beat_carries_path_when_provided(self) -> None:
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        coordinator = OnboardingCoordinator(bus, self.sentinel)
+
+        coordinator.publish_log_path_beat("/tmp/events.log")
+
+        events = recorder.of(EventType.FIRST_RUN_TOUR_LOG_PATH)
+        self.assertEqual(len(events), 1)
+        payload = events[0].payload
+        self.assertEqual(payload["path"], "/tmp/events.log")
+        self.assertEqual(payload["lines"], list(FIRST_RUN_LOG_PATH_LINES))
+
+    def test_log_path_beat_normalises_none_to_empty_string(self) -> None:
+        """The predicate on the default binding gates on `path != ''`; a
+        `None` from Application.build (no file logger) must round-trip
+        as `""` so the binding drops the beat rather than crashing."""
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        coordinator = OnboardingCoordinator(bus, self.sentinel)
+
+        coordinator.publish_log_path_beat(None)
+
+        payload = recorder.of(EventType.FIRST_RUN_TOUR_LOG_PATH)[0].payload
+        self.assertEqual(payload["path"], "")
+
+    def test_tour_completed_beat_carries_replay_marker(self) -> None:
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        coordinator = OnboardingCoordinator(bus, self.sentinel)
+
+        coordinator.publish_tour_completed_beat(replay=True)
+
+        events = recorder.of(EventType.FIRST_RUN_TOUR_COMPLETED)
+        self.assertEqual(len(events), 1)
+        payload = events[0].payload
+        self.assertEqual(payload["lines"], list(FIRST_RUN_COMPLETED_LINES))
+        self.assertTrue(payload["replay"])
+
+    def test_publish_tour_step_accepts_replay_kwarg(self) -> None:
+        """The F43 tour step gains a `replay` marker so the `:welcome`
+        replay can be distinguished from the genuine first-run fire."""
+        bus = EventBus()
+        recorder = _Recorder(bus)
+        coordinator = OnboardingCoordinator(bus, self.sentinel)
+
+        coordinator.publish_tour_step(replay=True)
+
+        payload = recorder.of(EventType.FIRST_RUN_TOUR_STEP)[0].payload
+        self.assertTrue(payload["replay"])
+
+
+class ApplicationFirstRunTourTests(unittest.TestCase):
+    """Application.build drives the full four-beat tour on first run."""
+
+    def setUp(self) -> None:
+        self._tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tempdir.cleanup)
+        self.sentinel = Path(self._tempdir.name) / "first-run-done"
+        self.log_dir = Path(self._tempdir.name) / "log"
+
+    def _factory(self, seen: list[Event]):
+        def _build(bus: EventBus) -> OnboardingCoordinator:
+            bus.subscribe("*", seen.append)
+            return OnboardingCoordinator(bus, self.sentinel)
+        return _build
+
+    def test_first_run_seeds_outline_and_command_cell(self) -> None:
+        seen: list[Event] = []
+        app = Application.build(onboarding_factory=self._factory(seen))
+        self.addCleanup(app.close)
+
+        cells = app.session.cells
+        self.assertEqual(len(cells), len(FIRST_RUN_OUTLINE_HEADINGS) + 1)
+        for cell, (level, title) in zip(cells, FIRST_RUN_OUTLINE_HEADINGS):
+            self.assertEqual(cell.kind, CellKind.HEADING)
+            self.assertEqual(cell.heading_level, level)
+            self.assertEqual(cell.heading_title, title)
+        self.assertEqual(cells[-1].kind, CellKind.COMMAND)
+        self.assertEqual(cells[-1].command, FIRST_RUN_TOUR_COMMAND)
+
+    def test_first_run_fires_all_four_scripted_beats_in_order(self) -> None:
+        seen: list[Event] = []
+        app = Application.build(onboarding_factory=self._factory(seen))
+        self.addCleanup(app.close)
+
+        types = [e.event_type for e in seen]
+        welcome_idx = types.index(EventType.FIRST_RUN_DETECTED)
+        positions = [types.index(t) for t in SCRIPTED_TOUR_EVENTS]
+        self.assertLess(welcome_idx, positions[0])
+        self.assertEqual(sorted(positions), positions)
+
+    def test_first_run_scripted_beats_are_not_marked_replay(self) -> None:
+        seen: list[Event] = []
+        app = Application.build(onboarding_factory=self._factory(seen))
+        self.addCleanup(app.close)
+
+        for event_type in SCRIPTED_TOUR_EVENTS:
+            events = [e for e in seen if e.event_type == event_type]
+            self.assertEqual(len(events), 1)
+            self.assertFalse(events[0].payload["replay"])
+
+    def test_first_run_log_path_beat_carries_file_path_when_configured(self) -> None:
+        """When an event-log directory is wired, the log-path beat
+        carries the concrete path so the narrator can announce it."""
+        seen: list[Event] = []
+        app = Application.build(
+            onboarding_factory=self._factory(seen),
+            event_log_dir=self.log_dir,
+        )
+        self.addCleanup(app.close)
+
+        event = [
+            e for e in seen if e.event_type == EventType.FIRST_RUN_TOUR_LOG_PATH
+        ][0]
+        self.assertTrue(event.payload["path"].endswith(".log"))
+        self.assertIn(str(self.log_dir), event.payload["path"])
+
+    def test_first_run_log_path_beat_is_empty_without_file_logger(self) -> None:
+        seen: list[Event] = []
+        app = Application.build(onboarding_factory=self._factory(seen))
+        self.addCleanup(app.close)
+
+        event = [
+            e for e in seen if e.event_type == EventType.FIRST_RUN_TOUR_LOG_PATH
+        ][0]
+        self.assertEqual(event.payload["path"], "")
+
+    def test_returning_user_does_not_fire_scripted_beats(self) -> None:
+        """Sentinel-exists path must skip every post-welcome beat so a
+        returning user does not hear the tour on every launch."""
+        self.sentinel.write_text("done\n", encoding="utf-8")
+        seen: list[Event] = []
+        app = Application.build(onboarding_factory=self._factory(seen))
+        self.addCleanup(app.close)
+
+        types = [e.event_type for e in seen]
+        self.assertNotIn(EventType.FIRST_RUN_TOUR_STEP, types)
+        for beat in SCRIPTED_TOUR_EVENTS:
+            self.assertNotIn(beat, types)
+
+    def test_welcome_meta_command_replays_every_scripted_beat(self) -> None:
+        """`:welcome` must re-publish every tour event with replay=True
+        and must not re-seed cells (that would stomp the user's work)."""
+        self.sentinel.write_text("done\n", encoding="utf-8")
+
+        def _factory(bus: EventBus) -> OnboardingCoordinator:
+            return OnboardingCoordinator(bus, self.sentinel)
+
+        app = Application.build(onboarding_factory=_factory)
+        self.addCleanup(app.close)
+        cell_count_before = len(app.session.cells)
+
+        replays: list[Event] = []
+        app.bus.subscribe("*", replays.append)
+        from asat.keys import Key
+        for ch in ":welcome":
+            app.handle_key(Key.printable(ch))
+        app.handle_key(Key.special("enter"))
+
+        # FIRST_RUN_DETECTED + all four scripted beats all fire with replay=True.
+        expected = (EventType.FIRST_RUN_DETECTED,) + SCRIPTED_TOUR_EVENTS
+        for event_type in expected:
+            events = [e for e in replays if e.event_type == event_type]
+            self.assertEqual(len(events), 1, f"missing replay of {event_type}")
+            self.assertTrue(events[0].payload["replay"])
+
+        # No extra cells got seeded.
+        self.assertEqual(len(app.session.cells), cell_count_before)
+
+    def test_welcome_without_onboarding_does_not_crash(self) -> None:
+        """--quiet / --check paths leave `onboarding=None`; `:welcome`
+        there must stay a harmless no-op."""
+        app = Application.build()  # no onboarding_factory
+        self.addCleanup(app.close)
+
+        from asat.keys import Key
+        for ch in ":welcome":
+            app.handle_key(Key.printable(ch))
+        app.handle_key(Key.special("enter"))
+
+        self.assertTrue(app.running)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Extends the first-run experience into a five-beat guided tour that proves each MVP surface is working. Seeds a H1+H2+command demo so PR 2's outline pane has structure to render, narrates the event-log keystroke, announces the grouped-log file path when one is attached, and lands in INPUT mode. `:welcome` replays every beat with replay=True without re-seeding cells.

Closes F43 follow-through and F44 replay parity.