### PR TITLE
Reliability hardening: Never Crashes invariant (Workstream 1)

### DIFF
--- a/asat/__main__.py
+++ b/asat/__main__.py
@@ -35,6 +35,8 @@ from typing import Optional, Sequence
 from asat import __version__
 from asat.actions import SystemClipboard
 from asat.app import Application
+from asat.event_bus import EventBusError, publish_event
+from asat.events import EventType
 from asat.audio_sink import (
     AudioSink,
     LiveAudioUnavailable,
@@ -211,14 +213,77 @@ def _print_check_report(app: Application, args: argparse.Namespace) -> int:
 
 
 def _run(app: Application, keyboard: KeyboardReader) -> None:
-    """Read keys until the Application flags itself as done."""
+    """Read keys until the Application flags itself as done.
+
+    Reliability contract (Never Crashes invariant): any exception
+    raised below ``keyboard.read_key()`` — including ``EventBusError``
+    aggregated from a failed audio handler — is caught, sonified via
+    ``AUDIO_PIPELINE_FAILED``, and logged to stderr. The loop keeps
+    running. Only ``KeyboardInterrupt`` (Ctrl+C) and ``SystemExit``
+    bubble out; everything else is survivable.
+
+    ``SoundEngine`` is the first line of defense — it guards its own
+    ``_dispatch`` and plays a fail-audible error tone when a binding
+    renders wrong. This supervisor is the belt-and-braces net for
+    anything that escapes: a broken keyboard reader, a bug in the
+    input router, an exception thrown by ``app.execute``'s kernel.
+    """
     while app.running:
-        key = keyboard.read_key()
+        try:
+            key = keyboard.read_key()
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as exc:  # noqa: BLE001 — intentional last-resort catch
+            _report_loop_failure(app, where="keyboard.read_key", error=exc)
+            continue
         if key is None:
             break
-        app.handle_key(key)
-        for cell_id in app.drain_pending():
-            app.execute(cell_id)
+        try:
+            app.handle_key(key)
+            for cell_id in app.drain_pending():
+                app.execute(cell_id)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as exc:  # noqa: BLE001 — intentional last-resort catch
+            _report_loop_failure(app, where="handle_key/execute", error=exc)
+
+
+def _report_loop_failure(app: Application, *, where: str, error: BaseException) -> None:
+    """Publish AUDIO_PIPELINE_FAILED and log to stderr; never raise.
+
+    Triple-guarded: publishing the failure event itself may raise
+    (e.g. an ``EventBusError`` aggregating a downstream subscriber),
+    so we wrap the publish and the stderr write in their own
+    try/except. If literally everything fails, the loop still
+    continues — silence is better than a crash.
+    """
+    try:
+        publish_event(
+            app.bus,
+            EventType.AUDIO_PIPELINE_FAILED,
+            {
+                "event_type": where,
+                "binding_id": "",
+                "error_class": type(error).__name__,
+                "error_message": str(error),
+            },
+            source="main_loop_supervisor",
+        )
+    except Exception:
+        # SoundEngine's own _handle_render_failure guard should have
+        # absorbed any downstream failure, but just in case there is
+        # a second-level aggregate, swallow it here.
+        pass
+    try:
+        print(
+            f"[asat] recovered from error in {where}: "
+            f"{type(error).__name__}: {error}",
+            file=sys.stderr,
+        )
+    except Exception:
+        # stderr may be closed / redirected to a dead pipe; don't
+        # let that take the loop down.
+        pass
 
 
 def _parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:

--- a/asat/audio_sink.py
+++ b/asat/audio_sink.py
@@ -40,6 +40,7 @@ import shutil
 import struct
 import subprocess
 import sys
+import threading
 import wave
 from pathlib import Path
 from typing import Optional, Protocol
@@ -394,6 +395,13 @@ class PosixLiveAudioSink:
         """Path of the player binary this sink uses (for diagnostics)."""
         return self._binary
 
+    # Budget for writing the WAV bytes into the player's stdin. Every
+    # buffer we emit is tens to hundreds of KB; even the slowest real
+    # player drains it in <50ms on modern hardware. If we hit 500ms,
+    # the player is wedged and we kill it so a stuck backend cannot
+    # block the event loop that's trying to speak to the user.
+    WRITE_TIMEOUT_SECONDS = 0.5
+
     def play(self, buffer: AudioBuffer) -> None:
         """Render the buffer to WAV bytes and pipe them to the player."""
         self._kill_previous()
@@ -414,16 +422,48 @@ class PosixLiveAudioSink:
             ) from exc
         if self._process.stdin is None:
             return  # pragma: no cover - Popen with stdin=PIPE always sets it.
