### PR TITLE
Docs handoff: MVP status snapshot + PR 1-4 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,13 @@ and is bound to a spoken phrase or a spatialised tone. Keyboard
 only, standard library only, no mouse, no screen coordinates.
 
 > **Status.** Pre-1.0 (current `pyproject.toml` says `0.7.0`). The
-> Windows audio path, the notebook surface, and the POSIX shared-shell
-> backend are usable end-to-end; the POSIX live audio sink and cell
-> hierarchy are tracked as feature requests (see "What is not here
-> yet" below).
+> four MVP surfaces — live audio on Linux / macOS / Windows, an
+> on-screen outline pane, an interactive event-log viewer, and a
+> scripted first-run tour — are all usable end-to-end after the
+> 2026-04 MVP stabilization roadmap. Remaining gaps are catalogued in
+> [docs/FEATURE_REQUESTS.md](docs/FEATURE_REQUESTS.md); a hands-on
+> handoff snapshot of what's verified-by-tests vs. pending manual
+> smoke lives in [docs/HANDOFF.md](docs/HANDOFF.md).
 
 ## Who this is for
 
@@ -25,6 +28,30 @@ stdout that mirrors what the audio is saying.
 
 ## What ASAT actually delivers today
 
+- **Cross-platform live audio on launch.** A pluggable TTS registry
+  (`pyttsx3` preferred, `espeak-ng` / macOS `say` / Windows SAPI as
+  native fallbacks, tone generator as the deterministic floor)
+  combined with a POSIX live sink (`aplay` / `paplay` / `afplay`) +
+  the existing Windows `winsound` path means `python -m asat` speaks
+  on the first launch on Linux, macOS, and Windows. `:tts list` /
+  `:tts use <id>` / `:tts set <param> <value>` swap engines live.
+- **An on-screen outline pane.** The renderer subscribes to
+  `FOCUS_CHANGED` / `CELL_*` events and paints an indented tree of
+  heading cells with a `>` arrow on the focused cell. `]` / `[`
+  moves both the audio cursor and the visual marker. `--view
+  {trace,outline,both}` picks which panes show on a TTY.
+- **An interactive event-log viewer.** `Ctrl+E` opens a narrated
+  ring of the last 200 events; Up/Down walks entries, `Enter` jumps
+  to the binding's field in the SETTINGS editor, `e` quick-edits the
+  `say_template`, and `t` replays the event through the live
+  pipeline. Every event is also written to a grouped text log at
+  `<workspace>/.asat/log/events-YYYY-MM-DD.log` (or `--log-events
+  DIR`).
+- **A scripted first-run tour.** A five-beat tour seeds a
+  `H1 + H2 + command` demo notebook so the outline pane has
+  something to render, narrates the `Ctrl+E` keystroke, announces
+  the event-log file path, and lands in INPUT mode. `:welcome`
+  replays every beat without re-seeding.
 - A **session of editable cells**, each with its own command,
   captured stdout/stderr, and exit code; saved as JSON via
   `--session file.json` and resumable.
@@ -41,27 +68,29 @@ stdout that mirrors what the audio is saying.
 - **Four focus modes** — NOTEBOOK (walk cells), INPUT (type a
   command), OUTPUT (step line-by-line through one cell's captured
   output, with `/` search and `g` goto), SETTINGS (live editor for
-  every voice / sound / binding without restarting).
+  every voice / sound / binding without restarting), plus the
+  `EVENT_LOG` overlay introduced by the viewer.
 - A **live audio engine**: HRTF spatialisation on stdlib audio,
   three TTS voices, a per-event SoundBank you can edit and save.
 - An **F2 actions menu** for context-sensitive copy / navigate
   affordances.
 - **Meta-commands** (`:help`, `:state`, `:pwd`, `:save`, `:quit`,
-  `:welcome`, `:reset bank`, …) with case-insensitive matching and
-  did-you-mean hints on typos.
-- **First-run onboarding** that introduces the keystroke vocabulary
-  the first time you launch on a machine.
+  `:welcome`, `:reset bank`, `:tts …`, `:log`, …) with
+  case-insensitive matching and did-you-mean hints on typos.
 
 What is **not** here yet, with the docs grounding the gap:
 