-        try:
-            self._process.stdin.write(data)
-            self._process.stdin.close()
-        except (BrokenPipeError, ValueError):
-            # The player exited before we could finish writing — this
-            # can happen when the next `play()` kills the prior one
-            # mid-write, or when the device is suddenly unavailable.
-            # Neither case is fatal: the subsequent play() will try
-            # fresh.
-            pass
+        self._write_with_watchdog(self._process, data)
+
+    def _write_with_watchdog(
+        self, process: subprocess.Popen[bytes], data: bytes
+    ) -> None:
+        """Write ``data`` to ``process.stdin`` with a hard timeout.
+
+        Runs the write on a background thread and joins for at most
+        ``WRITE_TIMEOUT_SECONDS``. If the thread hasn't returned — the
+        player hung without draining its stdin — we terminate the
+        process so the next ``play()`` can start fresh. Broken pipes
+        and closed streams are tolerated silently; the next event
+        will re-try with a new subprocess.
+        """
+        def _write() -> None:
+            assert process.stdin is not None  # narrowed above
+            try:
+                process.stdin.write(data)
+                process.stdin.close()
+            except (BrokenPipeError, ValueError, OSError):
+                # Player exited before we finished writing, or stdin
+                # was closed by a concurrent kill. Both recoverable —
+                # the next play() will spawn a fresh subprocess.
+                pass
+
+        thread = threading.Thread(target=_write, daemon=True)
+        thread.start()
+        thread.join(timeout=self.WRITE_TIMEOUT_SECONDS)
+        if thread.is_alive():
+            # The player isn't draining stdin; kill it so we don't
+            # block forever on the next play() call. The thread is
+            # daemon so it will not prevent process exit.
+            try:
+                process.terminate()
+            except ProcessLookupError:
+                pass
+            thread.join(timeout=0.1)
+            if thread.is_alive():
+                try:
+                    process.kill()
+                except ProcessLookupError:
+                    pass
 
     def close(self) -> None:
         """Stop any in-flight clip so the process exits quietly."""

--- a/asat/default_bank.py
+++ b/asat/default_bank.py
@@ -114,6 +114,8 @@ COVERED_EVENT_TYPES: frozenset[EventType] = frozenset({
     EventType.FIRST_RUN_TOUR_EVENT_LOG_PREVIEW,
     EventType.FIRST_RUN_TOUR_LOG_PATH,
     EventType.FIRST_RUN_TOUR_COMPLETED,
+    EventType.AUDIO_PIPELINE_FAILED,
+    EventType.AUDIO_SINK_DEGRADED,
 })
 
 
@@ -422,6 +424,32 @@ def _default_bindings() -> tuple[EventBinding, ...]:
             sound_id="soft_tick",
             say_template="bank reloaded from disk",
             priority=175,
+            verbosity="minimal",
+        ),
+
+        # Reliability: these two bindings narrate the fail-audible
+        # fallback that SoundEngine emits when the main render path
+        # hits an exception (AUDIO_PIPELINE_FAILED) or when the live
+        # sink has failed too many times and has been swapped for
+        # MemorySink (AUDIO_SINK_DEGRADED). The immediate "error tone"
+        # the user hears is played directly by SoundEngine without
+        # going through the binding system — these bindings are the
+        # follow-up spoken context, which itself may fail and that's
+        # fine: the error tone already told the user something broke.
+        EventBinding(
+            id="audio_pipeline_failed",
+            event_type=EventType.AUDIO_PIPELINE_FAILED.value,
+            voice_id="alert",
+            say_template="audio failed on {event_type}: {error_class}",
+            priority=190,
+            verbosity="minimal",
+        ),
+        EventBinding(
+            id="audio_sink_degraded",
+            event_type=EventType.AUDIO_SINK_DEGRADED.value,
+            voice_id="alert",
+            say_template="audio output disabled: {reason}",
+            priority=195,
             verbosity="minimal",
         ),
 

--- a/asat/events.py
+++ b/asat/events.py
@@ -64,7 +64,8 @@ class EventType(str, Enum):
         ANSI_LINE_ERASED, ANSI_OSC_RECEIVED, ANSI_BELL
 
     Audio engine:
-        AUDIO_SPOKEN, AUDIO_INTERRUPTED, NARRATION_REPLAYED
+        AUDIO_SPOKEN, AUDIO_INTERRUPTED, NARRATION_REPLAYED,
+        AUDIO_PIPELINE_FAILED, AUDIO_SINK_DEGRADED
 
     Help surface:
         HELP_REQUESTED
@@ -173,6 +174,8 @@ class EventType(str, Enum):
 
     AUDIO_SPOKEN = "audio.spoken"
     AUDIO_INTERRUPTED = "audio.interrupted"
+    AUDIO_PIPELINE_FAILED = "audio.pipeline.failed"
+    AUDIO_SINK_DEGRADED = "audio.sink.degraded"
     NARRATION_REPLAYED = "audio.narration.replayed"
 
     HELP_REQUESTED = "help.requested"

--- a/asat/sample_payloads.py
+++ b/asat/sample_payloads.py
@@ -105,6 +105,16 @@ SAMPLE_PAYLOADS: dict[EventType, dict[str, object]] = {
         "items": [],
     },
     EventType.INTERACTIVE_MENU_CLEARED: {"cell_id": "c1"},
+    EventType.AUDIO_PIPELINE_FAILED: {
+        "event_type": "command.completed",
+        "binding_id": "command-completed-default",
+        "error_class": "TTSEngineError",
+        "error_message": "espeak-ng returned empty WAV on stdout",
+    },
+    EventType.AUDIO_SINK_DEGRADED: {
+        "previous_sink": "SoundDeviceSink",
+        "reason": "3 consecutive sink failures; swapped to MemorySink",
+    },
     EventType.SETTINGS_OPENED: {"section": "voices", "record_count": 3},
     EventType.SETTINGS_CLOSED: {"dirty": False},
     EventType.SETTINGS_FOCUSED: {

--- a/asat/sound_engine.py
+++ b/asat/sound_engine.py
@@ -44,7 +44,7 @@ from asat.audio import (
     SpatialPosition,
     VoiceProfile,
 )
-from asat.audio_sink import AudioSink
+from asat.audio_sink import AudioSink, MemorySink
 from asat.event_bus import EventBus, publish_event
 from asat.events import Event, EventType
 from asat.hrtf import HRTFProfile, Spatializer
@@ -54,6 +54,46 @@ from asat.tts import TTSEngine, ToneTTSEngine
 
 
 NARRATION_HISTORY_CAPACITY = 20
+
+# Reliability: when the live sink raises this many times in a row we
+# assume the device is gone for the session and swap `MemorySink` in
+# so further events stop trying to play into a broken backend. The
+# swap publishes `AUDIO_SINK_DEGRADED`; a re-launch with `--live` is
+# the recovery path.
+MAX_CONSECUTIVE_SINK_FAILURES = 3
+
+
+def _build_error_tone_buffer(sample_rate: int = DEFAULT_SAMPLE_RATE) -> AudioBuffer:
+    """Return a distinct 3-note descending error tone.
+
+    Played directly by ``SoundEngine`` when the normal render path
+    raises — it's the "fail-audible" floor the user can rely on even
+    when TTS, the spatializer, the sound bank, or the binding system
+    is broken. Must depend on nothing outside ``AudioBuffer`` so it
+    cannot itself fail the same way the primary path just failed.
+
+    The shape (800 Hz → 600 Hz → 400 Hz, 80 ms each, short gaps) was
+    chosen to be clearly distinguishable from any of the default
+    bank's cues and to carry the universal "descending = something
+    went wrong" connotation.
+    """
+    import math
+
+    note_duration_s = 0.08
+    gap_duration_s = 0.02
+    frequencies = (800.0, 600.0, 400.0)
+    samples: list[float] = []
+    frame_count = int(note_duration_s * sample_rate)
+    gap_frames = int(gap_duration_s * sample_rate)
+    for freq in frequencies:
+        omega = 2.0 * math.pi * freq / sample_rate
+        for frame in range(frame_count):
+            # Envelope with a brief attack/release so the tone doesn't
+            # click audibly at buffer boundaries.
+            fade = min(1.0, frame / 80.0, (frame_count - frame) / 80.0)
+            samples.append(0.35 * fade * math.sin(omega * frame))
+        samples.extend(0.0 for _ in range(gap_frames))
+    return AudioBuffer.mono(samples, sample_rate=sample_rate)
 
 
 class NarrationHistoryEntry(NamedTuple):
@@ -151,6 +191,18 @@ class SoundEngine:
         )
         self._bank: SoundBank = SoundBank()
         self._subscribed_types: set[EventType] = set()
+        # Reliability: pre-compute the fail-audible error tone once
+        # so rendering it later requires nothing but sink.play().
+        self._error_tone_buffer: AudioBuffer = _build_error_tone_buffer(
+            sample_rate
+        )
+        # Consecutive sink failure counter. Reset on every successful
+        # play; when it hits MAX_CONSECUTIVE_SINK_FAILURES we swap the
+        # sink for MemorySink and publish AUDIO_SINK_DEGRADED.
+        self._sink_failure_count: int = 0
+        # Re-entrancy guard for error-tone playback and failure events
+        # so a failure in the failure path cannot recurse infinitely.
+        self._handling_failure: bool = False
         self.set_bank(bank)
 
     @property
@@ -298,17 +350,41 @@ class SoundEngine:
         self._subscribed_types = wanted
 
     def _dispatch(self, event: Event) -> None:
-        """Render every matching binding and play the result."""
+        """Render every matching binding and play the result.
+
+        Reliability contract (Never Crashes invariant): this method
+        never raises. A failure in predicate evaluation, binding
+        lookup, or rendering is caught, sonified with the fail-audible
+        error tone, and reported via ``AUDIO_PIPELINE_FAILED``. The
+        session always continues.
+        """
         if event.source == self.SOURCE:
             return
-        bindings = self._bank.bindings_for(event.event_type.value)
+        try:
+            bindings = self._bank.bindings_for(event.event_type.value)
+        except Exception as exc:
+            self._handle_render_failure(event, binding_id="", error=exc)
+            return
         for binding in bindings:
-            if not self._predicate.matches(binding.predicate, event.payload):
+            try:
+                matches = self._predicate.matches(binding.predicate, event.payload)
+            except Exception as exc:
+                self._handle_render_failure(event, binding_id=binding.id, error=exc)
                 continue
-            self._render(binding, event)
+            if not matches:
+                continue
+            try:
+                self._render(binding, event)
+            except Exception as exc:
+                self._handle_render_failure(event, binding_id=binding.id, error=exc)
 
     def _render(self, binding: EventBinding, event: Event) -> None:
-        """Render one binding into audio and route it to the sink."""
+        """Render one binding into audio and route it to the sink.
+
+        Raises whatever the underlying TTS / spatializer / generator /
+        sink raise. ``_dispatch`` is the single caller and is
+        responsible for the fail-audible fallback.
+        """
         voice = self._resolve_voice(binding)
         sound = self._resolve_sound(binding)
         text = _render_template(binding.say_template, event.payload)
@@ -338,6 +414,9 @@ class SoundEngine:
         if mixed is None:
             return
         self._sink.play(mixed)
+        # A successful play resets the consecutive-sink-failure counter
+        # so transient glitches don't eventually trip the degrade path.
+        self._sink_failure_count = 0
         if speech_buffer is not None and text and binding.voice_id:
             self._history.append(
                 NarrationHistoryEntry(
@@ -359,6 +438,83 @@ class SoundEngine:
             },
             source=self.SOURCE,
         )