-- No cell hierarchy / sections / folds —
-  [F61](docs/FEATURE_REQUESTS.md#f61--cell-hierarchy-sections-folds-and-grouping).
 - No PTY inside a cell, so `vim` / `less` / curses programs do not
   run inside one — see
   [docs/USER_MANUAL.md § What a cell is](docs/USER_MANUAL.md#what-a-cell-is-and-is-not-today).
-- No live POSIX speaker sink (Windows works today; POSIX renders
-  to WAV files) —
-  [F6](docs/FEATURE_REQUESTS.md#f6--live-speaker-audio-sink-posix).
+- No Ctrl+R reverse-incremental command-history search (Up / Down
+  recall ships today) — [F4](docs/FEATURE_REQUESTS.md#f4--command-history).
+- No settings-editor record create / delete — [F2](docs/FEATURE_REQUESTS.md#f2--settings-editor-create--delete-records).
+- No tab completion inside INPUT — [F23](docs/FEATURE_REQUESTS.md#f23--tab-completion).
+- Cross-platform smoke on the four new surfaces has only been run
+  inside the dev sandbox; see
+  [docs/HANDOFF.md](docs/HANDOFF.md) for the outstanding manual
+  checks before tagging 1.0.
 
 ## Install and run
 
@@ -77,31 +106,48 @@ python -m unittest discover -s tests -t .   # confirm the suite passes
 ### Launching a session
 
 ```
-python -m asat --live               # play audio on the speaker (Windows today)
-python -m asat --wav-dir /tmp/asat  # write each rendered buffer to WAV (any platform)
-python -m asat --live --wav-dir DIR # Windows: speaker + capture in one run
+python -m asat                      # live audio on any TTY platform (POSIX + Windows)
+python -m asat --wav-dir /tmp/asat  # also capture each rendered buffer to WAV
+python -m asat --no-live            # opt out of the live sink (MemorySink only)
+python -m asat --view trace         # suppress the outline pane (text trace only)
+python -m asat --view outline       # suppress the text trace (outline pane only)
 python -m asat --quiet              # suppress the text trace, audio only
-python -m asat --check              # run the four-step diagnostic self-test, exit
+python -m asat --check              # run the diagnostic self-test on every covered event, exit
 python -m asat --version            # print the version string and exit
 ```
 
-Bare `python -m asat` runs silently (audio goes to an in-memory
-sink) and prints a one-line stderr hint. **ASAT needs an
-interactive terminal** — if stdin is not a TTY the CLI exits with
-`[asat] cannot start: …` and returns code 2.
+Per-platform audio prerequisites (the CLI names the missing binary
+if none are found; the tone fallback keeps the pipeline moving):
+
+- **Linux:** `pip install pyttsx3` **or** `apt install espeak-ng`,
+  plus `alsa-utils` (for `aplay`) or `pulseaudio-utils` (for
+  `paplay`).
+- **macOS:** ships working out of the box — `say` is built-in and
+  `afplay` is on PATH.
+- **Windows:** ships working out of the box via SAPI + `winsound`;
+  `pip install pyttsx3` gives you extra voices.
+
+**ASAT needs an interactive terminal** — if stdin is not a TTY the
+CLI exits with `[asat] cannot start: …` and returns code 2.
 
 ### First five minutes
 
-1. Launch with `--live` (Windows) or `--wav-dir /tmp/asat` (POSIX).
-   You hear the session-start chime overhead and the trace prints
-   `[asat] session <id> ready. Type :help …`.
-2. Type `:help` + Enter any time for the cheat sheet (audio + text).
-3. Type a command (`echo hi`, `git status`, `python --version`),
-   press Enter. Submit cue, output narrated as it streams,
-   success or failure chord on exit.
-4. Press Escape → NOTEBOOK mode. Up/Down walks cells, Ctrl+O steps
-   through the focused cell's output, Ctrl+, opens the live
-   settings editor.
+1. Launch with bare `python -m asat`. You hear the session-start
+   chime overhead, then the scripted first-run tour: welcome →
+   three-cell demo notebook (a H1, a H2, and a pre-filled
+   `echo hello, ASAT` cell) → event-log preview → log-path
+   announcement → "press Enter to run, or colon h e l p for more".
+   The screen paints the outline pane with a `>` on the focused
+   cell.
+2. Press Enter to run the seeded command. You hear the submit cue,
+   the output narrated, and the success chord on exit.
+3. Press `Ctrl+E` to open the event log. Up / Down walks entries;
+   `Enter` jumps to the binding's field in SETTINGS; `e` quick-edits
+   the `say_template`; `t` replays the event with your new phrase.
+   `Escape` closes the viewer.
+4. Type `:help` + Enter any time for the full cheat sheet. Type
+   `:welcome` to replay the tour without re-seeding cells. Type
+   `:tts list` / `:tts use espeak-ng` to switch TTS engines live.
 5. Type `:quit` + Enter to exit.
 
 The full keystroke cheat sheet lives in
@@ -152,27 +198,36 @@ engine voices it.
 | `prompt_context.py`        | Publishes `PROMPT_REFRESH` so re-entering INPUT shows last exit + cwd.    |
 | `error_tail.py`            | Auto-narrates the last few stderr lines after a failed command.           |
 | `completion_alert.py`      | Watches focus + completion so off-focus completions still alert.          |
-| `onboarding.py`            | First-run welcome tour; sentinel under `ASAT_HOME`.                       |
+| `onboarding.py`            | First-run welcome tour coordinator; sentinel under `ASAT_HOME`; scripted PR 4 beats (tour step, event-log preview, log path, completed). |
 | `event_bus.py`             | Synchronous typed event bus; wildcard subscription.                       |
 | `events.py`                | `EventType` enum + `Event` dataclass; the contract every module uses.     |
 | `jsonl_logger.py`          | `--log` writer: one JSON line per event for diagnostics / replay.         |
-| `terminal.py`              | The text trace renderer (`[asat] …`, `[input #…]`, `$ command`, …).       |
+| `event_log.py`             | `EventLogViewer`: bounded ring, Ctrl+E overlay, quick-edit + replay.      |
+| `event_log_file.py`        | Grouped daily text log under `<workspace>/.asat/log/events-YYYY-MM-DD.log`. |
+| `terminal.py`              | Text trace + outline-pane renderer (ANSI-clear redraw on TTY, append-only when piped). |
+| `outline.py`               | Pure `render_outline(cells, focus_cell_id, max_width)`; scope + enclosing-heading helpers. |
 | `audio.py`                 | Core audio data types (AudioBuffer, sample-rate constants).               |
-| `audio_sink.py`            | Sinks: `MemorySink`, `WinMMSink` (Windows), `WavDirSink` (any platform).  |
+| `audio_sink.py`            | Sinks: `MemorySink`, `WavFileSink`, `WindowsLiveAudioSink`, `PosixLiveAudioSink` (aplay / paplay / afplay), `pick_live_sink()`. |
 | `sound_engine.py`          | Subscribes to events, renders cues + narrations, hands buffers to a sink. |
 | `sound_bank.py`            | The bank model: `Voice`, `SoundRecipe`, `EventBinding` records.           |
 | `sound_bank_schema.json`   | JSON schema for an on-disk bank file.                                     |
 | `sound_generators.py`      | Sine / chord / noise generators consumed by `SoundRecipe.kind`.           |
-| `default_bank.py`          | The shipped bank — every default cue, voice, and binding.                 |
-| `tts.py`                   | TTS adapters (`pyttsx3` on Windows, `espeak` fallback elsewhere).         |
+| `default_bank.py`          | The shipped bank — every default cue, voice, and binding; `COVERED_EVENT_TYPES` enumerates every event that must have a sample payload. |
+| `sample_payloads.py`       | Canonical one-per-event-type reference payloads; the source the coverage test and `--check` both consume. |
+| `self_check.py`            | Diagnostic self-test behind `--check` — replays every `COVERED_EVENT_TYPE` through the live engine + sink. |
+| `tts.py`                   | `TTSEngine` Protocol + adapters: `Pyttsx3Engine`, `EspeakNgEngine`, `SystemSayEngine`, `ToneTTSEngine`. |
+| `tts_registry.py`          | Registry of TTS adapters with availability probes; `select_default()` walks the priority list. |
 | `hrtf.py`                  | HRTF spatialiser; numpy-accelerated when available.                       |
-| `settings_controller.py`   | Mode-aware controller orchestrating the editor + the audio bank.          |
-| `settings_editor.py`       | The pure editor: cursor over sections / records / fields, undo/redo.     |
+| `settings_controller.py`   | Mode-aware controller orchestrating the editor + the audio bank; `open_at_binding(binding_id)` used by the event-log viewer. |
+| `settings_editor.py`       | The pure editor: cursor over sections / records / fields, undo/redo, `/` search, reset scopes. |
 | `help_topics.py`           | The `:help <topic>` registry consumed by the input router.                |
 | `ansi.py`                  | ANSI escape parser used by the screen + TUI detector.                     |
 | `screen.py`                | `VirtualScreen`: applies ANSI tokens to a 2D grid for menu detection.    |
 | `interactive.py`           | TUI menu detection over the virtual screen.                               |
 | `tui_bridge.py`            | Glue: streams a child program's bytes through ansi + screen + detector.  |
+| `output_playback.py`       | Continuous line-by-line playback of a cell's captured output.             |
+| `streaming_monitor.py`     | Gap + beat detection on live output streams.                              |
+| `workspace.py`             | Workspace discovery (`.asat/`), multi-notebook layout, `:workspace` meta-commands. |
 | `common.py`                | Tiny shared utilities (id generation, UTC clock).                         |
 
 ### `docs/` — documentation
@@ -182,11 +237,13 @@ engine voices it.
 | `USER_MANUAL.md`           | Keystrokes, modes, meta-commands, troubleshooting. Start here as a user.  |
 | `CHEAT_SHEET.md`           | Single-page reference: every binding, meta-command, and audio cue.        |
 | `SMOKE_TEST.md`            | Hands-on, keystroke-by-keystroke walkthrough with expected narrations.   |
-| `ARCHITECTURE.md`          | Module map, focus model, execution path. Read first as a contributor.     |
+| `ARCHITECTURE.md`          | Module map, focus model, execution path, sync gates, predicate DSL. Read first as a contributor. |
 | `DEVELOPER_GUIDE.md`       | Guiding principles, simplicity checklist, the PR recipe.                  |
-| `FEATURE_REQUESTS.md`      | Open gaps (F1 … F61) with code-and-doc pointers; the active roadmap.      |
+| `HANDOFF.md`               | MVP verification snapshot: per-surface status, what's test-covered vs. pending manual smoke. Read first if you're picking up the project in a fresh chat. |
+| `FEATURE_REQUESTS.md`      | Open gaps (F1 … F64) with code-and-doc pointers; the active roadmap.      |
 | `EVENTS.md`                | Every event type and its payload (kept in sync by a test).                |
-| `AUDIO.md`                 | Voices, recipes, bindings, HRTF, the spatialiser.                         |
+| `AUDIO.md`                 | Voices, recipes, bindings, HRTF, the spatialiser, TTS registry.           |
+| `BINDINGS.md`              | Auto-generated binding reference — regenerate via `python -m asat.tools.render_bindings_doc`. |
 | `CLAUDE_CODE_MODES.md`     | Sonification targets for the Claude Code TUI running inside ASAT.         |
 
 ### `tests/` — test suite
@@ -197,8 +254,14 @@ Two cross-cutting suites:
 - `tests/test_smoke_scenarios.py` — end-to-end keyboard-and-event
   scenarios mirroring the acts in `docs/SMOKE_TEST.md`.
 - `tests/test_user_manual_sync.py`, `tests/test_events_docs_sync.py`,
-  `tests/test_default_bank_orphans.py` — guards that fail when the
-  docs drift from the code.
+  `tests/test_default_bank_orphans.py`,
+  `tests/test_bindings_introspection.py` (section `BindingsDocInSyncTests`),
+  `tests/test_default_bank.py` (class `CoverageTests` — every
+  `COVERED_EVENT_TYPE` must have a `SAMPLE_PAYLOADS` entry) — guards
+  that fail when the docs drift from the code. See
+  [docs/ARCHITECTURE.md § Sync gates](docs/ARCHITECTURE.md#sync-gates)
+  for the full list and how to satisfy each one when adding a new
+  event type or binding.
 
 Run the whole suite with `python -m unittest discover -s tests -t .`.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,12 +40,15 @@ it; the event bus is the sole backchannel.
            |  Entry point                |
            |  __main__.py  app.py        |
            |  keyboard.py  terminal.py   |
+           |  outline.py  self_check.py  |
            +---------------+-------------+
                            |
            +---------------v-------------+
            |  Presentation               |
            |  settings_controller.py     |
            |  settings_editor.py         |
+           |  event_log.py               |
+           |  onboarding.py              |
            +---------------+-------------+
                            |
            +---------------v-------------+
@@ -54,8 +57,10 @@ it; the event bus is the sole backchannel.
            |  sound_generators.py        |
            |  sound_bank.py              |
            |  default_bank.py            |
+           |  sample_payloads.py         |
            |  audio.py  audio_sink.py    |
-           |  tts.py  hrtf.py            |
+           |  tts.py  tts_registry.py    |
+           |  hrtf.py                    |
            +---------------+-------------+
                            |
            +---------------v-------------+
@@ -63,6 +68,7 @@ it; the event bus is the sole backchannel.
            |  input_router.py            |
            |  notebook.py  actions.py    |
            |  output_cursor.py           |
+           |  output_playback.py         |
            +---------------+-------------+
                            |
            +---------------v-------------+
@@ -76,13 +82,18 @@ it; the event bus is the sole backchannel.
            |  Execution kernel           |
            |  kernel.py  runner.py       |
            |  execution.py               |
+           |  execution_worker.py        |
+           |  shell_backend.py           |
+           |  streaming_monitor.py       |
            +---------------+-------------+
                            |
            +---------------v-------------+
            |  Data + bus (foundation)    |
            |  cell.py  session.py        |
            |  events.py  event_bus.py    |
+           |  event_log_file.py          |
            |  output_buffer.py           |
+           |  workspace.py               |
            |  common.py  keys.py         |
            +-----------------------------+
 ```
@@ -167,6 +178,83 @@ baseline, and `SettingsEditor` plus `SettingsController` let users
 reshape the bank live from the keyboard without restarting. See
 [AUDIO.md](AUDIO.md) for the full reference.
 
+The TTS engine is pluggable via `TTSEngineRegistry` in
+`asat/tts_registry.py`. The default priority is `pyttsx3` →
+`espeak-ng` → macOS `say` → Windows SAPI → the deterministic tone
+fallback. `:tts list` / `:tts use <id>` / `:tts set <param> <value>`
+swap engines and parameters live without restarting.
+
+## MVP surfaces (2026-04 roadmap)
+
+The four user-observable surfaces promised by the 2026-04 MVP
+stabilization roadmap are wired as follows — each one is one
+direction of a dependency edge in the diagram above.
+
+- **Live audio on launch.** `audio_sink.pick_live_sink()` returns
+  `WindowsLiveAudioSink` on Windows and `PosixLiveAudioSink` (pipes
+  WAV to `aplay` / `paplay` / `afplay`) on POSIX; `tts_registry.
+  select_default()` picks the first installed TTS adapter. `--live`
+  is the default on a TTY; `--no-live` opts out.
+- **On-screen outline pane.** `outline.render_outline()` is pure and
+  unit-tested; `terminal.TerminalRenderer` subscribes to
+  `FOCUS_CHANGED` / `CELL_*` / outline-fold events and repaints the
+  pane (ANSI-clear redraw on TTY, append-only trace when piped).
+  `--view {trace,outline,both}` picks panes.
+- **Interactive event log.** `event_log.EventLogViewer` holds a
+  bounded ring (200 entries) of wildcard-subscribed events,
+  re-narrates them on navigation, and dispatches the `e` / `t` /
+  `Enter` quick-edit / replay / jump-to-binding actions.
+  `event_log_file.EventLogFile` is a separate wildcard subscriber
+  that writes the grouped daily text log.
+- **Scripted first-run tour.** `onboarding.OnboardingCoordinator`
+  owns the five published beats; `app.Application.build` seeds the
+  three-cell demo notebook on first run and calls `_run_scripted_
+  tour(replay=False)`. `:welcome` invokes `_replay_welcome`, which
+  re-runs the tour with `replay=True` and does **not** re-seed cells.
+
+## Sync gates
+
+Several test guards fail when code and docs drift. Each new event
+type, binding, or user-visible surface must satisfy every gate that
+applies:
+
+| Gate                                                | What it checks                                                                                                        | How to satisfy when adding a new event type                                                                                   |
+|-----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
+| `tests/test_events_docs_sync.py`                    | Every `EventType` member is mentioned in `docs/EVENTS.md`.                                                            | Add a row + prose under the appropriate category in `docs/EVENTS.md`.                                                         |
+| `tests/test_default_bank.py::CoverageTests`         | Every `COVERED_EVENT_TYPES` member has a reference payload in `asat/sample_payloads.py` and renders cleanly.          | Add an entry to `SAMPLE_PAYLOADS` keyed by the new `EventType`; add a binding to `default_bank.py` and list it in `COVERED_EVENT_TYPES`. |
+| `tests/test_user_manual_sync.py`                    | Keystrokes, meta-commands, and focus-mode bindings referenced in `docs/USER_MANUAL.md` match the code.                | Update the relevant table in `USER_MANUAL.md` when you change a binding.                                                      |
+| `tests/test_bindings_introspection.py::BindingsDocInSyncTests` | `docs/BINDINGS.md` matches the output of `python -m asat.tools.render_bindings_doc`.                                   | Regenerate: `python -m asat.tools.render_bindings_doc > docs/BINDINGS.md`.                                                     |
+| `tests/test_default_bank_orphans.py`                | No `EventBinding.event_type` references an `EventType` no producer emits.                                             | Wire a publisher (or delete the orphan binding).                                                                              |
+
+`asat/self_check.py` — invoked by `python -m asat --check` — replays
+one `SAMPLE_PAYLOADS` entry per `COVERED_EVENT_TYPES` member through
+the live engine and sink, so a fresh install can prove end-to-end
+that audio works before the user hits the keyboard.
+
+## Predicate DSL
+
+`EventBinding.predicate` (see `asat/sound_engine.py`,
+`DefaultPredicateEvaluator`) is a deliberately tiny string language,
+not Python. The grammar is **strictly** `key op literal`, one
+clause, no attribute access:
+
+- `key` is a top-level payload key (e.g. `exit_code`, `path`, `kind`).
+- `op` is one of `==`, `!=`, `in` (the `in` operator takes a
+  comma-separated list literal).
+- `literal` is a string (single or double quoted), a bare integer,
+  a bare float, `true` / `false`, or an unquoted token compared as a
+  string.
+
+Examples: `exit_code != 0`, `kind == 'heading'`, `path != ''`,
+`category in 'prompt_start,prompt_end'`.
+
+Things the DSL does **not** support: nested attribute access
+(`payload.path`), logical operators (`and` / `or` / `not`), numeric
+comparisons other than equality, function calls, or arbitrary Python
+expressions. Gating on a non-empty string is the `path != ''` idiom
+shown above; gating on presence of a key is not expressible — give
+the payload a well-known empty default instead.
+
 ## Testing
 
 Every module ships a matching `tests/test_<module>.py` built on
@@ -218,18 +306,25 @@ Three supporting modules round the entry point out:
   audio pipeline is the primary UI; the renderer exists so sighted
   viewers and anyone debugging have a readable mirror of the event
   stream. `--quiet` switches it off.
-* `asat/audio_sink.py::WindowsLiveAudioSink` — the first sink that
-  produces actual audio on real speakers, via `winsound.PlaySound`
-  with `SND_MEMORY | SND_ASYNC`. Selected by `--live`.
-  `pick_live_sink()` is the one place the CLI asks "what live backend
-  does this host offer?"; POSIX raises `LiveAudioUnavailable` today
-  (tracked as FEATURE_REQUESTS.md F6).
+* `asat/audio_sink.py` — `pick_live_sink()` returns
+  `WindowsLiveAudioSink` on Windows (`winsound.PlaySound` with
+  `SND_MEMORY | SND_ASYNC`) and `PosixLiveAudioSink` on Linux /
+  macOS (pipes WAV blobs to `aplay` / `paplay` / `afplay`). The CLI
+  uses the live sink by default on a TTY; `--no-live` opts out,
+  `--wav-dir DIR` captures every rendered buffer in parallel.
+  `LiveAudioUnavailable` now surfaces only when no player binary is
+  installed on POSIX, and the guard message names the binaries to
+  install.
 * `asat/app.py::Application.build` publishes `SESSION_CREATED` after
   the SoundEngine has subscribed so the startup chime actually plays
   through the sink, and emits `SESSION_LOADED` / `SESSION_SAVED` at
   the matching boundaries.
 
 Open feature requests for the next generation live in
-[FEATURE_REQUESTS.md](FEATURE_REQUESTS.md); the short version is
-Windows-native TTS, live-speaker sinks, settings-editor record
-creation, and command history.
+[FEATURE_REQUESTS.md](FEATURE_REQUESTS.md); as of the 2026-04 MVP
+stabilization roadmap the remaining gaps are settings-editor record
+create / delete (F2), Ctrl+R reverse-incremental command-history
+search (F4 deferred leg), tab completion (F23), and the polish
+items in F49's code-quality backlog. Hands-on cross-platform smoke
+of the four new MVP surfaces is still pending and lives in
+[HANDOFF.md](HANDOFF.md).

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -7,6 +7,25 @@ the gap surfaces today, and a sketch of what the fix would look like.
 This file is descriptive, not prescriptive: priorities and scheduling
 live in the PR queue.
 
+## 2026-04 MVP stabilization roadmap — status
+
+Four focused PRs (see [HANDOFF.md](HANDOFF.md) for the snapshot)
+flipped the four MVP surfaces that used to be hollow:
+
+- **PR 1** — cross-platform live audio via pluggable TTS registry +
+  POSIX live sink (addresses F5, F6, F28 engine leg).
+- **PR 2** — on-screen outline pane (addresses F27 render leg, F40
+  user-facing leg, F61 render leg).
+- **PR 3** — interactive event-log viewer + grouped text log file
+  (addresses F39, F63).
+- **PR 4** — scripted first-run tour with `:welcome` replay parity
+  (addresses F43 follow-through, F44).
+
+Each affected entry below is flagged **Status: Shipped (pending
+cross-platform hands-on smoke)** or similar. Hands-on verification
+before tagging 1.0 is enumerated in [HANDOFF.md](HANDOFF.md) and is
+the remaining blocker for all four surfaces.
+
 ---
 
 ## F1 — Cancel a running command
@@ -119,55 +138,39 @@ machine mirroring the approach `SettingsEditor` already uses).
 
 ## F5 — Windows-native TTS adapter
 
-**Gap.** The shipping `ToneTTSEngine` is a parametric tone generator
-— useful as a self-contained default but not a real voice. On Windows
-the obvious target is SAPI / OneCore TTS via `pywin32` (or `ctypes`
-to avoid adding a dep).
-
-**Where it surfaces.** [ARCHITECTURE.md](ARCHITECTURE.md) phase
-history lists this as a next-generation item.
-
-**Sketch.** Implement the `TTSEngine` protocol against SAPI,
-expose a `SapiTTSEngine` class, let the user pick it via the `engine`
-field on `Voice`. Add a Voice-level routing step in `SoundEngine`
-that picks the right engine by id. Keep `ToneTTSEngine` as the
-deterministic fallback for headless tests.
+**Status: Shipped (pending cross-platform hands-on smoke).** PR 1
+of the 2026-04 MVP stabilization roadmap replaced the TTS layer with
+a pluggable registry (`asat/tts_registry.py`) covering the three
+platforms in one go. The shipping adapters — `Pyttsx3Engine`
+(cross-platform, routes to SAPI / espeak / NSSpeechSynthesizer),
+`EspeakNgEngine` (Linux `espeak-ng` subprocess), `SystemSayEngine`
+(macOS `say` subprocess) — all implement the `TTSEngine` protocol.
+`ToneTTSEngine` is retained as the deterministic fallback.
+`TTSEngineRegistry.select_default()` walks the priority list and
+returns the first `available()` engine; users swap at runtime via
+`:tts list`, `:tts use <id>`, `:tts set <param> <value>`. Still
+owed: hands-on verification that SAPI produces audible output on a
+real Windows host (see [HANDOFF.md](HANDOFF.md)).
 
 ---
 
 ## F6 — Live-speaker audio sink (POSIX)
 
-**Status.** Partially shipped. Windows live playback ships
-(`WindowsLiveAudioSink` in `asat/audio_sink.py`, selected by
-`python -m asat --live`). POSIX (macOS / Linux) is still open —
-`pick_live_sink()` raises `LiveAudioUnavailable` on those platforms
-and the CLI falls back to `MemorySink` with a spoken warning.
-
-**Gap.** On macOS and Linux, `pick_live_sink()` raises
-`LiveAudioUnavailable` and the CLI falls back to `MemorySink` with a
-message. There is no stdlib-only live audio backend on POSIX — every
-candidate (`winsound`) is Windows-only, and `subprocess`-ing `aplay`
-/ `afplay` has latency and availability problems.
-
-**Where it surfaces.** `python -m asat --live` on Linux or macOS
-prints `[asat] --live unavailable: ...` and continues silently. Users
-today have to pair `--wav-dir DIR` with a WAV player, which is
-asynchronous and awkward.
-
-**Sketch.** Two reasonable paths:
-
-1. **Stdlib `subprocess` dispatch.** Write each buffer to a temp WAV
-   and invoke `/usr/bin/afplay` (macOS) or `aplay`/`paplay` (Linux).
-   Simple, no deps, but latency is ~50-150 ms per buffer — noticeable
-   for keystroke feedback.
-2. **Small C extension via `ctypes`.** Bind to CoreAudio (macOS) or
-   ALSA (Linux) directly. Better latency, no new Python deps, but
-   non-trivial to build and test.
-
-Either way the implementation goes in `asat/audio_sink.py` behind
-the same `AudioSink` protocol, and `pick_live_sink()` learns new
-branches. A queueing strategy (drop in-flight keystroke cues when a
-narration voice starts) should be designed together with this.
+**Status: Shipped (pending cross-platform hands-on smoke).** PR 1
+of the 2026-04 MVP stabilization roadmap added `PosixLiveAudioSink`
+to `asat/audio_sink.py`. The sink writes each buffer to a temp
+in-memory WAV and pipes it to the first available player binary on
+PATH — `aplay` / `paplay` (Linux via ALSA or PulseAudio /
+PipeWire), `afplay` (macOS). `pick_live_sink()` now returns a
+working live sink on every supported platform: `WindowsLiveAudioSink`
+on Windows, `PosixLiveAudioSink` on Linux / macOS. `LiveAudioUnavailable`
+surfaces only when no player binary is installed; the silent-sink
+guard then names the binaries to install. The latency trade-off
+called out in the original sketch (subprocess dispatch per buffer)
+is accepted — it's noticeable on rapid keystroke cues but acceptable
+for the MVP. Still owed: hands-on verification that audible output
+reaches real speakers on a fresh Linux and macOS box (see
+[HANDOFF.md](HANDOFF.md)).
 
 ---
 
@@ -883,6 +886,15 @@ path. F61 already ships with `Cell.kind` defaulting to
 
 ## F28 — Speech output console (programmatic + braille / screen-reader routing)
 
+**Status: Partially shipped.** PR 1 of the 2026-04 MVP
+stabilization roadmap addressed the "plug in a different engine"
+half via `asat/tts_registry.py` and the `:tts use / set` meta-
+commands — a screen-reader user can now point ASAT at their
+preferred backend without recompiling. The **capture** and
+**routing** halves below (SPEECH_RENDERED event, `SpeechConsole`
+ring, `SpeechRouter` protocol, braille / NVDA controller hooks)
+are still open.
+
 **Gap.** When a binding fires with a `say_template`, the rendered
 phrase goes straight into `SoundEngine` and out to audio. Nothing
 captures the *text* of what is being spoken in a user- or test-
@@ -1242,6 +1254,23 @@ discoverable from the cheat sheet itself.
 
 ## F39 — Interactive event log viewer (trigger → jump → edit)
 
+**Status: Shipped (pending end-to-end hands-on smoke).** PR 3 of
+the 2026-04 MVP stabilization roadmap landed every sub-PR from
+F39a through F39d in a single shot: `asat/event_log.py` holds the
+`EventLogViewer` with a bounded 200-entry ring,
+`FocusMode.EVENT_LOG` was added, `Ctrl+E` / `:log` / `:log tail`
+are wired, and every per-entry action works — `Enter` jumps to the
+binding's `say_template` field via `SettingsController.open_at_
+binding(binding_id)`, `e` cycles the four-field quick-edit,
+`t` replays the event through the live pipeline, and `Escape`
+returns to the prior focus mode. The five new events
+(`EVENT_LOG_OPENED` / `_CLOSED` / `_FOCUSED` /
+`_QUICK_EDIT_COMMITTED` / `_REPLAYED`) are in
+`COVERED_EVENT_TYPES`, `SAMPLE_PAYLOADS`, `default_bank.py`,
+`docs/EVENTS.md`, and `docs/USER_MANUAL.md`. Still owed: the
+full trigger → jump → edit → replay loop on a real user's host
+(see [HANDOFF.md](HANDOFF.md)).
+
 **Gap.** ASAT publishes rich typed events on every state change
 (`asat/events.py`), but there is no user-facing surface that shows
 the recent event stream, and no path from "I just heard a cue I
@@ -1335,6 +1364,18 @@ today: *"I heard a cue I didn't like — where do I change it?"*
 ---
 
 ## F40 — Speech viewer (programmatic + on-screen narration log)
+
+**Status: Partially shipped.** PR 3 of the 2026-04 MVP
+stabilization roadmap delivered the **user-facing** viewer half:
+the `asat/event_log.py` `EventLogViewer` surfaces every narrated
+event (each entry already holds the rendered narration string),
+Up / Down walks the ring, `t` re-reads a specific entry, and
+`Escape` exits. The F39 viewer therefore covers the scroll-back
+use-case for blind users who missed a word. Still open: the
+**programmatic** half — a dedicated `SpeechConsole` + explicit
+`SPEECH_RENDERED` event fired *before* TTS synthesis so external
+routers (braille, NVDA controller) can replace or suppress it.
+That belongs with F28's routing leg and should land as one PR.
 
 **Gap.** `SoundEngine` renders `say_template` phrases and hands
 the final text to TTS (`asat/sound_engine.py`), but nothing
@@ -1481,7 +1522,7 @@ quick-start; cross-reference from F41's silent-sink hint.
 
 ## F43 — Guided first-command tour
 
-**Status: Shipped.**
+**Status: Shipped (minimal + full scripted follow-through).**
 
 **Gap (at time of shipping).** F20 narrated a welcome and explained
 the key meta-commands but stopped there. The user was then dropped
@@ -1491,7 +1532,7 @@ the newcomer still had to invent their own first command to hear
 what `COMMAND_SUBMITTED` / `COMMAND_STARTED` / `COMMAND_COMPLETED`
 / exit-code narration sounded like.
 
-**Sketch (shipped).** `asat/onboarding.py` gained
+**Sketch (first pass).** `asat/onboarding.py` gained
 `FIRST_RUN_TOUR_COMMAND = "echo hello, ASAT"` + a short
 `FIRST_RUN_TOUR_LINES` prompt and a new
 `OnboardingCoordinator.publish_tour_step(...)` helper.
@@ -1501,12 +1542,26 @@ the build seeded a fresh session, `cursor.new_cell(...)` is called
 with the tour command so the newcomer's first Enter press exercises
 the full submit → start → complete → exit-code arc. The tour step
 fires after the welcome event so the audio order is "welcome, then
-prompt". If the user clears or rewrites the pre-filled line before
-pressing Enter, the tour is considered complete — the coordinator
-never re-inserts. A new `FIRST_RUN_TOUR_STEP` event in
-`asat/events.py` carries `command` + `lines`; the default bank
-binds it to the narrator voice. `--quiet` / `--check` skip
-onboarding entirely, which transparently skips the tour too.
+prompt". A new `FIRST_RUN_TOUR_STEP` event in `asat/events.py`
+carries `command` + `lines`; the default bank binds it to the
+narrator voice. `--quiet` / `--check` skip onboarding entirely,
+which transparently skips the tour too.
+
+**Follow-through (PR 4 of the 2026-04 MVP stabilization roadmap).**
+The tour grew from one beat to five. `OnboardingCoordinator` gained
+`publish_event_log_preview_beat`, `publish_log_path_beat`, and
+`publish_tour_completed_beat`; `publish_tour_step` gained a
+`replay: bool` kwarg. `Application.build` now seeds a
+`H1 + H2 + COMMAND` demo notebook using
+`FIRST_RUN_OUTLINE_HEADINGS` so the PR 2 outline pane has
+structure to render; `_run_scripted_tour(replay=False)` publishes
+all four scripted beats in order (tour step, event-log preview,
+log-path, completed). Three new event types —
+`FIRST_RUN_TOUR_EVENT_LOG_PREVIEW`, `FIRST_RUN_TOUR_LOG_PATH`,
+`FIRST_RUN_TOUR_COMPLETED` — carry a `replay` payload marker so the
+`:welcome` replay can be distinguished from the genuine first run.
+The log-path beat is gated by `predicate="path != ''"` so the
+narration never fires with an empty path (no file logger attached).
 
 ---
 
@@ -1535,8 +1590,13 @@ when `onboarding is None` (--quiet or --check) the meta-command
 is a harmless no-op. Tests: three new coordinator cases, two
 Application cases, one router case.
 
-F43 (guided first-command tour) follow-up: `:welcome tour` as a
-richer variant remains on the F43 entry once that lands.
+F43 (guided first-command tour) follow-up landed in PR 4 of the
+2026-04 MVP stabilization roadmap: `:welcome` now replays every
+scripted beat (welcome, tour step, event-log preview, log-path,
+completed) with `replay=True` in each payload and does **not**
+re-seed the demo cells, so the user's notebook survives the
+replay. `:welcome` without an active `OnboardingCoordinator`
+(`--quiet` / `--check`) stays a harmless no-op.
 
 ---
 
@@ -3491,12 +3551,27 @@ killing-the-shell, sentinel-prefix-mid-line) and
 
 ## F61 — Cell hierarchy: sections, folds, and grouping
 
-**Sketch (partially shipped).** The flat `Session.cells` list now
-has a polymorphic `Cell.kind: CellKind` discriminator with two
-values: `COMMAND` (the existing executable cell) and `HEADING`
-(an announce-only section header carrying `heading_level` 1-6 and
-`heading_title`). Heading cells cannot be executed (`mark_running`
-/ `update_command` guard on `is_executable`); `Application.execute`
+**Status: Shipped (render leg, pending on-screen smoke).** PR 2 of
+the 2026-04 MVP stabilization roadmap shipped the on-screen
+outline pane that the earlier partial work had been missing:
+`asat/outline.py` exposes a pure `render_outline(cells,
+focus_cell_id, max_width)` helper, `asat/terminal.TerminalRenderer`
+subscribes to `FOCUS_CHANGED` / `CELL_*` / outline-fold events and
+repaints the pane (ANSI-clear redraw on TTY, append-only trace
+when piped), and `--view {trace,outline,both}` picks which panes
+show on a TTY. The fold / collapse leg (`z` toggles,
+`OUTLINE_FOLDED` / `OUTLINE_UNFOLDED` events, scope-based
+selection) also shipped. Still owed: hands-on confirmation that
+the repaint behaves on a real user's TTY (see
+[HANDOFF.md](HANDOFF.md)).
+
+**Sketch (partially shipped earlier, now complete for the MVP).**
+The flat `Session.cells` list now has a polymorphic
+`Cell.kind: CellKind` discriminator with two values: `COMMAND`
+(the existing executable cell) and `HEADING` (an announce-only
+section header carrying `heading_level` 1-6 and `heading_title`).
+Heading cells cannot be executed (`mark_running` /
+`update_command` guard on `is_executable`); `Application.execute`
 short-circuits if the target cell is a heading. Session JSON
 gained `kind` / `heading_level` / `heading_title` fields with
 backward compatibility — a missing `kind` defaults to `COMMAND` so
@@ -3512,13 +3587,6 @@ typing). `FOCUS_CHANGED` now carries `kind` / `heading_level` /
 `heading_title`; the default sound bank branches on
 `transition == cell and kind == 'heading'` to voice "heading level
 N: title" instead of the usual `{command}` readout.
-
-**Remaining.** Parent-scope navigation (`{` / `}` jump to the
-enclosing heading), fold / collapse (`z` toggles), and scope-
-based selection (`select_heading_scope()` picks the focused
-heading plus its children through the next same-level heading)
-are still open. Those layer on top of the current flat
-implementation without rewriting it.
 
 **Forward-looking notes.**
 
@@ -3606,8 +3674,21 @@ so their deterministic ordering holds.
 
 ## F63 — Event log as an append-only text file grouped by user interaction
 
-**Gap.** F39 sketches an *interactive* event log viewer — an
-in-process ring buffer the user can walk. What's missing is the
+**Status: Shipped.** PR 3 of the 2026-04 MVP stabilization
+roadmap added `asat/event_log_file.py`, a wildcard subscriber
+that writes `<workspace>/.asat/log/events-YYYY-MM-DD.log` (one
+file per local day). Formatting follows the sketch below — every
+`KEY_PRESSED` opens a new group, every downstream event is
+indented one level and annotated with its source module. Auto-
+flush on every write, tail-safe. Auto-enabled when a workspace
+is open; otherwise the CLI takes `--log-events DIR`. The `:log
+tail` meta-command wires the file back into the interactive F39
+viewer. Silent-sink guard (F41) applies — a read-only workspace
+degrades to `stderr`.
+
+**Gap (pre-shipping).** F39 sketched an *interactive* event log
+viewer — an in-process ring buffer the user can walk. What was
+missing was the
 other half: a plain text file on disk that records every event,
 grouped so a human (or `grep`) can see which user interaction
 caused which downstream effect. Today a developer asking "what

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,0 +1,194 @@
+# ASAT handoff snapshot (2026-04-20)
+
+This file is the first thing a fresh AI-coding session (or a new
+human contributor) should read when picking up ASAT. It records
+**what was shipped in the 2026-04 MVP stabilization roadmap, what
+is verified by the test suite, and what still needs hands-on smoke
+before 1.0 can be tagged.**
+
+[`README.md`](../README.md) and [`ARCHITECTURE.md`](ARCHITECTURE.md)
+are the two other files a new contributor should read after this
+one; [`DEVELOPER_GUIDE.md`](DEVELOPER_GUIDE.md) is the PR recipe;
+[`FEATURE_REQUESTS.md`](FEATURE_REQUESTS.md) is the remaining
+roadmap.
+
+## TL;DR
+
+- **1295 tests pass** on `python -m unittest discover -s tests -t .`
+  as of the last commit on `main`.
+- **Four MVP surfaces** — live audio, outline pane, interactive
+  event log, scripted first-run tour — are wired and covered by
+  unit + integration tests, but the cross-platform hands-on smoke
+  below is **not** yet complete.
+- **Do not start PR 5.** Take the outstanding smoke list to your
+  shell first; any follow-up PR should be scoped from what that
+  smoke reveals, not from speculation.
+
+## What the 2026-04 roadmap delivered
+
+Each PR flipped one observable end-user behaviour at launch. The
+plan that scoped them is archived at
+`/root/.claude/plans/scalable-seeking-forest.md` in the session
+host; this section is the authoritative summary on disk.
+
+### PR 1 — live audio on every platform (merged #??)
+
+- New `asat/tts_registry.py` with `Pyttsx3Engine`,
+  `EspeakNgEngine`, `SystemSayEngine`, `ToneTTSEngine` adapters
+  behind the existing `TTSEngine` Protocol.
+- `PosixLiveAudioSink` added to `asat/audio_sink.py` — pipes WAV
+  blobs to `aplay` / `paplay` / `afplay`. `pick_live_sink()`
+  returns it on Linux / macOS.
+- New meta-commands: `:tts list`, `:tts use <id>`, `:tts set
+  <param> <value>`.
+- `--live` is default on a TTY; F41 silent-sink guard re-phrases to
+  name the player binaries to install.
+
+**Closes:** F5 (Windows-native TTS / cross-platform), F6
+(live-speaker sink POSIX), F28 (pluggable engine) — each marked
+with a status block + follow-up notes in `FEATURE_REQUESTS.md`.
+
+### PR 2 — on-screen outline pane (merged #93)
+
+- `asat/outline.py` exposes a pure `render_outline(cells,
+  focus_cell_id, max_width) -> list[str]`.
+- `asat/terminal.TerminalRenderer` now subscribes to `FOCUS_CHANGED`
+  / `CELL_*` / outline-fold events and repaints the pane; ANSI-clear
+  redraw on TTY, append-only trace when piped.
+- `--view {trace,outline,both}` CLI flag, default `both` on TTY,
+  `trace` under `--quiet` or a non-TTY.
+- `]` / `[` moves both the audio cursor and the `>` visual marker.
+
+**Closes:** F27 render leg, F40 (on-screen narration log — the
+outline is the narrated tree), F61 (cell hierarchy render).
+
+### PR 3 — interactive event-log viewer + grouped file log (merged #94)
+
+- `asat/event_log.py` — `EventLogViewer` holds a bounded ring of
+  200 entries, narrator-formatted strings, `focus_latest` /
+  `focus_previous` / `focus_next`, quick-edit sub-mode cycling
+  `say_template` / `voice_id` / `enabled` / `volume`, replay
+  helper.
+- `asat/event_log_file.py` — wildcard subscriber writing
+  `<workspace>/.asat/log/events-YYYY-MM-DD.log` grouped by
+  `KEY_PRESSED`. Auto-enabled with a workspace; otherwise
+  `--log-events DIR`.
+- `FocusMode.EVENT_LOG` added; `Ctrl+E`, `:log`, `:log tail`,
+  Up / Down / Enter / Escape / `e` / `t` wired.
+- `SettingsController.open_at_binding(binding_id)` jumps to the
+  binding's field.
+- Six new event types: `EVENT_LOG_OPENED`, `EVENT_LOG_CLOSED`,
+  `EVENT_LOG_FOCUSED`, `EVENT_LOG_QUICK_EDIT_COMMITTED`,
+  `EVENT_LOG_REPLAYED`.
+
+**Closes:** F39 (trigger → jump → edit → replay), F63 (grouped
+text log).
+
+### PR 4 — scripted first-run tour (merged #95)
+
+- `asat/onboarding.OnboardingCoordinator` gained four new beat
+  publishers (`publish_tour_step`, `publish_event_log_preview_beat`,
+  `publish_log_path_beat`, `publish_tour_completed_beat`), each
+  carrying a `replay: bool` payload marker.
+- `asat/app.Application.build` seeds a `H1 + H2 + command` demo
+  notebook on first run, then calls `_run_scripted_tour
+  (replay=False)`.
+- `:welcome` replays every beat with `replay=True` and does **not**
+  re-seed cells.
+- Three new event types: `FIRST_RUN_TOUR_EVENT_LOG_PREVIEW`,
+  `FIRST_RUN_TOUR_LOG_PATH`, `FIRST_RUN_TOUR_COMPLETED`.
+- Log-path announcement gated by `predicate="path != ''"` so the
+  narration never fires with an empty path.
+
+**Closes:** F43 follow-through, F44 (`:welcome` replay parity).
+
+## Per-surface verification state
+
+| Surface                    | Code on `main` | Unit tests   | Integration in `test_app.py` | Hands-on smoke pending |
+|----------------------------|----------------|--------------|-------------------------------|------------------------|
+| Live audio (POSIX + Win)   | yes            | yes          | yes                           | Linux + macOS + Win    |
+| Outline pane renderer      | yes            | yes          | yes                           | real TTY repaint       |
+| Event-log viewer + file    | yes            | yes          | yes                           | edit + replay loop     |
+| Scripted first-run tour    | yes            | yes          | yes                           | fresh-VM sentinel wipe |
+
+The test suite proves every surface works **in the dev sandbox's
+headless fake terminal + `MemorySink`**. None of it proves audio
+comes out of real speakers on a real user's machine.
+
+## Outstanding manual smoke (before tagging 1.0)
+
+1. **Fresh-VM install, Linux.** Spin up a clean Ubuntu or Fedora
+   VM, `pip install pyttsx3`, `apt install espeak-ng alsa-utils`,
+   remove `~/.asat/first-run-done`, run `python -m asat`. Confirm:
+   (a) audible welcome chime, (b) spoken tour, (c) visible outline
+   pane, (d) `Ctrl+E` opens the viewer and narrates entries,
+   (e) `:quit` exits cleanly. Same VM: `python -m asat --check`
+   must exit 0.
+2. **Fresh-VM install, macOS.** Same flow on a stock macOS box;
+   `say` and `afplay` ship by default, so no extra install. Confirm
+   items (a)-(e).
+3. **Fresh install, Windows.** On a stock Windows host with SAPI,
+   run `python -m asat`. Confirm items (a)-(e); `winsound` should
+   still drive the live sink.
+4. **TTS engine swap.** On each platform: `:tts list` speaks
+   available engines; `:tts use <id>` switches live; the next
+   narration uses the new voice; `:tts set rate 200` changes speed
+   without restart.
+5. **Edit-in-place loop.** `echo hi`, `Ctrl+E`, `Up` to the
+   `command.completed` entry, `Enter` → SETTINGS opens at that
+   binding, `e` edits `say_template`, `Enter` commits, `Escape`
+   back to viewer, `t` replays — the new phrase must be heard.
+6. **Event log file.** With a workspace open, `tail -f
+   <workspace>/.asat/log/events-*.log` must grow as events fire,
+   grouped by `key_pressed`.
+
+When each check above has been run and documented, update
+`FEATURE_REQUESTS.md` to mark the feature "verified on <platform>
+<date>" and re-generate `docs/BINDINGS.md` if any binding text
+changed.
+
+## Gotchas a fresh chat will not know
+
+- **Predicate DSL is not Python.** `EventBinding.predicate` is the
+  DSL documented in [ARCHITECTURE.md § Predicate DSL](ARCHITECTURE.md#predicate-dsl);
+  `key op literal` only, no attribute access, no `and` / `or`. The
+  default binding for `FIRST_RUN_TOUR_LOG_PATH` gates on
+  `predicate="path != ''"` for exactly this reason — an earlier
+  attempt at `payload.path` silently dropped every event.
+- **Sync gates cascade.** Adding a single `EventType` member
+  requires: (1) a `SAMPLE_PAYLOADS` entry in
+  `asat/sample_payloads.py`, (2) a row in `docs/EVENTS.md`, (3) a
+  binding in `asat/default_bank.py` if it's a user-audible event,
+  (4) regenerating `docs/BINDINGS.md`. Missing any one produces a
+  test failure in a file that does not mention your event; see
+  [ARCHITECTURE.md § Sync gates](ARCHITECTURE.md#sync-gates) for
+  the full table.
+- **`_replay_welcome` must not re-seed cells.** `:welcome` is idempotent
+  by design — the user's notebook must survive. Only the first-run
+  code path in `Application.build` owns cell seeding; tests pin
+  this behaviour (`test_welcome_meta_command_replays_every_scripted
+  _beat`).
+- **`pick_live_sink()` raises on POSIX only if no player is
+  installed.** The hosts that ship `aplay` / `paplay` /
+  `afplay` unconditionally are most distros + macOS; a Docker
+  `python:3.12-slim` image has none. `--no-live` on such hosts is
+  legitimate, not a bug.
+- **Git / PR workflow in this repo.** The user creates and merges
+  PRs manually from the pushed branch; the assistant pushes and
+  provides a PR-creation URL. MCP GitHub integration has been
+  flaky in recent sessions. Follow the branch-naming precedent on
+  `main` (e.g. `claude/mvp-pr5-…` for the next focused PR).
+
+## Where to pick up next
+
+The two natural follow-ups once the smoke list is clean:
+
+- **F2 — Settings editor: create / delete records.** The editor
+  can modify existing records but not add or remove them. See the
+  sketch in `FEATURE_REQUESTS.md § F2`.
+- **F4 deferred leg — Ctrl+R reverse-incremental history search.**
+  Up / Down recall shipped; reverse-incremental needs a composer
+  overlay analogous to the SETTINGS `/` search.
+
+Neither is blocking 1.0; both are the right size for a fresh-chat
+PR.


### PR DESCRIPTION
Closes the 2026-04 MVP stabilization roadmap with a docs-only pass so a fresh chat or new contributor can pick up the project cleanly:

- New docs/HANDOFF.md — per-surface verification state, outstanding cross-platform hands-on smoke, predicate-DSL and sync-gate gotchas a fresh reader will not know.
- README.md quickstart rewritten for the post-PR-1 reality: bare `python -m asat` now speaks on every platform, the scripted first-run tour + Ctrl+E event log are the first-five-minutes path, the module and docs tables list every shipping module.
- docs/ARCHITECTURE.md module map extended with the new surfaces (tts_registry, outline, event_log, event_log_file, self_check, sample_payloads, etc.); adds an MVP-surfaces section, a sync-gates table naming every test that fails when code and docs drift, and a Predicate DSL reference spelling out the `key op literal` restriction.
- docs/FEATURE_REQUESTS.md now flags F5, F6, F27, F28, F39, F40, F43, F44, F61, F63 as shipped-with-manual-smoke-pending and links each to HANDOFF.md; adds a roadmap-status intro explaining which PR addressed which feature.

No code changed; all 1295 tests still pass.