+
+    def _handle_render_failure(
+        self,
+        event: Event,
+        *,
+        binding_id: str,
+        error: BaseException,
+    ) -> None:
+        """Play the error tone and announce the failure; never raise.
+
+        Re-entrancy-guarded: if a failure occurs while we're already
+        handling a failure (e.g. the error-tone play() itself throws),
+        we swallow it rather than recursing. The supervisor in
+        ``__main__.py`` is the final net that keeps the process alive
+        if somehow this method still raises.
+        """
+        if self._handling_failure:
+            return
+        self._handling_failure = True
+        try:
+            self._play_error_tone_best_effort()
+            publish_event(
+                self._bus,
+                EventType.AUDIO_PIPELINE_FAILED,
+                {
+                    "event_type": event.event_type.value,
+                    "binding_id": binding_id,
+                    "error_class": type(error).__name__,
+                    "error_message": str(error),
+                },
+                source=self.SOURCE,
+            )
+        except Exception:
+            # Last-resort swallow: the process must not die here.
+            # The supervisor in __main__.py logs and continues.
+            pass
+        finally:
+            self._handling_failure = False
+
+    def _play_error_tone_best_effort(self) -> None:
+        """Play the fail-audible tone; on repeated failure, degrade the sink.
+
+        Each sink failure increments ``_sink_failure_count``. When it
+        reaches ``MAX_CONSECUTIVE_SINK_FAILURES`` we swap the sink for
+        ``MemorySink`` for the rest of the session and publish
+        ``AUDIO_SINK_DEGRADED`` so the user hears an announcement
+        through whatever sink is still working (typically none by then,
+        but the event log captures it regardless).
+        """
+        try:
+            self._sink.play(self._error_tone_buffer)
+            self._sink_failure_count = 0
+        except Exception as sink_error:
+            self._sink_failure_count += 1
+            if self._sink_failure_count >= MAX_CONSECUTIVE_SINK_FAILURES:
+                previous_name = type(self._sink).__name__
+                try:
+                    self._sink.close()
+                except Exception:
+                    # Sink is already broken; swallow close failures.
+                    pass
+                self._sink = MemorySink()
+                self._sink_failure_count = 0
+                publish_event(
+                    self._bus,
+                    EventType.AUDIO_SINK_DEGRADED,
+                    {
+                        "previous_sink": previous_name,
+                        "reason": (
+                            f"{MAX_CONSECUTIVE_SINK_FAILURES} consecutive "
+                            f"sink failures ({type(sink_error).__name__}); "
+                            "swapped to MemorySink. Re-launch with --live "
+                            "to restore audio output."
+                        ),
+                    },
+                    source=self.SOURCE,
+                )
 
     def _resolve_voice(self, binding: EventBinding) -> Optional[Voice]:
         """Return the voice this binding points at, or None."""

--- a/asat/tts.py
+++ b/asat/tts.py
@@ -172,6 +172,11 @@ class Pyttsx3Engine:
         self._volume = volume
         self._pitch = pitch
         self._backend: Optional[object] = None
+        # Reliability: bounded ring of property rejections. Previously
+        # these were silently swallowed (Fully Configurable invariant
+        # was violated — a user adjusting pitch and hearing no change
+        # had no way to know why). Capped at 16 entries per engine.
+        self._config_rejections: list[dict[str, str]] = []
 
     @classmethod
     def available(cls) -> bool:
@@ -237,13 +242,47 @@ class Pyttsx3Engine:
     def _apply_voice(self, backend: object, voice: VoiceProfile) -> None:
         """Push the VoiceProfile + user overrides into the pyttsx3 engine."""
         if self._voice is not None:
-            _try_set(backend, "voice", self._voice)
+            self._try_set(backend, "voice", self._voice)
         rate = self._rate if self._rate is not None else voice.speed_wpm
-        _try_set(backend, "rate", float(rate))
+        self._try_set(backend, "rate", float(rate))
         volume = self._volume if self._volume is not None else voice.volume
-        _try_set(backend, "volume", max(0.0, min(1.0, float(volume))))
+        self._try_set(backend, "volume", max(0.0, min(1.0, float(volume))))
         if self._pitch is not None:
-            _try_set(backend, "pitch", float(self._pitch))
+            self._try_set(backend, "pitch", float(self._pitch))
+
+    def _try_set(self, backend: object, key: str, value: object) -> None:
+        """Call ``backend.setProperty(key, value)`` and record rejections.
+
+        Some pyttsx3 drivers (notably Linux espeak) raise on unknown
+        property keys. We must not let that take narration down, but
+        we also must not swallow it silently: a user who configured
+        pitch and doesn't hear a change deserves to know the backend
+        rejected the property. Each rejection is appended to a bounded
+        ring and surfaced via ``config_rejections``.
+        """
+        try:
+            backend.setProperty(key, value)  # type: ignore[attr-defined]
+        except Exception as exc:  # noqa: BLE001 — backend may raise anything
+            record = {
+                "property": str(key),
+                "value": repr(value),
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+            self._config_rejections.append(record)
+            # Cap the ring at 16 so a misconfigured engine can't
+            # accumulate unbounded memory over a long session.
+            if len(self._config_rejections) > 16:
+                self._config_rejections = self._config_rejections[-16:]
+
+    @property
+    def config_rejections(self) -> tuple[dict[str, str], ...]:
+        """Return property rejections observed since engine construction.
+
+        Surfaced here for diagnostics — callers can display these in
+        ``:tts list`` output or the settings editor so the user knows
+        which properties their backend silently ignored.
+        """
+        return tuple(self._config_rejections)
 
 
 class EspeakNgEngine:
@@ -405,16 +444,6 @@ class SystemSayEngine:
                 tmp_path.unlink()
             except OSError:
                 pass
-
-
-def _try_set(backend: object, key: str, value: object) -> None:
-    """Call ``backend.setProperty(key, value)`` but tolerate old stubs."""
-    try:
-        backend.setProperty(key, value)  # type: ignore[attr-defined]
-    except Exception:
-        # Some pyttsx3 drivers (Linux espeak) raise on unknown keys.
-        # Swallow so a missing pitch control doesn't take narration down.
-        pass
 
 
 def _wav_to_mono_buffer(blob: bytes, target_sample_rate: int) -> AudioBuffer:

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -262,9 +262,11 @@ See [AUDIO.md](AUDIO.md) for the full reference.
 
 | EventType           | Payload keys                                                 |
 |---------------------|--------------------------------------------------------------|
-| `AUDIO_SPOKEN`      | `event_type`, `binding_id`, `text`, `voice_id`, `sound_id`   |
-| `AUDIO_INTERRUPTED` | `event_type` — **reserved; no producer ships today.** Future barge-in / cancellation work will publish it; until then no subscriber will ever hear it. The vocabulary entry is kept so external bindings can be authored ahead of the engine work. |
-| `NARRATION_REPLAYED`| `event_type`, `binding_id`, `text`, `voice_id`               |
+| `AUDIO_SPOKEN`         | `event_type`, `binding_id`, `text`, `voice_id`, `sound_id` |
+| `AUDIO_INTERRUPTED`    | `event_type` — **reserved; no producer ships today.** Future barge-in / cancellation work will publish it; until then no subscriber will ever hear it. The vocabulary entry is kept so external bindings can be authored ahead of the engine work. |
+| `AUDIO_PIPELINE_FAILED`| `event_type`, `binding_id`, `error_class`, `error_message` — fired when `SoundEngine._render()` catches an exception from TTS, the spatializer, a generator, or the sink. The engine immediately plays a fixed 3-note descending error tone so the user hears *something* even when the normal render path is broken, then publishes this event so the failure is audit-trailed and (optionally) spoken by the follow-up binding. Never re-raises; the session always continues. |
+| `AUDIO_SINK_DEGRADED`  | `previous_sink`, `reason` — fired when the live sink has failed 3 times in a row and has been swapped for `MemorySink` for the rest of the session. The user hears the usual audio until this event, which announces that subsequent output will be buffered silently; re-launching with `--live` is the recovery. |
+| `NARRATION_REPLAYED`   | `event_type`, `binding_id`, `text`, `voice_id`             |
 
 `NARRATION_REPLAYED` fires when the user presses `Ctrl+R` (or
 types `:repeat`) to re-hear the most recent narration. The engine

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -328,5 +328,81 @@ class WorkspaceResolutionTests(_AsatHomeIsolated):
                 cli._resolve_workspace(args)
 
 
+class MainLoopSupervisorTests(unittest.TestCase):
+    """Verify the Never Crashes invariant at the ``_run`` loop layer."""
+
+    def _make_app_stub(self, raise_on_key: Exception):
+        """Return a minimal Application-like stub that raises on first key."""
+        from asat.event_bus import EventBus
+        from asat.keys import Key, Modifier
+
+        class _AppStub:
+            def __init__(self) -> None:
+                self.bus = EventBus()
+                self.running = True
+                self.calls: list[Key] = []
+                self._first_call = True
+
+            def handle_key(self, key):
+                self.calls.append(key)
+                if self._first_call:
+                    self._first_call = False
+                    raise raise_on_key
+
+            def drain_pending(self):
+                return []
+
+            def execute(self, cell_id):
+                pass  # pragma: no cover
+
+        return _AppStub()
+
+    def test_exception_in_handle_key_is_caught_and_loop_continues(self) -> None:
+        # Never Crashes: handle_key raising must not exit the loop.
+        # The supervisor catches, publishes AUDIO_PIPELINE_FAILED,
+        # logs, and moves on to the next key.
+        from asat.events import EventType
+        from asat.keyboard import ScriptedKeyboard
+        from asat.keys import Key
+
+        app = self._make_app_stub(RuntimeError("router boom"))
+        observed_failures: list[dict] = []
+        app.bus.subscribe(
+            EventType.AUDIO_PIPELINE_FAILED,
+            lambda event: observed_failures.append(dict(event.payload)),
+        )
+        keys = iter([Key.printable("a"), Key.printable("b")])
+        keyboard = ScriptedKeyboard(keys)
+        err = io.StringIO()
+
+        with mock.patch("sys.stderr", err):
+            cli._run(app, keyboard)
+
+        # Both keys were delivered — the first one raised, the
+        # second one still arrived at handle_key.
+        self.assertEqual(len(app.calls), 2)
+        # AUDIO_PIPELINE_FAILED was published with the error details.
+        self.assertEqual(len(observed_failures), 1)
+        self.assertEqual(observed_failures[0]["error_class"], "RuntimeError")
+        self.assertIn("router boom", observed_failures[0]["error_message"])
+        # A stderr line was written for sighted/developer debugging.
+        self.assertIn("recovered from error", err.getvalue())
+        self.assertIn("RuntimeError", err.getvalue())
+
+    def test_keyboard_interrupt_still_propagates(self) -> None:
+        # KeyboardInterrupt is the one exception that MUST propagate
+        # so Ctrl+C behaves predictably. Verify the supervisor does
+        # not swallow it.
+        from asat.keyboard import ScriptedKeyboard
+        from asat.keys import Key
+
+        app = self._make_app_stub(KeyboardInterrupt())
+        keys = iter([Key.printable("a")])
+        keyboard = ScriptedKeyboard(keys)
+
+        with self.assertRaises(KeyboardInterrupt):
+            cli._run(app, keyboard)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_posix_live_sink.py
+++ b/tests/test_posix_live_sink.py
@@ -88,6 +88,59 @@ class _FakeProcess:
         return 0
 
 
+class _HangingStdin:
+    """Stdin that blocks on write until the test releases it.
+
+    Simulates a player process that accepts the pipe but never drains
+    — the scenario the watchdog is designed to catch.
+    """
+
+    def __init__(self) -> None:
+        import threading as _t
+        self._release = _t.Event()
+        self.closed = False
+
+    def write(self, data: bytes) -> int:
+        # Block here until the test signals release OR the write is
+        # interrupted by the player being killed (close() called).
+        self._release.wait(timeout=5.0)
+        return len(data)
+
+    def close(self) -> None:
+        self.closed = True
+        self._release.set()
+
+
+class _HangingProcess:
+    """Popen stand-in whose stdin never drains until terminate()."""
+
+    def __init__(self, argv: list[str], **_kwargs: object) -> None:
+        self.argv = argv
+        self.stdin = _HangingStdin()
+        self.terminated = False
+        self.killed = False
+        self._poll_result: "int | None" = None
+
+    def poll(self) -> "int | None":
+        return self._poll_result
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self._poll_result = -15
+        # Unblock the writer thread so it can exit cleanly after we
+        # "kill" the process.
+        self.stdin.close()
+
+    def kill(self) -> None:
+        self.killed = True
+        self._poll_result = -9
+        self.stdin.close()
+
+    def wait(self, timeout: float = 0.0) -> int:
+        self._poll_result = 0
+        return 0
+
+
 class ProbeTests(unittest.TestCase):
 
     def test_picks_first_available_candidate(self) -> None:
@@ -187,6 +240,49 @@ class PlayTests(unittest.TestCase):
         # or touch any process.
         sink.close()
         self.assertEqual(self.processes, [])
+
+
+class WriteWatchdogTests(unittest.TestCase):
+    """Verify the write-stdin watchdog kills a hung player.
+
+    A player that accepts the connection but never drains stdin
+    would block the sink forever. The watchdog terminates the
+    subprocess after ``WRITE_TIMEOUT_SECONDS`` so the event loop
+    that called ``play`` can return in bounded time.
+    """
+
+    def setUp(self) -> None:
+        self.processes: list[_HangingProcess] = []
+
+        def fake_popen(argv, **kwargs):
+            process = _HangingProcess(argv, **kwargs)
+            self.processes.append(process)
+            return process
+
+        def fake_which(name: str) -> "str | None":
+            return "/usr/bin/paplay" if name == "paplay" else None
+
+        self._popen_patch = mock.patch(
+            "asat.audio_sink.subprocess.Popen", side_effect=fake_popen
+        )
+        self._popen_patch.start()
+        self.addCleanup(self._popen_patch.stop)
+
+        self._which_patch = mock.patch(
+            "asat.audio_sink.shutil.which", side_effect=fake_which
+        )
+        self._which_patch.start()
+        self.addCleanup(self._which_patch.stop)
+
+    def test_hung_player_is_terminated_after_write_timeout(self) -> None:
+        sink = PosixLiveAudioSink()
+        # Shrink the timeout so the test runs fast. Still well above
+        # any real drain latency for a tiny buffer.
+        sink.WRITE_TIMEOUT_SECONDS = 0.05
+        sink.play(_buffer())
+        proc = self.processes[0]
+        # The watchdog must have fired terminate() on the hung proc.
+        self.assertTrue(proc.terminated)
 
 
 class PickLiveSinkTests(unittest.TestCase):

--- a/tests/test_sound_engine.py
+++ b/tests/test_sound_engine.py
@@ -898,5 +898,196 @@ class SoundEngineVerbosityTests(unittest.TestCase):
             engine.set_verbosity_level("whisper")
 
 
+class _FailingTTS:
+    """TTS stand-in that raises on demand, for reliability tests."""
+
+    def __init__(self, fail_next: bool = False) -> None:
+        self.fail_next = fail_next
+        self._inner = ToneTTSEngine(sample_rate=8000)
+        self.call_count = 0
+
+    def synthesize(self, text: str, voice: VoiceProfile) -> AudioBuffer:
+        self.call_count += 1
+        if self.fail_next:
+            self.fail_next = False
+            raise RuntimeError("TTS backend simulated crash")
+        return self._inner.synthesize(text, voice)
+
+
+class _FailingSink:
+    """Sink stand-in that can fail on demand, for reliability tests."""
+
+    def __init__(self) -> None:
+        self.played: list[AudioBuffer] = []
+        self.fail_count = 0  # how many more plays should raise
+
+    def play(self, buffer: AudioBuffer) -> None:
+        if self.fail_count > 0:
+            self.fail_count -= 1
+            raise OSError("sink simulated device failure")
+        self.played.append(buffer)
+
+    def close(self) -> None:
+        pass
+
+
+class SoundEngineReliabilityTests(unittest.TestCase):
+    """Verify the Never Crashes invariant at the SoundEngine layer."""
+
+    def _bank_with_binding(self) -> SoundBank:
+        voice = _voice(id="narrator")
+        binding = EventBinding(
+            id="command_submitted_default",
+            event_type=EventType.COMMAND_SUBMITTED.value,
+            voice_id=voice.id,
+            say_template="ran {cell_id}",
+            priority=100,
+        )
+        return SoundBank(voices=(voice,), sounds=(), bindings=(binding,))
+
+    def test_tts_exception_does_not_propagate_and_fires_failure_event(self) -> None:
+        # Never Crashes: a TTS that raises must not take the dispatch
+        # down. The error tone must reach the sink, and
+        # AUDIO_PIPELINE_FAILED must be published so downstream tools
+        # (event log, settings editor) can surface the failure.
+        bus = EventBus()
+        sink = MemorySink()
+        tts = _FailingTTS(fail_next=True)
+        observed_failures: list[dict] = []
+        bus.subscribe(
+            EventType.AUDIO_PIPELINE_FAILED,
+            lambda event: observed_failures.append(dict(event.payload)),
+        )
+        engine = SoundEngine(
+            bus,
+            self._bank_with_binding(),
+            sink,
+            tts=tts,
+            sample_rate=8000,
+        )
+        self.addCleanup(engine.close)
+
+        # Must not raise — the Never Crashes invariant.
+        publish_event(
+            bus,
+            EventType.COMMAND_SUBMITTED,
+            {"cell_id": "c1", "command": "ls"},
+            source="test",
+        )
+
+        self.assertEqual(len(observed_failures), 1)
+        self.assertEqual(observed_failures[0]["event_type"], "command.submitted")
+        self.assertEqual(observed_failures[0]["error_class"], "RuntimeError")
+        self.assertIn("simulated crash", observed_failures[0]["error_message"])
+        # The error tone must have reached the sink so the user is
+        # not left in silence.
+        self.assertEqual(len(sink.buffers), 1)
+        # The error tone is mono at the engine's sample rate.
+        self.assertEqual(sink.buffers[0].sample_rate, 8000)
+        self.assertEqual(sink.buffers[0].layout, ChannelLayout.MONO)
+
+    def test_subsequent_events_still_render_after_a_failure(self) -> None:
+        # After one failing render, a later successful render must
+        # still produce audio normally.
+        bus = EventBus()
+        sink = MemorySink()
+        tts = _FailingTTS(fail_next=True)
+        engine = SoundEngine(
+            bus,
+            self._bank_with_binding(),
+            sink,
+            tts=tts,
+            sample_rate=8000,
+        )
+        self.addCleanup(engine.close)
+
+        publish_event(
+            bus,
+            EventType.COMMAND_SUBMITTED,
+            {"cell_id": "c1", "command": "ls"},
+            source="test",
+        )
+        # The next event hits the same path but the TTS recovered
+        # (fail_next auto-resets to False inside synthesize).
+        publish_event(
+            bus,
+            EventType.COMMAND_SUBMITTED,
+            {"cell_id": "c2", "command": "pwd"},
+            source="test",
+        )
+
+        # Two sink plays: the error tone from the first event, then
+        # the successful speech buffer from the second event.
+        self.assertEqual(len(sink.buffers), 2)
+
+    def test_sink_swaps_to_memory_after_three_consecutive_failures(self) -> None:
+        # Never Crashes + graceful degrade: after the live sink has
+        # refused 3 buffers in a row, SoundEngine must swap it for
+        # MemorySink so subsequent events stop trying a broken device.
+        bus = EventBus()
+        sink = _FailingSink()
+        sink.fail_count = 100  # always fail
+        tts = _FailingTTS(fail_next=False)
+        observed_degrade: list[dict] = []
+        bus.subscribe(
+            EventType.AUDIO_SINK_DEGRADED,
+            lambda event: observed_degrade.append(dict(event.payload)),
+        )
+        engine = SoundEngine(
+            bus,
+            self._bank_with_binding(),
+            sink,
+            tts=tts,
+            sample_rate=8000,
+        )
+        self.addCleanup(engine.close)
+
+        # Force three failures by making TTS raise each time; the
+        # error tone tries to reach the sink and is rejected.
+        for i in range(3):
+            tts.fail_next = True
+            publish_event(
+                bus,
+                EventType.COMMAND_SUBMITTED,
+                {"cell_id": f"c{i}", "command": "ls"},
+                source="test",
+            )
+
+        self.assertEqual(len(observed_degrade), 1)
+        self.assertEqual(observed_degrade[0]["previous_sink"], "_FailingSink")
+        self.assertIn("MemorySink", observed_degrade[0]["reason"])
+
+    def test_failure_in_failure_handler_does_not_recurse(self) -> None:
+        # Re-entrancy guard: if publishing AUDIO_PIPELINE_FAILED
+        # itself triggers a failure (e.g. a pathological handler),
+        # the dispatch still returns cleanly instead of infinite
+        # recursion.
+        bus = EventBus()
+        sink = MemorySink()
+        tts = _FailingTTS(fail_next=True)
+        # A handler that itself raises whenever AUDIO_PIPELINE_FAILED
+        # is published. SoundEngine's guard must absorb this too.
+        bus.subscribe(
+            EventType.AUDIO_PIPELINE_FAILED,
+            lambda event: (_ for _ in ()).throw(ValueError("handler boom")),
+        )
+        engine = SoundEngine(
+            bus,
+            self._bank_with_binding(),
+            sink,
+            tts=tts,
+            sample_rate=8000,
+        )
+        self.addCleanup(engine.close)
+
+        # Must not raise despite the nested failure.
+        publish_event(
+            bus,
+            EventType.COMMAND_SUBMITTED,
+            {"cell_id": "c1", "command": "ls"},
+            source="test",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -92,5 +92,56 @@ class ToneTTSVoiceTests(unittest.TestCase):
         self.assertGreater(slow_buf.frame_count(), fast_buf.frame_count())
 
 
+class Pyttsx3ConfigRejectionTests(unittest.TestCase):
+    """Verify that property rejections are recorded, not silently dropped.
+
+    Previously ``_try_set`` did ``except Exception: pass`` — a user
+    adjusting pitch and hearing no change had no way to tell whether
+    their backend accepted the value. Now each rejection is appended
+    to a bounded ring on the engine instance and exposed via the
+    ``config_rejections`` property.
+    """
+
+    def test_rejected_property_is_recorded_not_silently_dropped(self) -> None:
+        from asat.tts import Pyttsx3Engine
+
+        # Don't construct the real backend; we just want to probe
+        # _try_set in isolation. Build the engine directly and call
+        # its method with a backend that raises.
+        engine = Pyttsx3Engine(sample_rate=22050)
+
+        class _BrokenBackend:
+            def setProperty(self, key, value):
+                raise RuntimeError(f"driver does not support {key!r}")
+
+        engine._try_set(_BrokenBackend(), "pitch", 1.5)
+
+        rejections = engine.config_rejections
+        self.assertEqual(len(rejections), 1)
+        self.assertEqual(rejections[0]["property"], "pitch")
+        self.assertEqual(rejections[0]["value"], "1.5")
+        self.assertIn("RuntimeError", rejections[0]["error"])
+        self.assertIn("pitch", rejections[0]["error"])
+
+    def test_rejection_ring_is_capped_at_16(self) -> None:
+        from asat.tts import Pyttsx3Engine
+
+        engine = Pyttsx3Engine(sample_rate=22050)
+
+        class _BrokenBackend:
+            def setProperty(self, key, value):
+                raise RuntimeError("always fails")
+
+        backend = _BrokenBackend()
+        for i in range(50):
+            engine._try_set(backend, f"prop_{i}", i)
+
+        rejections = engine.config_rejections
+        self.assertEqual(len(rejections), 16)
+        # The ring keeps the most recent entries, not the oldest.
+        self.assertEqual(rejections[-1]["property"], "prop_49")
+        self.assertEqual(rejections[0]["property"], "prop_34")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

This is **Workstream 1** of the reliability framework we aligned on — fulfilling the **Never Crashes** invariant. ASAT now survives failures in the audio pipeline instead of exiting the process.

Previously a single failure unwound through `SoundEngine._render` → `EventBus.publish` (raised `EventBusError`) → `_run` (no guard) → `main` (caught only `KeyboardInterrupt`) → **process exit, session lost**. For an app meant to be the primary computer interface for a blind user, that was disqualifying.

Six independent layers now close every link in that chain. Each layer has its own try/except and its own test, so a bug in one doesn't disable the others.

### What changed

| Layer | Change |
|---|---|
| 1 | New event types `AUDIO_PIPELINE_FAILED` + `AUDIO_SINK_DEGRADED` with sample payloads, default `alert` bindings, and `docs/EVENTS.md` rows |
| 2 | `ERROR_TONE_BUFFER` — a fixed 3-note descending tone (800/600/400 Hz, 80 ms each) built with pure stdlib. Depends on nothing but `AudioBuffer.mono()` — the fail-audible floor |
| 3 | `SoundEngine._dispatch` + `_render` are now self-contained. Any exception is caught, error tone played, `AUDIO_PIPELINE_FAILED` published. Re-entrancy guard prevents infinite recursion. After 3 consecutive sink failures, the live sink is swapped for `MemorySink` |
| 4 | `_run()` wraps the whole keystroke loop. Only `KeyboardInterrupt` / `SystemExit` propagate; everything else is caught, published as `AUDIO_PIPELINE_FAILED`, logged once to stderr, loop continues |
| 5 | `Pyttsx3Engine._try_set` was `except Exception: pass` — rejected voice properties were silently dropped. Now appends to a 16-entry bounded ring accessible via `config_rejections` |
| 6 | `PosixLiveAudioSink.play()` writes to player stdin on a daemon thread with 500 ms join. Hung player is terminated; next `play()` starts fresh |

### Tests

9 new tests across reliability surfaces (1,312 pass, was 1,303, zero regressions):

- **`SoundEngineReliabilityTests`** (4): TTS exception doesn't propagate + fires failure event; subsequent events still render after a failure; sink swaps to `MemorySink` after 3 consecutive failures; a failure inside the failure handler doesn't recurse.
- **`MainLoopSupervisorTests`** (2): `handle_key` exception is caught and the loop continues; `KeyboardInterrupt` still propagates so Ctrl+C works.
- **`Pyttsx3ConfigRejectionTests`** (2): rejected properties are recorded with class, property, value, error; ring is capped at 16.
- **`WriteWatchdogTests`** (1): hung player subprocess is terminated after the write timeout.

`python -m asat --check` passes all 5 diagnostic steps; the new events are exercised in the `event_cues` self-test (68 covered events, 75 bindings — both up by two).

### Non-goals (deferred to later workstreams)

- UI / UX changes or new meta-commands
- `default_bank.py` → JSON migration (Workstream 3)
- CI matrix for macOS / Windows (Workstream 2)
- `CLAUDE.md` / `CONTRIBUTING.md` contributor docs (Workstream 3)

## Test plan

- [x] `pytest -q` → 1,312 passing, 0 failures
- [x] `python -m asat --check` → all 5 steps pass
- [x] `python -m asat --version` → prints version and exits
- [ ] On your machine (manual): launch `python -m asat --live` from a real TTY, force a TTS crash (e.g., `:tts use` a broken engine id). You should hear the 3-note descending error tone, **not** a Python traceback. The session should still accept keystrokes.
- [ ] On your machine (manual): `Ctrl+E` → event log shows `audio_pipeline_failed` entries with payload details.
- [ ] On your machine (manual): verify `Ctrl+C` still exits cleanly.

https://claude.ai/code/session_014R5h5Lg2y4f3V3kQyziCHD